### PR TITLE
fix(DialogButton): no restore button icon if set IsAsync to true

### DIFF
--- a/src/BootstrapBlazor/Components/Dialog/DialogCloseButton.cs
+++ b/src/BootstrapBlazor/Components/Dialog/DialogCloseButton.cs
@@ -27,12 +27,12 @@ public partial class DialogCloseButton : Button
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    protected override void OnParametersSet()
+    protected override void OnInitialized()
     {
+        base.OnInitialized();
+
         Icon ??= IconTheme.GetIconByKey(ComponentIcons.DialogCloseButtonIcon);
         Text ??= Localizer[nameof(ModalDialog.CloseButtonText)];
-
-        base.OnParametersSet();
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Dialog/DialogCloseButton.cs
+++ b/src/BootstrapBlazor/Components/Dialog/DialogCloseButton.cs
@@ -29,10 +29,10 @@ public partial class DialogCloseButton : Button
     /// </summary>
     protected override void OnParametersSet()
     {
-        base.OnParametersSet();
-
-        ButtonIcon ??= IconTheme.GetIconByKey(ComponentIcons.DialogCloseButtonIcon);
+        Icon ??= IconTheme.GetIconByKey(ComponentIcons.DialogCloseButtonIcon);
         Text ??= Localizer[nameof(ModalDialog.CloseButtonText)];
+
+        base.OnParametersSet();
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Dialog/DialogSaveButton.cs
+++ b/src/BootstrapBlazor/Components/Dialog/DialogSaveButton.cs
@@ -30,9 +30,9 @@ public partial class DialogSaveButton : Button
     /// </summary>
     protected override void OnParametersSet()
     {
-        base.OnParametersSet();
-
-        ButtonIcon ??= IconTheme.GetIconByKey(ComponentIcons.DialogSaveButtonIcon);
+        Icon ??= IconTheme.GetIconByKey(ComponentIcons.DialogSaveButtonIcon);
         Text ??= Localizer[nameof(ModalDialog.SaveButtonText)];
+
+        base.OnParametersSet();
     }
 }

--- a/src/BootstrapBlazor/Components/Dialog/DialogSaveButton.cs
+++ b/src/BootstrapBlazor/Components/Dialog/DialogSaveButton.cs
@@ -22,17 +22,8 @@ public partial class DialogSaveButton : Button
     {
         base.OnInitialized();
 
-        ButtonType = ButtonType.Submit;
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    protected override void OnParametersSet()
-    {
         Icon ??= IconTheme.GetIconByKey(ComponentIcons.DialogSaveButtonIcon);
         Text ??= Localizer[nameof(ModalDialog.SaveButtonText)];
-
-        base.OnParametersSet();
+        ButtonType = ButtonType.Submit;
     }
 }


### PR DESCRIPTION
## no restore button icon if set IsAsync to true

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #1300
