### PR TITLE
feat(Table): order of edit pop-up consisitent with table column

### DIFF
--- a/src/BootstrapBlazor.Shared/BootstrapBlazor.Shared.csproj
+++ b/src/BootstrapBlazor.Shared/BootstrapBlazor.Shared.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="BootstrapBlazor.Bluetooth" Version="7.0.1" />
     <PackageReference Include="BootstrapBlazor.Chart" Version="7.6.0" />
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="7.2.1" />
-    <PackageReference Include="BootstrapBlazor.Dock" Version="7.0.11" />
+    <PackageReference Include="BootstrapBlazor.Dock" Version="7.0.12" />
     <PackageReference Include="BootstrapBlazor.FileViewer" Version="7.0.3" />
     <PackageReference Include="BootstrapBlazor.FontAwesome" Version="7.5.0" />
     <PackageReference Include="BootstrapBlazor.Html2Pdf" Version="7.2.0" />

--- a/src/BootstrapBlazor.Shared/Locales/en.json
+++ b/src/BootstrapBlazor.Shared/Locales/en.json
@@ -4665,6 +4665,7 @@
     "OnQueryAsyncAttr": "Asynchronous query callback method",
     "OnAddAsyncAttr": "New Button Callback Method",
     "OnColumnCreatingAttr": "Callback delegate method on column creation",
+    "ColumnOrderCallbackAttr": "Callback delegate method on column order",
     "OnDoubleClickCellCallbackAttr": "Set cell double-click event",
     "OnDeleteAsyncAttr": "Delete Button Asynchronous Callback Method",
     "OnEditAsyncAttr": "Edit button asynchronous callback method",

--- a/src/BootstrapBlazor.Shared/Locales/zh.json
+++ b/src/BootstrapBlazor.Shared/Locales/zh.json
@@ -4665,6 +4665,7 @@
     "OnQueryAsyncAttr": "异步查询回调方法",
     "OnAddAsyncAttr": "新建按钮回调方法",
     "OnColumnCreatingAttr": "列创建时回调委托方法",
+    "ColumnOrderCallbackAttr": "列排序回调委托方法",
     "OnDoubleClickCellCallbackAttr": "设置单元格双击事件",
     "OnDeleteAsyncAttr": "删除按钮异步回调方法",
     "OnEditAsyncAttr": "编辑按钮异步回调方法",

