### PR TITLE
fix(ImageViewer): drag image not smooth

### DIFF
--- a/src/BootstrapBlazor/wwwroot/modules/viewer.js
+++ b/src/BootstrapBlazor/wwwroot/modules/viewer.js
@@ -295,7 +295,9 @@ export default {
                     const newValY = viewer.pt.top + Math.ceil(eventY - viewer.originY)
 
                     viewer.prevImg.style.marginLeft = `${newValX}px`
+                    viewer.prevImg.style.marginRight = `${-newValX}px`
                     viewer.prevImg.style.marginTop = `${newValY}px`
+                    viewer.prevImg.style.marginBottom = `${-newValY}px`
                 }
 
             },


### PR DESCRIPTION
## drag image not smooth

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->
Fix the bug that the image does not follow the mouse when dragging (Implement Image Moving by setting margin must be set up, down, left and right simultaneously).
### Description

Original behavior: When drag the mouse (or touch) from the upper left to the lower right,  the image only moves half the distance.

Principle of bug : use Margin to move an image, need to set both left and right, up and down at the same time, for example: margin-left:100px;margin-right:-100px. Move 100px to the right, if only set one it will only move 50px.
After revision: Set the upper left and lower right simultaneously.

close #2172 