### PR TITLE
fix(Pagination): incorrect pagination jump

### DIFF
--- a/src/BootstrapBlazor/Components/Pagination/Pagination.razor.cs
+++ b/src/BootstrapBlazor/Components/Pagination/Pagination.razor.cs
@@ -181,7 +181,8 @@ public partial class Pagination
         var pageIndex = InternalPageIndex - index;
         if (pageIndex < 1)
         {
-            pageIndex = InternalPageCount;
+            //pageIndex = InternalPageCount;
+            pageIndex = 1;
         }
         await OnPageItemClick(pageIndex);
     }
@@ -194,7 +195,8 @@ public partial class Pagination
         var pageIndex = InternalPageIndex + index;
         if (pageIndex > InternalPageCount)
         {
-            pageIndex = 1;
+            //pageIndex = 1;
+            pageIndex = InternalPageCount;
         }
         await OnPageItemClick(pageIndex);
     }


### PR DESCRIPTION
## 文档例子分页无限循环

复现url  https://www.blazor.zone/table/loading 

发现 分页组件有点 问题，具体为 ：
假设 每页5条数据，当 到第5页时会出现 ...  ，点击这个 ... 会跳转到 最后一页，同理 下一页的 ...也会出现； 这时应该 为  上一页 为  1，同理 下一页为 最后一页即  InternalPageCount，


<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #2976 
