### PR TITLE
refactor(Select): not trigger SelectedItemChanged callback when click Empty item

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>7.7.4</Version>
+    <Version>7.7.5</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -145,7 +145,7 @@ public partial class Select<TValue> : ISelect
     /// </summary>
     private string? InputId => $"{Id}_input";
 
-    private string? _lastSelectedValueString;
+    private string _lastSelectedValueString = string.Empty;
 
     /// <summary>
     /// <inheritdoc/>
@@ -209,8 +209,6 @@ public partial class Select<TValue> : ISelect
 
             if (SelectedItem != null)
             {
-                _lastSelectedValueString ??= string.Empty;
-                SelectedItem.Value ??= string.Empty;
                 _ = SelectedItemChanged(SelectedItem);
             }
         }

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -207,10 +207,10 @@ public partial class Select<TValue> : ISelect
                 ?? DataSource.FirstOrDefault(i => i.Active)
                 ?? DataSource.FirstOrDefault();
 
-            // 检查 Value 值是否在候选项中存在
-            // Value 不等于 选中值即不存在
             if (SelectedItem != null)
             {
+                _lastSelectedValueString ??= string.Empty;
+                SelectedItem.Value ??= string.Empty;
                 _ = SelectedItemChanged(SelectedItem);
             }
         }
@@ -224,10 +224,7 @@ public partial class Select<TValue> : ISelect
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override async Task InvokeInitAsync()
-    {
-        await InvokeVoidAsync("init", Id, nameof(ConfirmSelectedItem), Interop);
-    }
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, nameof(ConfirmSelectedItem));
 
     /// <summary>
     /// 客户端回车回调方法
