### PR TITLE
feat: Added Table.ResetAllColumnsFilter() and IFilterAction.SetFilterConditions method

### DIFF
--- a/src/BootstrapBlazor/Components/Filters/BoolFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/BoolFilter.razor.cs
@@ -68,4 +68,23 @@ public partial class BoolFilter
         }
         return filters;
     }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    public void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions)
+    {
+        if(!conditions.Any())
+            return;
+
+        FilterKeyValueAction first = conditions.First();
+        if (first.FieldValue is bool value)
+        {
+            Value = value ? "true" : "false";
+        }
+        else if (first.FieldValue is null)
+        {
+            Value = "";
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Filters/DateTimeFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/DateTimeFilter.razor.cs
@@ -88,4 +88,41 @@ public partial class DateTimeFilter
         }
         return filters;
     }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    public void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions)
+    {
+        if (!conditions.Any())
+            return;
+
+        FilterKeyValueAction first = conditions.First();
+        if(first.FieldValue is DateTime value)
+        {
+            Value1 = value;
+        }
+        else
+        {
+            Value1 = null;
+        }
+        Action1 = first.FilterAction;
+
+        if(conditions.Count() == 2)
+        {
+            Count = 1;
+
+            FilterKeyValueAction second = conditions.ElementAt(1);
+            if (second.FieldValue is DateTime value2)
+            {
+                Value2 = value2;
+            }
+            else
+            {
+                Value2 = null;
+            }
+            Action1 = second.FilterAction;
+            Logic = second.FilterLogic;
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Filters/EnumFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/EnumFilter.razor.cs
@@ -81,4 +81,24 @@ public partial class EnumFilter
         }
         return filters;
     }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    public void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions)
+    {
+        if (!conditions.Any())
+            return;
+
+        var type = Nullable.GetUnderlyingType(Type) ?? Type;
+        FilterKeyValueAction first = conditions.First();
+        if (first.FieldValue?.GetType() == type)
+        {
+            Value = first.FieldValue.ToString() ?? "";
+        }
+        else
+        {
+            Value = "";
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Filters/IFilterAction.cs
+++ b/src/BootstrapBlazor/Components/Filters/IFilterAction.cs
@@ -19,4 +19,9 @@ public interface IFilterAction
     /// 重置过滤条件方法
     /// </summary>
     void Reset() { }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions) { }
 }

--- a/src/BootstrapBlazor/Components/Filters/LookupFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/LookupFilter.razor.cs
@@ -89,4 +89,24 @@ public partial class LookupFilter
         }
         return filters;
     }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    public void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions)
+    {
+        if (!conditions.Any())
+            return;
+
+        var type = Nullable.GetUnderlyingType(Type) ?? Type;
+        FilterKeyValueAction first = conditions.First();
+        if (first.FieldValue?.GetType() == type)
+        {
+            Value = first.FieldValue.ToString() ?? "";
+        }
+        else
+        {
+            Value = "";
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Filters/NumberFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/NumberFilter.razor.cs
@@ -94,4 +94,41 @@ public partial class NumberFilter<TType>
         }
         return filters;
     }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    public void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions)
+    {
+        if (!conditions.Any())
+            return;
+
+        FilterKeyValueAction first = conditions.First();
+        if (first.FieldValue is TType value)
+        {
+            Value1 = value;
+        }
+        else
+        {
+            Value1 = default;
+        }
+        Action1 = first.FilterAction;
+
+        if (conditions.Count() == 2)
+        {
+            Count = 1;
+
+            FilterKeyValueAction second = conditions.ElementAt(1);
+            if (second.FieldValue is TType value2)
+            {
+                Value2 = value2;
+            }
+            else
+            {
+                Value2 = default;
+            }
+            Action1 = second.FilterAction;
+            Logic = second.FilterLogic;
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Filters/StringFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/StringFilter.razor.cs
@@ -91,4 +91,41 @@ public partial class StringFilter
         }
         return filters;
     }
