### PR TITLE
fix(Localizer): can't find json stream when inconsistent namespace and assembly name

### DIFF
--- a/src/BootstrapBlazor.Server/Extensions/ServicesExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/ServicesExtensions.cs
@@ -46,17 +46,6 @@ internal static class ServicesExtensions
         // 增加 Baidu 语音服务
         services.AddBootstrapBlazorBaiduSpeech();
 
-        services.ConfigureJsonLocalizationOptions(op =>
-        {
-            // 附加自己的 json 多语言文化资源文件 如 zh-TW.json
-            op.AdditionalJsonAssemblies = new Assembly[]
-            {
-                typeof(BarcodeReader).Assembly,
-                typeof(Chart).Assembly,
-                typeof(SignaturePad).Assembly
-            };
-        });
-
         // 设置地理位置定位器
         services.ConfigureIPLocatorOption(op => op.LocatorFactory = sp => new BaiDuIPLocator());
 

--- a/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
@@ -76,6 +76,7 @@ internal static class LocalizationOptionsExtensions
 
     private static List<Stream> GetResourceStream(this JsonLocalizationOptions option, Assembly assembly, string cultureName)
     {
+        var resourceNames = assembly.GetManifestResourceNames();
         var ret = new List<Stream>();
 
         // 如果开启回落机制优先增加回落语言
@@ -101,11 +102,14 @@ internal static class LocalizationOptionsExtensions
 
         void AddStream(string name)
         {
-            var json = $"{assembly.GetName().Name}.{option.ResourcesPath}.{name}.json";
-            var stream = assembly.GetManifestResourceStream(json);
-            if (stream != null)
+            var json = resourceNames.FirstOrDefault(i => i.Contains($".{name}.json"));
+            if (json != null)
             {
-                ret.Add(stream);
+                var stream = assembly.GetManifestResourceStream(json);
+                if (stream != null)
+                {
+                    ret.Add(stream);
+                }
             }
         }
 

--- a/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
@@ -24,7 +24,7 @@ internal static class LocalizationOptionsExtensions
     public static IEnumerable<IConfigurationSection> GetJsonStringFromAssembly(this JsonLocalizationOptions option, Assembly assembly, string cultureName)
     {
         // 获得程序集内 Json 文件流集合
-        var langHandlers = option.GetResourceStream(assembly, cultureName);
+        var langHandlers = option.GetJsonHandlers(assembly, cultureName).ToList();
 
         // 创建配置 ConfigurationBuilder
         var builder = new ConfigurationBuilder();
@@ -58,6 +58,20 @@ internal static class LocalizationOptionsExtensions
             h.Dispose();
         }
         return config.GetChildren();
+    }
+
+    private static IEnumerable<Stream> GetJsonHandlers(this JsonLocalizationOptions option, Assembly assembly, string cultureName)
+    {
+        // 获取程序集中的资源文件
+        var assemblies = new List<Assembly>()
+        {
+            assembly
+        };
+        if (option.AdditionalJsonAssemblies != null)
+        {
+            assemblies.AddRange(option.AdditionalJsonAssemblies);
+        }
+        return assemblies.SelectMany(i => option.GetResourceStream(i, cultureName));
     }
 
     private static List<Stream> GetResourceStream(this JsonLocalizationOptions option, Assembly assembly, string cultureName)

--- a/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
@@ -24,7 +24,7 @@ internal static class LocalizationOptionsExtensions
     public static IEnumerable<IConfigurationSection> GetJsonStringFromAssembly(this JsonLocalizationOptions option, Assembly assembly, string cultureName)
     {
         // 获得程序集内 Json 文件流集合
-        var langHandlers = option.GetJsonHandlers(assembly, cultureName).ToList();
+        var langHandlers = option.GetResourceStream(assembly, cultureName);
 
         // 创建配置 ConfigurationBuilder
         var builder = new ConfigurationBuilder();
@@ -58,20 +58,6 @@ internal static class LocalizationOptionsExtensions
             h.Dispose();
         }
         return config.GetChildren();
-    }
-
-    private static IEnumerable<Stream> GetJsonHandlers(this JsonLocalizationOptions option, Assembly assembly, string cultureName)
-    {
-        // 获取程序集中的资源文件
-        var assemblies = new List<Assembly>()
-        {
-            assembly
-        };
-        if (option.AdditionalJsonAssemblies != null)
-        {
-            assemblies.AddRange(option.AdditionalJsonAssemblies);
-        }
-        return assemblies.SelectMany(i => option.GetResourceStream(i, cultureName));
     }
 
     private static List<Stream> GetResourceStream(this JsonLocalizationOptions option, Assembly assembly, string cultureName)

--- a/src/BootstrapBlazor/Localization/Json/JsonLocalizationOptions.cs
+++ b/src/BootstrapBlazor/Localization/Json/JsonLocalizationOptions.cs
@@ -20,8 +20,6 @@ public class JsonLocalizationOptions : LocalizationOptions
     /// <summary>
     /// 获得/设置 外置资源文件程序集集合
     /// </summary>
-    [Obsolete("已过期，内部自动识别，无需设置, No need to set")]
-    [ExcludeFromCodeCoverage]
     public IEnumerable<Assembly>? AdditionalJsonAssemblies { get; set; }
 
     /// <summary>