--- a/src/BootstrapBlazor.Shared/Samples/Table/Tables.razor.cs
+++ b/src/BootstrapBlazor.Shared/Samples/Table/Tables.razor.cs
@@ -950,6 +950,14 @@ public partial class Tables
         },
         new()
         {
+            Name = nameof(Table<Foo>.ColumnOrderCallback),
+            Description = Localizer["ColumnOrderCallbackAttr"],
+            Type = "Func<List<ITableColumn>, IEnumerable<ITableColumn>>",
+            ValueList = " — ",
+            DefaultValue = " — "
+        },
+        new()
+        {
             Name = nameof(Table<Foo>.OnDoubleClickCellCallback),
             Description = Localizer["OnDoubleClickCellCallbackAttr"],
             Type = "Func<string, object, object?, Task>",

--- a/src/BootstrapBlazor.Shared/Samples/Table/TablesEdit.razor
+++ b/src/BootstrapBlazor.Shared/Samples/Table/TablesEdit.razor
@@ -10,7 +10,7 @@
 <DemoBlock Title="@Localizer["TablesEditItemsTitle"]"
            Introduction="@Localizer["TablesEditItemsIntro"]"
            Name="EditItems">
-    <p class="mb-3">@((MarkupString)Localizer["TablesEditItemsDescription"].Value)</p>
+    <section ignore class="mb-3">@((MarkupString)Localizer["TablesEditItemsDescription"].Value)</section>
     <Table TItem="Foo" @bind-Items="EditItems"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true"
            ShowToolbar="true" ShowExtendButtons="true" ShowSkeleton="true"
@@ -54,13 +54,15 @@
 <DemoBlock Title="@Localizer["TablesEditOnAddAsyncTitle"]"
            Introduction="@Localizer["TablesEditOnAddAsyncIntro"]"
            Name="OnAddAsync">
-    <p id="anchor2">@((MarkupString)Localizer["TablesEditOnAddAsyncDescription"].Value)</p>
-    <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips1"].Value)</p>
-    <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips2"].Value)</p>
-    <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips3"].Value)</p>
-    <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips4"].Value)</p>
-    <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips5"].Value)</p>
-    <p class="mb-3">@((MarkupString)Localizer["TablesEditOnAddAsyncTips6"].Value)</p>
+    <section ignore>
+        <p>@((MarkupString)Localizer["TablesEditOnAddAsyncDescription"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips1"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips2"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips3"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips4"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditOnAddAsyncTips5"].Value)</p>
+        <p class="mb-3">@((MarkupString)Localizer["TablesEditOnAddAsyncTips6"].Value)</p>
+    </section>
     <Table TItem="Foo"
            IsPagination="true" PageItemsSource="@PageItemsSource"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true" EditDialogIsDraggable="true"
@@ -81,10 +83,10 @@
 <DemoBlock Title="@Localizer["TablesColumnEditTemplateTitle"]"
            Introduction="@Localizer["TablesColumnEditTemplateIntro"]"
            Name="EditTemplate">
-    <p class="mb-3">
+    <section ignore class="mb-3">
         <div>@((MarkupString)Localizer["TablesColumnEditTemplateDescription1"].Value)</div>
         <div>@((MarkupString)Localizer["TablesColumnEditTemplateTips"].Value)</div>
-    </p>
+    </section>
     <Table TItem="Foo"
            IsPagination="true" PageItemsSource="@PageItemsSource"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true" IsExtendButtonsInRowHeader="true"
@@ -110,9 +112,11 @@
 <DemoBlock Title="@Localizer["TablesEditModeTitle"]"
            Introduction="@Localizer["TablesEditModeIntro"]"
            Name="EditMode">
-    <p id="anchor4">@((MarkupString)Localizer["TablesEditModeDescription"].Value)</p>
-    <p>@((MarkupString)Localizer["TablesEditModeTips1"].Value)</p>
-    <p class="mb-3">@((MarkupString)Localizer["TablesEditModeTips2"].Value)</p>
+    <section ignore class="mb-3">
+        <p>@((MarkupString)Localizer["TablesEditModeDescription"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditModeTips1"].Value)</p>
+        <p>@((MarkupString)Localizer["TablesEditModeTips2"].Value)</p>
+    </section>
     <Table TItem="Foo"
            IsPagination="true" PageItemsSource="@PageItemsSource"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true"
@@ -130,8 +134,10 @@
         </TableColumns>
     </Table>
 
-    <p id="anchor5" class="mt-3">@((MarkupString)Localizer["TablesEditModeInCell"].Value)</p>
-    <RadioList @bind-Value="InsertMode" class="mb-3" />
+    <section ignore class="my-3">
+        <p>@((MarkupString)Localizer["TablesEditModeInCell"].Value)</p>
+        <RadioList @bind-Value="InsertMode" />
+    </section>
     <Table TItem="Foo"
            IsPagination="true" PageItemsSource="@PageItemsSource"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true"
@@ -152,7 +158,7 @@
 <DemoBlock Title="@Localizer["TablesEditInjectDataServiceTitle"]"
            Introduction="@Localizer["TablesEditInjectDataServiceIntro"]"
            Name="InjectDataService">
-    <p id="anchor6">
+    <section ignore>
         @((MarkupString)Localizer["TablesEditInjectDataServiceDescription"].Value)
         <ul class="ul-demo mb-3">
             <li><code>OnAddAsync</code></li>
@@ -163,8 +169,8 @@
         <div class="mb-3">@Localizer["TablesEditInjectDataServiceTips1"] <a href="@DataServiceUrl" target="_blank">@Localizer["TablesEditInjectDataServiceTips2"]</a></div>
         <b>@Localizer["TablesEditInjectDataServiceTips3"]</b>
         <div class="mt-1">@Localizer["TablesEditInjectDataServiceTips4"]</div>
-    </p>
-<Pre class="no-highlight my-3">services.AddTableDemoDataService();</Pre>
+        <Pre class="no-highlight my-3">services.AddTableDemoDataService();</Pre>
+    </section>
     <Table TItem="Foo"
            IsPagination="true" PageItemsSource="@PageItemsSource"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true" AutoGenerateColumns="true"
@@ -178,12 +184,12 @@
 <DemoBlock Title="@Localizer["TablesEditDataServiceTitle"]"
            Introduction="@Localizer["TablesEditDataServiceIntro"]"
            Name="DataService">
-    <p id="anchor7">
+    <section ignore>
         <b>@Localizer["TablesEditDataServiceDescription"]</b>
         <div class="mt-1">@((MarkupString)Localizer["TablesEditDataServiceTips1"].Value)</div>
         <div class="mt-1">@((MarkupString)Localizer["TablesEditDataServiceTips2"].Value)</div>
-    </p>
-    <Pre class="no-highlight my-3 mb-3">services.AddTableDemoDataService();</Pre>
+        <Pre class="no-highlight my-3 mb-3">services.AddTableDemoDataService();</Pre>
+    </section>
     <Table TItem="Foo" EditDialogShowMaximizeButton="true"
            IsPagination="true" PageItemsSource="@PageItemsSource" DataService="@CustomerDataService"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true" AutoGenerateColumns="true"
@@ -197,12 +203,14 @@
 <DemoBlock Title="@Localizer["TablesEditFooterTemplateTitle"]"
            Introduction="@Localizer["TablesEditFooterTemplateIntro"]"
            Name="EditFooterTemplate">
-    <p>@((MarkupString)Localizer["TablesEditFooterTemplateDescription"].Value)</p>
-    <Pre class="mb-3">&lt;EditFooterTemplate Context="model"&gt;
+    <section ignore>
+        <p>@((MarkupString)Localizer["TablesEditFooterTemplateDescription"].Value)</p>
+        <Pre class="mb-3">&lt;EditFooterTemplate Context="model"&gt;
     &lt;Button Text="Popup" Color="Color.Danger" Icon="fa-regular fa-comment-dots" OnClick="() =&gt; OnClick(model)"&gt;&lt;/Button&gt;
     &lt;DialogCloseButton /&gt;
     &lt;DialogSaveButton Color="Color.Primary" Icon="fa-solid fa-floppy-disk" Text="Save" /&gt;
 &lt;/EditFooterTemplate&gt;</Pre>
+    </section>
     <Table TItem="Foo" IsPagination="true" PageItemsSource="@PageItemsSource"
            IsStriped="true" IsBordered="true" IsMultipleSelect="true"
            ShowToolbar="true" ShowExtendButtons="true" ShowSkeleton="true" IsExtendButtonsInRowHeader="true"

--- a/src/BootstrapBlazor.Shared/docs.json
+++ b/src/BootstrapBlazor.Shared/docs.json
@@ -50,6 +50,7 @@
     "dock-view/stack": "DockViews\\DockViewStack",
     "dock-view/lock": "DockViews\\DockViewLock",
     "dock-view/visible": "DockViews\\DockViewVisible",
+    "dock-view/layout": "DockViews\\DockViewLayout",
     "download": "Downloads",
     "drag-drop": "DragDrops",
     "drawer": "Drawers",

--- a/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor
+++ b/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor
@@ -2,7 +2,7 @@
 @typeparam TModel
 @inherits BootstrapComponentBase
 
-<CascadingValue Value="@EditorItems" IsFixed="true">
+<CascadingValue Value="@_editorItems" IsFixed="true">
     @FieldItems?.Invoke(Model)
 </CascadingValue>
 

--- a/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
+++ b/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
@@ -142,6 +142,13 @@ public partial class EditorForm<TModel> : IShowLabel
     public bool ShowUnsetGroupItemsOnTop { get; set; }
 
     /// <summary>
+    /// 获得/设置 默认占位符文本 默认 null
+    /// </summary>
+    [Parameter]
+    [NotNull]
+    public string? PlaceHolderText { get; set; }
+
+    /// <summary>
     /// 获得/设置 级联上下文 EditContext 实例 内置于 EditForm 或者 ValidateForm 时有值
     /// </summary>
     [CascadingParameter]
@@ -164,22 +171,19 @@ public partial class EditorForm<TModel> : IShowLabel
     /// <summary>
     /// 获得/设置 配置编辑项目集合
     /// </summary>
-    private List<IEditorItem> EditorItems { get; } = new();
+    private readonly List<IEditorItem> _editorItems = new();
 
     /// <summary>
     /// 获得/设置 渲染的编辑项集合
     /// </summary>
-    private List<IEditorItem> FormItems { get; } = new();
+    private readonly List<IEditorItem> _formItems = new();
 
-    private IEnumerable<IEditorItem> UnsetGroupItems => FormItems.Where(i => string.IsNullOrEmpty(i.GroupName));
+    private IEnumerable<IEditorItem> UnsetGroupItems => _formItems.Where(i => string.IsNullOrEmpty(i.GroupName));
 
-    private IEnumerable<KeyValuePair<string, IOrderedEnumerable<IEditorItem>>> GroupItems => FormItems
+    private IEnumerable<KeyValuePair<string, IOrderedEnumerable<IEditorItem>>> GroupItems => _formItems
         .Where(i => !string.IsNullOrEmpty(i.GroupName))
         .GroupBy(i => i.GroupOrder).OrderBy(i => i.Key)
         .Select(i => new KeyValuePair<string, IOrderedEnumerable<IEditorItem>>(i.First().GroupName!, i.OrderBy(x => x.Order)));
-
-    [NotNull]
-    private string? PlaceHolderText { get; set; }
 
     /// <summary>
     /// OnInitialized 方法
@@ -237,7 +241,7 @@ public partial class EditorForm<TModel> : IShowLabel
             if (Items != null)
             {
                 // 通过级联参数渲染组件
-                FormItems.AddRange(Items);
+                _formItems.AddRange(Items);
             }
             else
             {
@@ -248,7 +252,7 @@ public partial class EditorForm<TModel> : IShowLabel
                     var items = Utility.GetTableColumns<TModel>(defaultOrderCallback: ColumnOrderCallback).ToList();
 
                     // 通过设定的 FieldItems 模板获取项进行渲染
-                    foreach (var el in EditorItems)
+                    foreach (var el in _editorItems)
                     {
                         var item = items.FirstOrDefault(i => i.GetFieldName() == el.GetFieldName());
                         if (item != null)
@@ -266,11 +270,11 @@ public partial class EditorForm<TModel> : IShowLabel
                             }
                         }
                     }
-                    FormItems.AddRange(items.Where(i => i.Editable));
+                    _formItems.AddRange(items.Where(i => i.Editable));
                 }
                 else
                 {
-                    FormItems.AddRange(EditorItems.Where(i => i.Editable));
+                    _formItems.AddRange(_editorItems.Where(i => i.Editable));
                 }
             }
             StateHasChanged();

--- a/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
+++ b/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
@@ -130,6 +130,12 @@ public partial class EditorForm<TModel> : IShowLabel
     public IEnumerable<IEditorItem>? Items { get; set; }
 
     /// <summary>
+    /// 获得/设置 自定义列排序规则 默认 null 未设置 使用内部排序机制 1 2 3 0 -3 -2 -1 顺序
+    /// </summary>
+    [Parameter]
+    public Func<IEnumerable<ITableColumn>, IEnumerable<ITableColumn>>? ColumnOrderCallback { get; set; }
+
+    /// <summary>
     /// 获得/设置 未设置 GroupName 编辑项是否放置在顶部 默认 false
     /// </summary>
     [Parameter]
@@ -165,7 +171,7 @@ public partial class EditorForm<TModel> : IShowLabel
     /// </summary>
     private List<IEditorItem> FormItems { get; } = new();
 
-    private IEnumerable<IEditorItem> UnsetGroupItems => FormItems.Where(i => string.IsNullOrEmpty(i.GroupName)).OrderBy(i => i.Order);
+    private IEnumerable<IEditorItem> UnsetGroupItems => FormItems.Where(i => string.IsNullOrEmpty(i.GroupName));
 
     private IEnumerable<KeyValuePair<string, IOrderedEnumerable<IEditorItem>>> GroupItems => FormItems
         .Where(i => !string.IsNullOrEmpty(i.GroupName))
@@ -239,7 +245,7 @@ public partial class EditorForm<TModel> : IShowLabel
                 if (AutoGenerateAllItem)
                 {
                     // 获取绑定模型所有属性
-                    var items = Utility.GetTableColumns<TModel>().ToList();
+                    var items = Utility.GetTableColumns<TModel>(defaultOrderCallback: ColumnOrderCallback).ToList();
 
                     // 通过设定的 FieldItems 模板获取项进行渲染
                     foreach (var el in EditorItems)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -543,6 +543,12 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     public Func<List<ITableColumn>, Task>? OnColumnCreating { get; set; }
 
     /// <summary>
+    /// 获得/设置 自定义列排序规则 默认 null 未设置 使用内部排序机制 1 2 3 0 -3 -2 -1 顺序
+    /// </summary>
+    [Parameter]
+    public Func<IEnumerable<ITableColumn>, IEnumerable<ITableColumn>>? ColumnOrderCallback { get; set; }
+
+    /// <summary>
     /// 获得/设置 OnAfterRenderCallback 是否已经触发 默认 false
     /// </summary>
     /// <remarks>与 <see cref="OnAfterRenderCallback"/> 回调配合</remarks>
@@ -822,7 +828,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         // 初始化列
         if (AutoGenerateColumns)
         {
-            var cols = Utility.GetTableColumns<TItem>(Columns);
+            var cols = Utility.GetTableColumns<TItem>(Columns, ColumnOrderCallback);
             Columns.Clear();
             Columns.AddRange(cols);
         }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -263,16 +263,18 @@ public static class Utility
     /// </summary>
     /// <typeparam name="TModel"></typeparam>
     /// <param name="source"></param>
+    /// <param name="defaultOrderCallback">默认排序回调方法</param>
     /// <returns></returns>
-    public static IEnumerable<ITableColumn> GetTableColumns<TModel>(IEnumerable<ITableColumn>? source = null) => GetTableColumns(typeof(TModel), source);
+    public static IEnumerable<ITableColumn> GetTableColumns<TModel>(IEnumerable<ITableColumn>? source = null, Func<IEnumerable<ITableColumn>, IEnumerable<ITableColumn>>? defaultOrderCallback = null) => GetTableColumns(typeof(TModel), source, defaultOrderCallback);
 
     /// <summary>
     /// 通过特定类型模型获取模型属性集合
     /// </summary>
     /// <param name="type">绑定模型类型</param>
     /// <param name="source">Razor 文件中列集合</param>
+    /// <param name="defaultOrderCallback">默认排序回调方法</param>
     /// <returns></returns>
-    public static IEnumerable<ITableColumn> GetTableColumns(Type type, IEnumerable<ITableColumn>? source = null)
+    public static IEnumerable<ITableColumn> GetTableColumns(Type type, IEnumerable<ITableColumn>? source = null, Func<IEnumerable<ITableColumn>, IEnumerable<ITableColumn>>? defaultOrderCallback = null)
     {
         var cols = new List<ITableColumn>(50);
         var classAttribute = type.GetCustomAttribute<AutoGenerateClassAttribute>(true);
@@ -320,7 +322,7 @@ public static class Utility
             cols.Add(tc);
         }
 
-        return cols.Where(a => a.Order > 0).OrderBy(a => a.Order)
+        return defaultOrderCallback?.Invoke(cols) ?? cols.Where(a => a.Order > 0).OrderBy(a => a.Order)
             .Concat(cols.Where(a => a.Order == 0))
             .Concat(cols.Where(a => a.Order < 0).OrderBy(a => a.Order));
     }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -322,10 +322,12 @@ public static class Utility
             cols.Add(tc);
         }
 
-        return defaultOrderCallback?.Invoke(cols) ?? cols.Where(a => a.Order > 0).OrderBy(a => a.Order)
-            .Concat(cols.Where(a => a.Order == 0))
-            .Concat(cols.Where(a => a.Order < 0).OrderBy(a => a.Order));
+        return defaultOrderCallback?.Invoke(cols) ?? cols.OrderFunc();
     }
