### PR TITLE
GetKeyValue return tuple when model has multiple keys

### DIFF
--- a/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
@@ -832,12 +832,27 @@ public static class LambdaExtensions
     {
         var type = model is not null ? model.GetType() : typeof(TModel);
         Expression<Func<TModel, TValue>> ret = _ => default!;
-        var property = type.GetRuntimeProperties().FirstOrDefault(p => p.IsDefined(typeof(KeyAttribute)));
-        if (property != null)
+        var properties = type.GetRuntimeProperties().Where(p => p.IsDefined(typeof(KeyAttribute))).ToList();
+        if (properties.Any())
         {
             var param = Expression.Parameter(typeof(TModel));
-            var body = Expression.Property(Expression.Convert(param, type), property);
-            ret = Expression.Lambda<Func<TModel, TValue>>(Expression.Convert(body, typeof(TValue)), param);
+            var tupleType = Type.GetType($"System.Tuple`{properties.Count}");
+            if (properties.Count >= 2 && properties.Count <= 8 && tupleType != null && tupleType.IsSubclassOf(typeof(TValue)))
+            {
+                var keyPropertyTypes = properties.Select(x => x.PropertyType).ToArray();
+                var tupleConstructor = tupleType.MakeGenericType(keyPropertyTypes).GetConstructor(keyPropertyTypes);
+                if (tupleConstructor == null)
+                    throw new InvalidOperationException($"No tuple constructor found for key in {type}");
+
+                var newTupleExpression = Expression.New(tupleConstructor, properties.Select(p => Expression.Property(param, p)));
+                var body = Expression.Convert(newTupleExpression, typeof(TValue));
+                ret = Expression.Lambda<Func<TModel, TValue>>(Expression.Convert(body, typeof(TValue)), param);
+            }
+            else
+            {
+                var body = Expression.Property(Expression.Convert(param, type), properties.First());
+                ret = Expression.Lambda<Func<TModel, TValue>>(Expression.Convert(body, typeof(TValue)), param);
+            }
         }
         return ret;
     }


### PR DESCRIPTION
Summary of the changes (Less than 80 chars)

Table component 在 QueryData  時，如果 TItem 有多個 Key ，SelectedRows 只會保留第一個 Key 不同的 row

修改後 Utility.GetKeyValue 在 TModel 有2 - 8個 Keys，且回傳的 Tuple 是 TValue( = object) 的情況下，會回傳 Tuple，這樣 table 的 SelectedRows 就可以正確的被留下