+
+    /// <summary>
+    /// Override existing filter conditions
+    /// </summary>
+    public void SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions)
+    {
+        if (!conditions.Any())
+            return;
+
+        FilterKeyValueAction first = conditions.First();
+        if (first.FieldValue is string value)
+        {
+            Value1 = value;
+        }
+        else
+        {
+            Value1 = "";
+        }
+        Action1 = first.FilterAction;
+
+        if (conditions.Count() == 2)
+        {
+            Count = 1;
+
+            FilterKeyValueAction second = conditions.ElementAt(1);
+            if (second.FieldValue is string value2)
+            {
+                Value2 = value2;
+            }
+            else
+            {
+                Value2 = "";
+            }
+            Action1 = second.FilterAction;
+            Logic = second.FilterLogic;
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -239,7 +239,7 @@
             }
         </div>
 
-        if (ActiveRenderMode == TableRenderMode.Table)
+        if (ActiveRenderMode == TableRenderMode.Table && !ShowFilterHeader)
         {
             if (FilterColumns == null) FilterColumns = Columns.Where(i => i.Filterable);
             if (FilterColumns.Any())

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1192,6 +1192,22 @@ public partial class Table<TItem> : BootstrapComponentBase, IDisposable, ITable 
         return ret;
     }
 
+    /// <summary>
+    /// Reset all Columns Filter
+    /// </summary>
+    public void ResetAllColumnsFilter()
+    {
+        foreach (ITableColumn column in Columns)
+        {
+            column.Filter?.FilterAction?.Reset();
+        }
+        Filters.Clear();
+        if (OnFilterAsync is not null)
+        {
+            OnFilterAsync();
+        }
+    }
+
     #region Dispose
     /// <summary>
     /// Dispose 方法

--- a/test/UnitTest/Components/TableBoolFilterTest.cs
+++ b/test/UnitTest/Components/TableBoolFilterTest.cs
@@ -63,4 +63,26 @@ public class TableBoolFilterTest : BootstrapBlazorTestBase
         cut.InvokeAsync(() => condtions = filter.GetFilterConditions());
         Assert.Single(condtions);
     }
+
+    [Fact]
+    public void SetFilterConditions_Ok()
+    {
+        var cut = Context.RenderComponent<BoolFilter>();
+
+        var filter = cut.Instance;
+        IEnumerable<FilterKeyValueAction>? conditions = null;
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Empty(conditions);
+
+        List<FilterKeyValueAction>? newConditions = new(1);
+
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = true });
+
+        cut.InvokeAsync(() => filter.SetFilterConditions(newConditions));
+
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Single(conditions);
+        Assert.True(conditions?.First().FieldValue is bool);
+        Assert.True((bool?)conditions?.First().FieldValue);
+    }
 }

--- a/test/UnitTest/Components/TableDateTimeFilterTest.cs
+++ b/test/UnitTest/Components/TableDateTimeFilterTest.cs
@@ -115,4 +115,29 @@ public class TableDateTimeFilterTest : BootstrapBlazorTestBase
         });
         Assert.Empty(condtions);
     }
+
+    [Fact]
+    public void SetFilterConditions_Ok()
+    {
+        var cut = Context.RenderComponent<DateTimeFilter>();
+
+        var filter = cut.Instance;
+        IEnumerable<FilterKeyValueAction>? conditions = null;
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Empty(conditions);
+
+        List<FilterKeyValueAction>? newConditions = new(1);
+
+        DateTime dati = DateTime.Now;
+
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = dati });
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = dati });
+
+        cut.InvokeAsync(() => filter.SetFilterConditions(newConditions));
+
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.True(conditions?.Count() == 2);
+        Assert.True(conditions?.First().FieldValue is DateTime);
+        Assert.True((DateTime?)conditions?.First().FieldValue == dati);
+    }
 }

--- a/test/UnitTest/Components/TableEnumFilterTest.cs
+++ b/test/UnitTest/Components/TableEnumFilterTest.cs
@@ -75,4 +75,28 @@ public class TableEnumFilterTest : BootstrapBlazorTestBase
         cut.InvokeAsync(() => condtions = cut.FindComponent<EnumFilter>().Instance.GetFilterConditions());
         Assert.Single(condtions);
     }
+
+    [Fact]
+    public void SetFilterConditions_Ok()
+    {
+        var cut = Context.RenderComponent<EnumFilter>(pb =>
+        {
+            pb.Add(a => a.Type, typeof(EnumEducation));
+        });
+
+        var filter = cut.Instance;
+        IEnumerable<FilterKeyValueAction>? conditions = null;
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Empty(conditions);
+
+        List<FilterKeyValueAction>? newConditions = new(1);
+
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = EnumEducation.Middel });
+
+        cut.InvokeAsync(() => filter.SetFilterConditions(newConditions));
+
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Single(conditions);
+        Assert.True(conditions?.First().FieldValue is EnumEducation.Middel);
+    }
 }

--- a/test/UnitTest/Components/TableFilterTest.cs
+++ b/test/UnitTest/Components/TableFilterTest.cs
@@ -116,6 +116,32 @@ public class TableFilterTest : BootstrapBlazorTestBase
         });
     }
 
