### PR TITLE
fix: can not drag Dialog/Model when set IsScrolling to true

### DIFF
--- a/src/BootstrapBlazor/wwwroot/modules/modal.js
+++ b/src/BootstrapBlazor/wwwroot/modules/modal.js
@@ -102,7 +102,7 @@ export class Modal extends BlazorComponent {
                     this._originX = e.clientX || e.touches[0].clientX;
                     this._originY = e.clientY || e.touches[0].clientY;
 
-                    const rect = this._dialog.getBoundingClientRect()
+                    const rect = this._dialog.querySelector('.modal-content').getBoundingClientRect()
                     this._dialogWidth = rect.width
                     this._dialogHeight = rect.height
                     this._pt.top = rect.top


### PR DESCRIPTION
## can not drag Dialog/Model when set IsScrolling to true

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #501 
