### PR TITLE
fix(SelectTree): do not show the Text when value is not null in first render

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>7.5.3</Version>
+    <Version>7.5.4-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
@@ -158,6 +158,13 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
             // 组件未赋值 Value 通过 IsActive 设置默认值
             await TriggerItemChanged(s => s.IsActive);
         }
+        else
+        {
+            var allItems = Items.GetAllItems();
+            var item = allItems.FirstOrDefault(s => Equals(s.Value, Value));
+                if (item != null)
+                await ItemChanged(item);
+        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
@@ -144,6 +144,19 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        if (Value != null)
+        {
+            await TriggerItemChanged(s => Equals(s.Value, Value));
+        }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
     protected override async Task OnParametersSetAsync()
     {
         await base.OnParametersSetAsync();
@@ -157,13 +170,6 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
         {
             // 组件未赋值 Value 通过 IsActive 设置默认值
             await TriggerItemChanged(s => s.IsActive);
-        }
-        else
-        {
-            var allItems = Items.GetAllItems();
-            var item = allItems.FirstOrDefault(s => Equals(s.Value, Value));
-                if (item != null)
-                await ItemChanged(item);
         }
     }
 


### PR DESCRIPTION
## fix the selecttree has a value, the corresponding node is not selected

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #988 
