### PR TITLE
fix(GoTop): should not throw exception when Target is null or empty

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>7.8.10-beta01</Version>
+    <Version>7.8.10-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/GoTop/GoTop.razor.cs
+++ b/src/BootstrapBlazor/Components/GoTop/GoTop.razor.cs
@@ -53,6 +53,6 @@ public partial class GoTop
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Target ?? "");
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Target);
 
 }

--- a/src/BootstrapBlazor/Components/GoTop/GoTop.razor.js
+++ b/src/BootstrapBlazor/Components/GoTop/GoTop.razor.js
@@ -1,6 +1,14 @@
 ﻿import Data from "../../modules/data.js?v=$version"
 import EventHandler from "../../modules/event-handler.js?v=$version"
 
+const getScrollElement = el => {
+    let ele = el
+    while (ele && ele.scrollHeight <= ele.clientHeight) {
+        ele = ele.parentNode
+    }
+    return ele || window
+}
+
 export function init(id, target) {
     const el = document.getElementById(id)
     if (el === null) {
@@ -12,7 +20,8 @@ export function init(id, target) {
     go.tip = new bootstrap.Tooltip(el)
     EventHandler.on(el, 'click', e => {
         e.preventDefault();
-        const element = document.querySelector(target) || window
+
+        const element = (target && document.querySelector(target)) || getScrollElement(el)
         element.scrollTop = 0
         go.tip.hide()
     })


### PR DESCRIPTION
## should not throw exception when Target is null or empty

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #1593