### PR TITLE
logout link text fix

### DIFF
--- a/src/BootstrapBlazor/Components/Logout/LogoutLink.razor
+++ b/src/BootstrapBlazor/Components/Logout/LogoutLink.razor
@@ -8,6 +8,6 @@
     }
     @if (!string.IsNullOrEmpty(Text))
     {
-        <span>注销</span>
+        <span>@Text</span>
     }
 </a>


### PR DESCRIPTION
`<LogoutLink  Text="Log Out" />`

This Text parameter is not reflected to the UI. 

With this fix, Text parameter is shown in the component
