### PR TITLE
fix(Table): keep client column width not work when set AutoGenerateColumns to true

### DIFF
--- a/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
@@ -82,7 +82,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     int? ITableColumn.Width
     {
         get => Width <= 0 ? null : Width;
-        set => Width = value == null ? 0 : Width;
+        set => Width = value ?? 0;
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.3.2-beta01</Version>
+    <Version>8.3.2-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -357,7 +357,7 @@ public static class Utility
     /// </summary>
     /// <param name="predicate"></param>
     /// <returns></returns>
-    public static IEnumerable<ITableColumn> GenerateColumns<TModel>(Func<ITableColumn, bool> predicate) => Utility.GetTableColumns<TModel>().Where(predicate);
+    public static IEnumerable<ITableColumn> GenerateColumns<TModel>(Func<ITableColumn, bool> predicate) => GetTableColumns<TModel>().Where(predicate);
 
     /// <summary>
     /// RenderTreeBuilder 扩展方法 通过 IEditorItem 与 model 创建 Display 组件

--- a/test/UnitTest/Attributes/AutoGenerateClassTest.cs
+++ b/test/UnitTest/Attributes/AutoGenerateClassTest.cs
@@ -129,7 +129,7 @@ public class AutoGenerateClassTest
         Assert.Equal(0, attr.Width);
 
         attrInterface.Width = -10;
-        Assert.Equal(0, attr.Width);
+        Assert.Equal(-10, attr.Width);
 
         attr.Width = -10;
         Assert.Null(attrInterface.Width);


### PR DESCRIPTION
## keep client column width not work when set AutoGenerateColumns to true

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #3046 