--- a/src/BootstrapBlazor/Localization/Json/JsonLocalizationOptions.cs
+++ b/src/BootstrapBlazor/Localization/Json/JsonLocalizationOptions.cs
@@ -20,6 +20,8 @@ public class JsonLocalizationOptions : LocalizationOptions
     /// <summary>
     /// 获得/设置 外置资源文件程序集集合
     /// </summary>
+    [Obsolete("已过期，内部自动识别，无需设置, No need to set")]
+    [ExcludeFromCodeCoverage]
     public IEnumerable<Assembly>? AdditionalJsonAssemblies { get; set; }
 
     /// <summary>

--- a/test/UnitTest/Core/BootstrapBlazorTestBase.cs
+++ b/test/UnitTest/Core/BootstrapBlazorTestBase.cs
@@ -60,7 +60,6 @@ public class BootstrapBlazorTestHost : IDisposable
         services.ConfigureJsonLocalizationOptions(op =>
         {
             op.IgnoreLocalizerMissing = false;
-            op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly };
         });
         services.AddSingleton<ILookupService, FooLookupService>();
     }

--- a/test/UnitTest/Core/DialogTestBase.cs
+++ b/test/UnitTest/Core/DialogTestBase.cs
@@ -47,7 +47,6 @@ public class DialogTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor();
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/MessageTestBase.cs
+++ b/test/UnitTest/Core/MessageTestBase.cs
@@ -46,7 +46,7 @@ public class MessageTestHost : IDisposable
 
     protected virtual void ConfigureServices(IServiceCollection services)
     {
-        services.AddBootstrapBlazor(localizationConfigure: op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
+        services.AddBootstrapBlazor();
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/PopoverTestBase.cs
+++ b/test/UnitTest/Core/PopoverTestBase.cs
@@ -47,7 +47,6 @@ public class PopoverTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor();
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/SwalTestBase.cs
+++ b/test/UnitTest/Core/SwalTestBase.cs
@@ -47,7 +47,6 @@ public class SwalTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor();
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/TabTestBase.cs
+++ b/test/UnitTest/Core/TabTestBase.cs
@@ -47,7 +47,6 @@ public class TabTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor(op => op.ToastDelay = 2000);
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
         services.ConfigureTabItemMenuBindOptions(options =>
         {
             options.Binders = new()

--- a/test/UnitTest/Core/TableDialogTestBase.cs
+++ b/test/UnitTest/Core/TableDialogTestBase.cs
@@ -49,7 +49,6 @@ public class TableDialogTestHost : IDisposable
     {
         services.AddBootstrapBlazor(op => op.ToastDelay = 2000);
         services.AddSingleton(typeof(IDataService<>), typeof(MockEFCoreDataService<>));
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfiguration(IServiceCollection services)

--- a/test/UnitTest/Core/TablePopConfirmTestBase.cs
+++ b/test/UnitTest/Core/TablePopConfirmTestBase.cs
@@ -47,7 +47,6 @@ public class TableConfirmTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor(op => op.ToastDelay = 2000);
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/TableSortDialogTestBase.cs
+++ b/test/UnitTest/Core/TableSortDialogTestBase.cs
@@ -47,7 +47,6 @@ public class TableSortDialogTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor();
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfiguration(IServiceCollection services)

--- a/test/UnitTest/Core/TableTestBase.cs
+++ b/test/UnitTest/Core/TableTestBase.cs
@@ -47,7 +47,6 @@ public class TableTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor(op => op.ToastDelay = 2000);
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/ValidateFormTestBase.cs
+++ b/test/UnitTest/Core/ValidateFormTestBase.cs
@@ -47,6 +47,7 @@ public class ValidateFormTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor();
+        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { GetType().Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Core/ValidateFormTestBase.cs
+++ b/test/UnitTest/Core/ValidateFormTestBase.cs
@@ -47,7 +47,6 @@ public class ValidateFormTestHost : IDisposable
     protected virtual void ConfigureServices(IServiceCollection services)
     {
         services.AddBootstrapBlazor();
-        services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly, GetType().Assembly });
     }
 
     protected virtual void ConfigureConfigration(IServiceCollection services)

--- a/test/UnitTest/Localization/JsonStringLocalizerTest.cs
+++ b/test/UnitTest/Localization/JsonStringLocalizerTest.cs
@@ -260,7 +260,6 @@ public class JsonStringLocalizerTest : BootstrapBlazorTestBase
         context.Services.AddBootstrapBlazor(localizationConfigure: option =>
         {
             option.ResourceManagerStringLocalizerType = typeof(Foo);
-            option.AdditionalJsonAssemblies = new[] { typeof(Alert).Assembly, GetType().Assembly };
             option.AdditionalJsonFiles = localizationConfigure;
         });
         context.Services.GetRequiredService<ICacheManager>();

--- a/test/UnitTestDocs/MenuTest.cs
+++ b/test/UnitTestDocs/MenuTest.cs
@@ -22,10 +22,7 @@ public partial class MenuTest
         _logger = logger;
         var serviceCollection = new ServiceCollection();
         var assembly = typeof(App).Assembly;
-        serviceCollection.AddBootstrapBlazor(localizationConfigure: option =>
-        {
-            option.AdditionalJsonAssemblies = new[] { assembly };
-        });
+        serviceCollection.AddBootstrapBlazor();
 
         _serviceProvider = serviceCollection.BuildServiceProvider();
         _serviceProvider.GetRequiredService<ICacheManager>();


### PR DESCRIPTION
## can't find json stream when inconsistent namespace and assembly name

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #2431 