@@ -284,7 +281,7 @@ public partial class Select<TValue> : ISelect
 
     private async Task SelectedItemChanged(SelectedItem item)
     {
-        if (!string.IsNullOrEmpty(item.Value) && _lastSelectedValueString != item.Value)
+        if (_lastSelectedValueString != item.Value)
         {
             _lastSelectedValueString = item.Value;
 

--- a/src/BootstrapBlazor/Components/Select/Select.razor.js
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.js
@@ -3,7 +3,7 @@ import Data from "../../modules/data.js?v=$version"
 import EventHandler from "../../modules/event-handler.js?v=$version"
 import Popover from "../../modules/base-popover.js?v=$version"
 
-export function init(id, method, obj) {
+export function init(id, invoke, method) {
     const el = document.getElementById(id)
 
     if (el == null) {
@@ -12,13 +12,6 @@ export function init(id, method, obj) {
 
     const search = el.querySelector("input.search-text")
     const popover = Popover.init(el)
-    const select = {
-        el,
-        search,
-        method,
-        obj,
-        popover
-    }
 
     const shown = () => {
         if (search) {
@@ -71,7 +64,7 @@ export function init(id, method, obj) {
                 if (e.key === "Enter") {
                     popover.toggleMenu.classList.remove('show')
                     let index = indexOf(el, activeItem)
-                    obj.invokeMethodAsync(method, index)
+                    invoke.invokeMethodAsync(method, index)
                 }
             }
         }
@@ -80,18 +73,23 @@ export function init(id, method, obj) {
     EventHandler.on(el, 'shown.bs.dropdown', shown);
     EventHandler.on(el, 'keydown', keydown)
 
+    const select = {
+        el,
+        popover
+    }
     Data.set(id, select)
 }
 
 
 export function dispose(id) {
-    const data = Data.get(id)
-    if (data) {
-        EventHandler.off(data.el, 'shown.bs.dropdown')
-        EventHandler.off(data.el, 'keydown')
-        Popover.dispose(data.popover)
-    }
+    const select = Data.get(id)
     Data.remove(id)
+
+    if (select) {
+        EventHandler.off(select.el, 'shown.bs.dropdown')
+        EventHandler.off(select.el, 'keydown')
+        Popover.dispose(select.popover)
+    }
 }
 
 

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -158,7 +158,7 @@ public class SelectTest : BootstrapBlazorTestBase
     {
         var triggered = false;
 
-        // 候选项有空值时，不触发 OnSelectedItemChanged 回调
+        // 空值时，不触发 OnSelectedItemChanged 回调
         var cut = Context.RenderComponent<Select<string>>(pb =>
         {
             pb.Add(a => a.Items, new SelectedItem[]
@@ -184,18 +184,21 @@ public class SelectTest : BootstrapBlazorTestBase
 
             var item = items[1];
             item.Click();
-            Assert.True(triggered);
-
-            // 切换回 空值 触发 OnSelectedItemChanged 回调测试
-            triggered = false;
-            items = cut.FindAll(".dropdown-item");
-            item = items[1];
-            item.Click();
-            Assert.True(triggered);
         });
+        Assert.True(triggered);
 
+        // 切换回 空值 触发 OnSelectedItemChanged 回调测试
         triggered = false;
+        cut.InvokeAsync(() =>
+        {
+            var items = cut.FindAll(".dropdown-item");
+            var item = items[0];
+            item.Click();
+        });
+        Assert.True(triggered);
+
         // 首次加载值不为空时触发 OnSelectedItemChanged 回调测试
+        triggered = false;
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.Items, new SelectedItem[]
@@ -205,25 +208,20 @@ public class SelectTest : BootstrapBlazorTestBase
                 new SelectedItem("2", "Test2")
             });
             pb.Add(a => a.Value, "2");
-            pb.Add(a => a.OnSelectedItemChanged, item =>
-            {
-                triggered = true;
-                return Task.CompletedTask;
-            });
         });
         Assert.True(triggered);
 
+        // 切换回 空值 触发 OnSelectedItemChanged 回调测试
+        triggered = false;
         cut.InvokeAsync(() =>
         {
-            // 切换回 空值 触发 OnSelectedItemChanged 回调测试
-            triggered = false;
             var items = cut.FindAll(".dropdown-item");
             var count = items.Count;
             Assert.Equal(3, count);
             var item = items[0];
             item.Click();
-            Assert.True(triggered);
         });
+        Assert.True(triggered);
     }
 
     [Fact]

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -157,11 +157,50 @@ public class SelectTest : BootstrapBlazorTestBase
     public void OnSelectedItemChanged_OK()
     {
         var triggered = false;
-        // 首次加载触发 OnSelectedItemChanged 回调测试
+
+        // 候选项有空值时，不触发 OnSelectedItemChanged 回调
         var cut = Context.RenderComponent<Select<string>>(pb =>
         {
             pb.Add(a => a.Items, new SelectedItem[]
             {
+                new SelectedItem("", "Test"),
+                new SelectedItem("1", "Test2")
+            });
+            pb.Add(a => a.Value, "");
+            pb.Add(a => a.OnSelectedItemChanged, item =>
+            {
+                triggered = true;
+                return Task.CompletedTask;
+            });
+        });
+        Assert.False(triggered);
+
+        // 切换候选项时触发 OnSelectedItemChanged 回调测试
+        cut.InvokeAsync(() =>
+        {
+            var items = cut.FindAll(".dropdown-item");
+            var count = items.Count;
+            Assert.Equal(2, count);
+
+            var item = items[1];
+            item.Click();
+            Assert.True(triggered);
+
+            // 切换回 空值 触发 OnSelectedItemChanged 回调测试
+            triggered = false;
+            items = cut.FindAll(".dropdown-item");
+            item = items[1];
+            item.Click();
+            Assert.True(triggered);
+        });
+
+        triggered = false;
+        // 首次加载值不为空时触发 OnSelectedItemChanged 回调测试
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.Items, new SelectedItem[]
+            {
+                new SelectedItem("", "Test"),
                 new SelectedItem("1", "Test1"),
                 new SelectedItem("2", "Test2")
             });
@@ -173,6 +212,18 @@ public class SelectTest : BootstrapBlazorTestBase
             });
         });
         Assert.True(triggered);
+
+        cut.InvokeAsync(() =>
+        {
+            // 切换回 空值 触发 OnSelectedItemChanged 回调测试
+            triggered = false;
+            var items = cut.FindAll(".dropdown-item");
+            var count = items.Count;
+            Assert.Equal(3, count);
+            var item = items[0];
+            item.Click();
+            Assert.True(triggered);
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## not trigger SelectedItemChanged callback when click Empty item

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #1435 