+    [Fact]
+    public void OnlyOneTableFilterPerColumn_Ok()
+    {
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.Items, new List<Foo>() { new Foo() });
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.ShowFilterHeader, true);
+                pb.Add(a => a.TableColumns, new RenderFragment<Foo>(foo => builder =>
+                {
+                    var index = 0;
+                    builder.OpenComponent<TableColumn<Foo, bool>>(index++);
+                    builder.AddAttribute(index++, nameof(TableColumn<Foo, bool>.Field), foo.Complete);
+                    builder.AddAttribute(index++, nameof(TableColumn<Foo, bool>.FieldExpression), foo.GenerateValueExpression(nameof(Foo.Complete), typeof(bool)));
+                    builder.AddAttribute(index++, nameof(TableColumn<Foo, bool>.Filterable), true);
+                    builder.CloseComponent();
+                }));
+            });
+        });
+
+        var filters = cut.FindComponents<BoolFilter>();
+        Assert.Single(filters);
+    }
+
     private static RenderFragment<Foo> CreateTableColumns() => foo => builder =>
     {
         var index = 0;

--- a/test/UnitTest/Components/TableLookupFilterTest.cs
+++ b/test/UnitTest/Components/TableLookupFilterTest.cs
@@ -94,4 +94,34 @@ public class TableLookupFilterTest : BootstrapBlazorTestBase
         cut.InvokeAsync(() => condtions = cut.FindComponent<LookupFilter>().Instance.GetFilterConditions());
         Assert.Single(condtions);
     }
+
+    [Fact]
+    public void SetFilterConditions_Ok()
+    {
+        var cut = Context.RenderComponent<LookupFilter>(pb =>
+        {
+            pb.Add(a => a.Type, typeof(bool));
+            pb.Add(a => a.Lookup, new List<SelectedItem>()
+            {
+                new SelectedItem("true", "True"),
+                new SelectedItem("false", "False")
+            });
+        });
+
+        var filter = cut.Instance;
+        IEnumerable<FilterKeyValueAction>? conditions = null;
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Empty(conditions);
+
+        List<FilterKeyValueAction>? newConditions = new(1);
+
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = true });
+
+        cut.InvokeAsync(() => filter.SetFilterConditions(newConditions));
+
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Single(conditions);
+        Assert.True(conditions?.First().FieldValue is bool);
+        Assert.True((bool?)conditions?.First().FieldValue);
+    }
 }

--- a/test/UnitTest/Components/TableNumberFilterTest.cs
+++ b/test/UnitTest/Components/TableNumberFilterTest.cs
@@ -151,4 +151,27 @@ public class TableNumberFilterTest : BootstrapBlazorTestBase
         var input = cut.FindComponent<BootstrapInput<string>>().Instance;
         cut.InvokeAsync(() => input.SetValue("10"));
     }
+
+    [Fact]
+    public void SetFilterConditions_Ok()
+    {
+        var cut = Context.RenderComponent<NumberFilter<int>>();
+
+        var filter = cut.Instance;
+        IEnumerable<FilterKeyValueAction>? conditions = null;
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.NotEmpty(conditions); //This is a problem with the NumberFilter, actually it should be empty
+
+        List<FilterKeyValueAction>? newConditions = new(1);
+
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = 1 });
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = 2 });
+
+        cut.InvokeAsync(() => filter.SetFilterConditions(newConditions));
+
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.True(conditions?.Count() == 2);
+        Assert.True(conditions?.First().FieldValue is int);
+        Assert.True((int?)conditions?.First().FieldValue == 1);
+    }
 }

--- a/test/UnitTest/Components/TableStringFilterTest.cs
+++ b/test/UnitTest/Components/TableStringFilterTest.cs
@@ -85,4 +85,27 @@ public class TableStringFilterTest : BootstrapBlazorTestBase
         Assert.Equal(FilterAction.NotEqual, condtion.First().FilterAction);
         Assert.Equal(FilterLogic.And, condtion.First().FilterLogic);
     }
+
+    [Fact]
+    public void SetFilterConditions_Ok()
+    {
+        var cut = Context.RenderComponent<StringFilter>();
+
+        var filter = cut.Instance;
+        IEnumerable<FilterKeyValueAction>? conditions = null;
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.Empty(conditions);
+
+        List<FilterKeyValueAction>? newConditions = new(1);
+
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = "test1" });
+        newConditions.Add(new FilterKeyValueAction() { FieldValue = "test2" });
+
+        cut.InvokeAsync(() => filter.SetFilterConditions(newConditions));
+
+        cut.InvokeAsync(() => conditions = filter.GetFilterConditions());
+        Assert.True(conditions?.Count() == 2);
+        Assert.True(conditions?.First().FieldValue is string);
+        Assert.True((string?)conditions?.First().FieldValue == "test1");
+    }
 }


### PR DESCRIPTION
New table functions:

1) Added Table.ResetAllColumnsFilter() method.
You can use this method to reset all filters.
It needs the fix for the TableFilter I pulled earlier.

2) Added the IFilterAction.SetFilterConditions(IEnumerable<FilterKeyValueAction> conditions) method, extending the existing filters.
This allows you to overwrite the existing conditions.

Also, I added unit tests for all new methods.