+
+    private static IEnumerable<ITableColumn> OrderFunc(this List<ITableColumn> cols) => cols.Where(a => a.Order > 0).OrderBy(a => a.Order)
+        .Concat(cols.Where(a => a.Order == 0))
+        .Concat(cols.Where(a => a.Order < 0).OrderBy(a => a.Order));
 
     /// <summary>
     /// 通过指定 Model 获得 IEditorItem 集合方法

--- a/src/Extensions/Components/BootstrapBlazor.Dock/Components/DockView/DockView.razor.js
+++ b/src/Extensions/Components/BootstrapBlazor.Dock/Components/DockView/DockView.razor.js
@@ -148,7 +148,7 @@ const unLockStack = (stack, dock) => {
 const resetDockLock = dock => {
     const unlocks = dock.layout.getAllContentItems().filter(com => com.isComponent && !com.container.initialState.lock)
     const lock = unlocks.length === 0
-    if (dock.lock != lock) {
+    if (dock.lock !== lock) {
         dock.lock = lock
         dock.invokeLockAsync(lock)
     }

--- a/test/UnitTest/Components/EditorFormTest.cs
+++ b/test/UnitTest/Components/EditorFormTest.cs
@@ -365,6 +365,28 @@ public class EditorFormTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void ColumnOrderCallback_Ok()
+    {
+        var foo = new Foo();
+        var cut = Context.RenderComponent<EditorForm<Foo>>(pb =>
+        {
+            pb.Add(a => a.Model, foo);
+            pb.Add(a => a.AutoGenerateAllItem, true);
+            pb.Add(a => a.ColumnOrderCallback, cols =>
+            {
+                return cols.OrderByDescending(i => i.Order);
+            });
+        });
+        var editor = cut.Instance;
+        var itemsField = editor.GetType().GetField("_formItems", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.GetField);
+        Assert.NotNull(itemsField);
+
+        var v = itemsField.GetValue(editor) as List<IEditorItem>;
+        Assert.NotNull(v);
+        Assert.Equal(new List<int>() { 60, 50, 40, 20, 10, 1 }, v.Select(i => i.Order));
+    }
+
+    [Fact]
     public void LookupServiceKey_Ok()
     {
         var foo = new Foo();

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -4215,6 +4215,29 @@ public class TableTest : TableTestBase
     }
 
     [Fact]
+    public void ColumnOrderCallback_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer, 2);
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.Items, items);
+                pb.Add(a => a.AutoGenerateColumns, true);
+                pb.Add(a => a.ColumnOrderCallback, cols =>
+                {
+                    return cols.OrderByDescending(i => i.Order);
+                });
+            });
+        });
+        var table = cut.FindComponent<Table<Foo>>();
+        var seqs = table.Instance.Columns.Select(i => i.Order);
+        Assert.Equal(new List<int>() { 70, 60, 50, 40, 20, 10, 1 }, seqs);
+    }
+
+    [Fact]
     public void TableColumn_TextWrap()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6494,7 +6494,7 @@ public class TableTest : TableTestBase
     }
 
     [Fact]
