### PR TITLE
fix: multiply class for upload input buttons

### DIFF
--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor
@@ -11,9 +11,9 @@
         <input type="text" class="@InputValueClassString" id="@Id" disabled="@Disabled" readonly placeholder="@PlaceHolder" value="@GetFileName(CurrentFile)" />
         @if (ShowDeleteButton)
         {
-            <Button class="@RemoveButtonClassString" IsDisabled="@IsDeleteButtonDisabled" Icon="@DeleteButtonIcon" Text="@DeleteButtonText" OnClick="@OnDeleteFile" />
+            <Button class="@RemoveButtonClassString" IsDisabled="@IsDeleteButtonDisabled" Icon="@DeleteButtonIcon" Text="@DeleteButtonText" OnClick="@OnDeleteFile" Color="Color.None" />
         }
-        <Button class="@BrowserButtonClassString" IsDisabled="@IsDisabled" Icon="@BrowserButtonIcon" Text="@BrowserButtonText" />
+        <Button class="@BrowserButtonClassString" IsDisabled="@IsDisabled" Icon="@BrowserButtonIcon" Text="@BrowserButtonText" Color="Color.None" />
     </div>
     <InputFile AdditionalAttributes="@GetUploadAdditionalAttributes()" OnChange="OnFileChange" />
 </div>


### PR DESCRIPTION
Summary:
InputUpload has remove and add buttons. When render this component thats buttons have several classes like:
`btn btn-primary btn btn-danger` and `btn btn-primary btn btn-browser btn-primary`.
Thats happend because buttons (`ButtonBase`) generate `ClassName` from `Color` with default value `Color.Primary`.

I think that fix may repair it, because `RemoveButtonClassString` from `InputUpload` use value from `DeleteButtonClass` with `btn-danger`, `BrowserButtonClassString` works same.