### PR TITLE
fix(Table): fix ModelEqualityComparer not work with ClickToSelect

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -272,9 +272,9 @@ public partial class Table<TItem>
                 SelectedRows.Clear();
             }
 
-            if (SelectedRows.Contains(val))
+            if (SelectedRows.Any(row => Equals(val, row)))
             {
-                SelectedRows.Remove(val);
+                SelectedRows.RemoveAll(row => Equals(val, row));
             }
             else
             {
@@ -306,7 +306,7 @@ public partial class Table<TItem>
     /// </summary>
     /// <param name="val"></param>
     /// <returns></returns>
-    protected virtual bool CheckActive(TItem val) => SelectedRows.Contains(val);
+    protected virtual bool CheckActive(TItem val) => SelectedRows.Any(row => Equals(val, row));
 
     /// <summary>
     /// 


### PR DESCRIPTION
## Fix ModelEqualityComparer not work with ClickToSelect

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #984 