-    public async Task QueryItems_Null()
+    public void QueryItems_Null()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
@@ -6507,14 +6507,12 @@ public class TableTest : TableTestBase
         });
 
         var table = cut.FindComponent<MockTable>();
-        var items = await table.Instance.DataService!.QueryAsync(new QueryPageOptions());
-        Assert.Null(items.Items);
-
-        table.SetParametersAndRender(pb =>
+        Assert.NotNull(table.Instance.DataService);
+        cut.InvokeAsync(async () =>
         {
-            pb.Add(a => a.ScrollMode, ScrollMode.Virtual);
+            var items = await table.Instance.DataService.QueryAsync(new QueryPageOptions());
+            Assert.Null(items.Items);
         });
-        await cut.InvokeAsync(() => table.Instance.QueryAsync());
     }
 
     [Fact]

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -2509,6 +2509,7 @@ public class TableTest : TableTestBase
     [Fact]
     public void ScrollMode_Query_Ok()
     {
+        var isVirtual = false;
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
@@ -2517,7 +2518,17 @@ public class TableTest : TableTestBase
                 pb.Add(a => a.RenderMode, TableRenderMode.Table);
                 pb.Add(a => a.ScrollMode, ScrollMode.Virtual);
                 pb.Add(a => a.ShowLineNo, true);
-                pb.Add(a => a.OnQueryAsync, OnQueryAsync(localizer));
+                pb.Add(a => a.OnQueryAsync, option =>
+                {
+                    isVirtual = option.IsVirtualScroll;
+                    var items = Foo.GenerateFoo(localizer, 5);
+                    var ret = new QueryData<Foo>()
+                    {
+                        Items = items,
+                        TotalCount = 5
+                    };
+                    return Task.FromResult(ret);
+                });
                 pb.Add(a => a.TableColumns, foo => builder =>
                 {
                     builder.OpenComponent<TableColumn<Foo, string>>(0);
@@ -2549,6 +2560,8 @@ public class TableTest : TableTestBase
             var th = ths[1];
             th.Click();
         });
+
+        Assert.True(isVirtual);
     }
 
     [Theory]

