### PR TITLE
InstallContent.razor文件24行打错字

### DIFF
--- a/src/BootstrapBlazor.Shared/Pages/Components/InstallContent.razor
+++ b/src/BootstrapBlazor.Shared/Pages/Components/InstallContent.razor
@@ -21,7 +21,7 @@
 &lt;link href="_content/BootstrapBlazor/css/bootstrap.blazor.bundle.min.css" rel="stylesheet"&gt;</Pre>
 
 <Tips>
-    <p>如果是使用 <code>Blazozr App</code> 模板创建的工程请移除默认的 <code>Bootstrap</code> 样式链接 <code>&lt;link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" /&gt;</code></p>
+    <p>如果是使用 <code>Blazor App</code> 模板创建的工程请移除默认的 <code>Bootstrap</code> 样式链接 <code>&lt;link rel="stylesheet" href="css/bootstrap/bootstrap.min.css" /&gt;</code></p>
 </Tips>
 
 <h5>JS 文件</h5>


### PR DESCRIPTION
InstallContent.razor文件24行>“Blazor App”误为“>Blazozr App”

Summary of the changes (Less than 80 chars)

Detail 1
Detail 2

Addresses #bugnumber (in this specific format)