### PR TITLE
fix(Table): render cell missing parameters when readonly

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.0.6-beta02</Version>
+    <Version>8.0.6-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -393,6 +393,10 @@ public static class Utility
             {
                 builder.AddAttribute(5, "rows", item.Rows);
             }
+            if (item is ITableColumn col && col.ComponentParameters != null)
+            {
+                builder.AddMultipleAttributes(6, col.ComponentParameters);
+            }
             builder.CloseComponent();
         }
         else

--- a/test/UnitTest/Utils/UtilityTest.cs
+++ b/test/UnitTest/Utils/UtilityTest.cs
@@ -200,6 +200,22 @@ public class UtilityTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void CreateDisplayByFieldType_Parameter()
+    {
+        var editor = new MockNullDisplayNameColumn("Name", typeof(string))
+        {
+            ComponentType = typeof(Textarea),
+            ComponentParameters = new Dictionary<string, object>()
+            {
+                { "rows", "3" }
+            }
+        };
+        var fragment = new RenderFragment(builder => builder.CreateDisplayByFieldType(editor, new Foo() { Name = "Test-Display" }));
+        var cut = Context.Render(builder => builder.AddContent(0, fragment));
+        Assert.Contains("<textarea readonly rows=\"3\"", cut.Markup);
+    }
+
+    [Fact]
     public void CreateDisplayByFieldType_FormatString()
     {
         var dt = DateTime.Now;


### PR DESCRIPTION
## render cell missing parameters when readonly

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #2554 