--- a/test/UnitTest/Utils/GroupTest.cs
+++ b/test/UnitTest/Utils/GroupTest.cs
@@ -36,4 +36,12 @@ public class GroupTest
         var actual = string.Join(",", results);
         Assert.Equal(expected, actual);
     }
+
+    [Fact]
+    public void OrderBy_Ok()
+    {
+        var items = new List<int> { 0, -1, 1 };
+        var actual = items.OrderByDescending(i => i);
+        Assert.Equal("1, 0, -1", string.Join(", ", actual));
+    }
 }

--- a/test/UnitTest/Utils/GroupTest.cs
+++ b/test/UnitTest/Utils/GroupTest.cs
@@ -43,5 +43,17 @@ public class GroupTest
         var items = new List<int> { 0, -1, 1, -4 };
         var actual = items.OrderByDescending(i => i);
         Assert.Equal("1, 0, -1, -4", string.Join(", ", actual));
+
+        items = new List<int> { 1, 3, 2, 4 };
+        actual = items.OrderBy(i => i);
+        Assert.Equal("1, 2, 3, 4", string.Join(", ", actual));
+
+        items = new List<int> { -1, -3, -2, -4 };
+        actual = items.OrderBy(i => i);
+        Assert.Equal("-4, -3, -2, -1", string.Join(", ", actual));
+
+        items = new List<int> { 2, 1, 0, -1, -3, -2, -4 };
+        actual = items.OrderBy(i => i);
+        Assert.Equal("-4, -3, -2, -1", string.Join(", ", actual));
     }
 }

