### PR TITLE
fix(MenuLink): always active if href equal "/"

### DIFF
--- a/src/BootstrapBlazor/Components/Menu/MenuLink.razor.cs
+++ b/src/BootstrapBlazor/Components/Menu/MenuLink.razor.cs
@@ -52,7 +52,7 @@ public sealed partial class MenuLink
     [NotNull]
     private IStringLocalizer<Menu>? Localizer { get; set; }
 
-    private NavLinkMatch ItemMatch => string.IsNullOrEmpty(Item.Url) ? NavLinkMatch.All : Item.Match;
+    private NavLinkMatch ItemMatch => string.IsNullOrEmpty(Item.Url?.TrimStart('/')) ? NavLinkMatch.All : Item.Match;
 
     private string? IconString => CssBuilder.Default("menu-icon")
         .AddClass(Item.Icon)


### PR DESCRIPTION
Solutions as per https://github.com/dotnet/aspnetcore/issues/9156 <NavLink href="/" Match=NavLinkMatch.All>Home</NavLink>

## always active if href equal "/"

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #2207 
