### PR TITLE
Fix bug that navigation buttons in Calendar don't trigger ValueChanged event.

### DIFF
--- a/src/BootstrapBlazor/Components/Calendar/Calendar.razor.cs
+++ b/src/BootstrapBlazor/Components/Calendar/Calendar.razor.cs
@@ -187,16 +187,20 @@ public partial class Calendar
     /// 右侧快捷切换年按钮回调此方法
     /// </summary>
     /// <param name="offset"></param>
-    protected void OnChangeYear(int offset)
+    protected async Task OnChangeYear(int offset)
     {
         Value = Value.AddYears(offset);
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(Value);
+        }
     }
 
     /// <summary>
     /// 右侧快捷切换月按钮回调此方法
     /// </summary>
     /// <param name="offset"></param>
-    protected void OnChangeMonth(int offset)
+    protected async Task OnChangeMonth(int offset)
     {
         if (offset == 0)
         {
@@ -206,13 +210,18 @@ public partial class Calendar
         {
             Value = Value.AddMonths(offset);
         }
+
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(Value);
+        }
     }
 
     /// <summary>
     /// 右侧快捷切换周按钮回调此方法
     /// </summary>
     /// <param name="offset"></param>
-    protected void OnChangeWeek(int offset)
+    protected async Task OnChangeWeek(int offset)
     {
         if (offset == 0)
         {
@@ -223,6 +232,11 @@ public partial class Calendar
             Value = Value.AddDays(offset);
         }
         WeekNumberText = Localizer[nameof(WeekNumberText), GetWeekCount()];
+
+        if (ValueChanged.HasDelegate)
+        {
+            await ValueChanged.InvokeAsync(Value);
+        }
     }
 
     private CalendarCellValue CreateCellValue(DateTime cellValue)


### PR DESCRIPTION
Fix bug that navigation buttons in Calendar don't trigger ValueChanged event.

Functions OnChangeYear, OnChangeMonth and OnChangeWeek in Calendar component changes only Value and don't trigger event ValueChanged. This Pull Request is going to fix that problem.
Tested on working solution.