--- a/test/UnitTest/Utils/GroupTest.cs
+++ b/test/UnitTest/Utils/GroupTest.cs
@@ -17,10 +17,10 @@ public class GroupTest
 
         var items = new List<MockTableColumn>(50)
         {
-            new MockTableColumn("Test1", typeof(string)) { GroupName = "Test1", GroupOrder = 2, Order = 2  },
-            new MockTableColumn("Test2", typeof(string)) { GroupName = "Test1", GroupOrder = 2, Order = 1  },
-            new MockTableColumn("Test3", typeof(string)) { GroupName = "Test2", GroupOrder = 1, Order = 2  },
-            new MockTableColumn("Test4", typeof(string)) { GroupName = "Test2", GroupOrder = 1, Order = 1 }
+            new("Test1", typeof(string)) { GroupName = "Test1", GroupOrder = 2, Order = 2  },
+            new("Test2", typeof(string)) { GroupName = "Test1", GroupOrder = 2, Order = 1  },
+            new("Test3", typeof(string)) { GroupName = "Test2", GroupOrder = 1, Order = 2  },
+            new("Test4", typeof(string)) { GroupName = "Test2", GroupOrder = 1, Order = 1 }
         };
         var groups = items.GroupBy(i => i.GroupOrder).OrderBy(i => i.Key).Select(i => new { i.Key, Items = i.OrderBy(x => x.Order) });
         foreach (var g in groups)
@@ -40,8 +40,8 @@ public class GroupTest
     [Fact]
     public void OrderBy_Ok()
     {
-        var items = new List<int> { 0, -1, 1 };
+        var items = new List<int> { 0, -1, 1, -4 };
         var actual = items.OrderByDescending(i => i);
-        Assert.Equal("1, 0, -1", string.Join(", ", actual));
+        Assert.Equal("1, 0, -1, -4", string.Join(", ", actual));
     }
 }

--- a/test/UnitTest/Utils/GroupTest.cs
+++ b/test/UnitTest/Utils/GroupTest.cs
@@ -54,6 +54,6 @@ public class GroupTest
 
         items = new List<int> { 2, 1, 0, -1, -3, -2, -4 };
         actual = items.OrderBy(i => i);
-        Assert.Equal("-4, -3, -2, -1", string.Join(", ", actual));
+        Assert.Equal("-4, -3, -2, -1, 0, 1, 2", string.Join(", ", actual));
     }
 }


### PR DESCRIPTION
## The order of editing pop-up windows is consistent with the order of table columns

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #2213 
