### PR TITLE
fix(ImageViewer): can't reload imager after occur error

### DIFF
--- a/src/BootstrapBlazor/Components/ImageViewer/ImageViewer.razor.cs
+++ b/src/BootstrapBlazor/Components/ImageViewer/ImageViewer.razor.cs
@@ -123,6 +123,7 @@ public partial class ImageViewer
     {
         base.OnParametersSet();
 
+        IsError = false;
         FileIcon ??= IconTheme.GetIconByKey(ComponentIcons.ImageViewerFileIcon);
     }
 
@@ -174,7 +175,7 @@ public partial class ImageViewer
             }
             if (ShouldHandleError)
             {
-                builder.AddAttribute(4, "onerror", EventCallback.Factory.Create(this, async () =>
+                builder.AddAttribute(5, "onerror", EventCallback.Factory.Create(this, async () =>
                 {
                     IsError = true;
                     if (OnErrorAsync != null)

--- a/test/UnitTest/Components/ImageTest.cs
+++ b/test/UnitTest/Components/ImageTest.cs
@@ -67,7 +67,7 @@ public class ImageTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public async Task HandleError_Ok()
+    public void HandleError_Ok()
     {
         var error = false;
         var cut = Context.RenderComponent<ImageViewer>(pb =>
@@ -83,10 +83,14 @@ public class ImageTest : BootstrapBlazorTestBase
         cut.Contains("d-none");
 
         // trigger error event
-        var img = cut.Find("img");
-        await cut.InvokeAsync(() => img.Error());
+        cut.InvokeAsync(() =>
+        {
+            var img = cut.Find("img");
+            img.Error();
+        });
         Assert.True(error);
 
+        error = false;
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.HandleError, false);
@@ -95,6 +99,13 @@ public class ImageTest : BootstrapBlazorTestBase
                 builder.AddContent(0, "error-template");
             }));
         });
+
+        cut.InvokeAsync(() =>
+        {
+            var img = cut.Find("img");
+            img.Error();
+        });
+        Assert.True(error);
         cut.Contains("error-template");
     }
 

--- a/test/UnitTest/Components/SwalTest.cs
+++ b/test/UnitTest/Components/SwalTest.cs
@@ -258,8 +258,11 @@ public class SwalTest : SwalTestBase
 
         forceOption.ForceDelay = false;
         cut.InvokeAsync(() => swal.Show(forceOption));
-        cut.InvokeAsync(() => modal.Instance.CloseCallback());
-        Assert.Equal(4000, forceOption.Delay);
+        cut.InvokeAsync(async () =>
+        {
+            await modal.Instance.CloseCallback();
+            Assert.Equal(4000, forceOption.Delay);
+        });
 
         // 自动关闭
         cut.InvokeAsync(() => swal.Show(new SwalOption()


### PR DESCRIPTION
## can't reload imager after occur error

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #1663 
