### PR TITLE
bug(Ribbon): missing menu-bg/menu-color sass variable

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.1.6-beta01</Version>
+    <Version>8.1.6-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/RibbonTab/RibbonTab.razor.scss
+++ b/src/BootstrapBlazor/Components/RibbonTab/RibbonTab.razor.scss
@@ -7,6 +7,8 @@
     --bb-ribbon-menu-padding: #{$bb-ribbon-menu-padding};
     --bb-ribbon-menu-border-color: #{$bb-ribbon-menu-border-color};
     --bb-ribbon-menu-hover-color: #{$bb-ribbon-menu-hover-color};
+    --bb-ribbon-menu-bg: #{$bb-ribbon-menu-bg};
+    --bb-ribbon-menu-color: #{$bb-ribbon-menu-color};
     --bb-ribbon-button-hover-bg: #{$bb-ribbon-button-hover-bg};
     --bb-ribbon-button-hover-border-color: #{$bb-ribbon-button-hover-border-color};
     --bb-ribbon-button-active-bg: #{$bb-ribbon-button-active-bg};
@@ -34,7 +36,7 @@
 }
 
 .ribbon-tab .ribbon-header .tabs-header {
-    background-color: var(--bs-body-bg);
+    background-color: var(--bb-ribbon-menu-bg);
     border-bottom: 1px solid var(--bs-border-color);
 }
 
@@ -73,7 +75,7 @@
 }
 
 .ribbon-tab .ribbon-header .tabs-border-card .tabs-header .tabs-item:not(:hover):not(.active) {
-    color: var(--bs-body-color);
+    color: var(--bb-ribbon-menu-color);
 }
 
 .ribbon-tab .ribbon-header .tabs-border-card .tabs-header .tabs-item:hover {

--- a/src/BootstrapBlazor/wwwroot/scss/theme/bootstrap.blazor.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/theme/bootstrap.blazor.scss
@@ -415,6 +415,8 @@ $bb-ribbon-menu-radius: var(--bs-border-radius);
 $bb-ribbon-menu-padding: .5rem;
 $bb-ribbon-menu-border-color: var(--bs-border-color);
 $bb-ribbon-menu-hover-color: #409eff;
+$bb-ribbon-menu-bg: var(--bs-body-bg);
+$bb-ribbon-menu-color: var(--bs-body-color);
 $bb-ribbon-button-hover-bg: rgb(51 147 246 / 48%);
 $bb-ribbon-button-hover-border-color: #89b9ea;
 $bb-ribbon-button-active-bg: #acd4fd;


### PR DESCRIPTION
## missing menu-bg/menu-color sass variable

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #2770 
