### PR TITLE
fix(FullScreenButton): show tow icons when set FullScreenIcon

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/FullScreens.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/FullScreens.razor
@@ -11,11 +11,11 @@
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["FullScreenTitleTitle"]" Introduction="@Localizer["FullScreenTitleIntro"]" Name="Title">
-    <ul class="ul-demo mb-3">
-        <li>@((MarkupString)Localizer["FullScreenTitleLi1"].Value)</li>
-        <li>@((MarkupString)Localizer["FullScreenTitleLi2"].Value)</li>
-        <li>@((MarkupString)Localizer["FullScreenTitleLi3"].Value)</li>
-    </ul>
-    <Pre class="mt-3">&lt;@Localizer["Pre"] /&gt;</Pre>
-    <FullScreenButton Title="@Localizer["FullScreenTitleButton1Text"]" FullScreenIcon="fa-solid fa-font-awesome" />
+    <section ignore>
+        <ul class="ul-demo mb-3">
+            <li>@((MarkupString)Localizer["FullScreenTitleLi1"].Value)</li>
+            <li>@((MarkupString)Localizer["FullScreenTitleLi3"].Value)</li>
+        </ul>
+    </section>
+    <FullScreenButton FullScreenIcon="fa-solid fa-font-awesome"></FullScreenButton>
 </DemoBlock>

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2168,10 +2168,7 @@
     "FullScreenTitleTitle": "Button",
     "FullScreenTitleIntro": "The full screen of the entire web page is component <code>FullScreenButton</code>",
     "FullScreenTitleLi1": "The button default icon can be set through the <code>ButtonIcon</code>, and the full-screen icon can be set through the <code>FullScreenIcon</code> property",
-    "FullScreenTitleLi2": "Use the <code>Title</code> property to set the prompt bar text when the mouse hovers",
-    "FullScreenTitleLi3": "Use the <code>Text</code> property to set current page title",
-    "FullScreenTitleButton1Text": "Tap for a full screen operation",
-    "Pre": "FullScreenButton Title=\"Click for full screen operation\""
+    "FullScreenTitleLi3": "Use the <code>Text</code> property to set current page title"
   },
   "BootstrapBlazor.Server.Components.Samples.Buttons": {
     "Title": "Button",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2168,10 +2168,7 @@
     "FullScreenTitleTitle": "按钮组件",
     "FullScreenTitleIntro": "通过 <code>FullScreenButton</code> 组件将整个网页进行全屏化",
     "FullScreenTitleLi1": "可通过 <code>ButtonIcon</code> 设置按钮默认图标，通过 <code>FullScreenIcon</code> 属性设置全屏时图标",
-    "FullScreenTitleLi2": "通过 <code>Title</code> 属性设置鼠标悬浮时提示栏文字",
-    "FullScreenTitleLi3": "通过 <code>Text</code> 属性设置当前页标题文字",
-    "FullScreenTitleButton1Text": "点击进行全屏操作",
-    "Pre": "FullScreenButton Title=\"点击进行全屏操作\""
+    "FullScreenTitleLi3": "通过 <code>Text</code> 属性设置当前页标题文字"
   },
   "BootstrapBlazor.Server.Components.Samples.Buttons": {
     "Title": "Button 按钮",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.3.5-beta06</Version>
+    <Version>8.3.5</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/FullScreen/FullScreen.razor.scss
+++ b/src/BootstrapBlazor/Components/FullScreen/FullScreen.razor.scss
@@ -1,12 +1,8 @@
-.fs-on,
-.fs-open {
-    .fs-off {
-        display: none;
-    }
+.bb-fs-off,
+.bb-fs-open .bb-fs-on {
+    display: none;
 }
 
-.fs-open {
-    .fs-on {
-        display: block;
-    }
+.bb-fs-open .bb-fs-off {
+    display: inline-block;
 }

--- a/src/BootstrapBlazor/Components/FullScreen/FullScreenButton.razor
+++ b/src/BootstrapBlazor/Components/FullScreen/FullScreenButton.razor
@@ -4,4 +4,11 @@
 <a @attributes="AdditionalAttributes" id="@Id" class="@ClassString" @onclick="ToggleFullScreen">
     <i class="@ButtonIconString"></i>
     <i class="@FullScreenIconString"></i>
+    @if (!string.IsNullOrEmpty(Text))
+    {
+        <span>@Text</span>
+    }
+    <CascadingValue Value="this" IsFixed="true">
+        @ChildContent
+    </CascadingValue>
 </a>

--- a/src/BootstrapBlazor/Components/FullScreen/FullScreenButton.razor.cs
+++ b/src/BootstrapBlazor/Components/FullScreen/FullScreenButton.razor.cs
@@ -23,13 +23,12 @@ public partial class FullScreenButton
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
-    private string? ButtonIconString => CssBuilder.Default()
-        .AddClass(Icon)
-        .AddClass("fs-off", !string.IsNullOrEmpty(FullScreenIcon))
+    private string? ButtonIconString => CssBuilder.Default(Icon)
+        .AddClass("bb-fs-off")
         .Build();
 
-    private string? FullScreenIconString => CssBuilder.Default("fs-on")
-        .AddClass(FullScreenIcon)
+    private string? FullScreenIconString => CssBuilder.Default(FullScreenIcon)
+        .AddClass("bb-fs-on")
         .Build();
 
     /// <summary>

--- a/src/BootstrapBlazor/wwwroot/modules/fullscreen.js
+++ b/src/BootstrapBlazor/wwwroot/modules/fullscreen.js
@@ -12,7 +12,7 @@ export function init(id) {
         else {
             fs.enter()
         }
-        fs.toggleElement.classList.toggle('fs-open')
+        fs.toggleElement.classList.toggle('bb-fs-open')
     }
 
     fs.enter = () => {

--- a/test/UnitTest/Components/FullScreenTest.cs
+++ b/test/UnitTest/Components/FullScreenTest.cs
@@ -11,7 +11,11 @@ public class FullScreenTest : BootstrapBlazorTestBase
     [Fact]
     public void ButtonIcon_Ok()
     {
-        var cut = Context.RenderComponent<FullScreenButton>(builder => builder.Add(s => s.Icon, "fa-solid fa-maximize"));
+        var cut = Context.RenderComponent<FullScreenButton>(builder =>
+        {
+            builder.Add(s => s.Icon, "fa-solid fa-maximize");
+            builder.Add(s => s.Text, "button-text");
+        });
         var ele = cut.Find(".fa-maximize");
         Assert.NotNull(ele);
     }


### PR DESCRIPTION
## show tow icons when set FullScreenIcon

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #{bug number}
