### PR TITLE
feat(Chart): Add a CanvasBackgroundColor parameter

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="BootstrapBlazor.Bluetooth" Version="8.0.2" />
     <PackageReference Include="BootstrapBlazor.BootstrapIcon" Version="8.0.2" />
     <PackageReference Include="BootstrapBlazor.BootstrapIcon.Extensions" Version="8.0.3" />
-    <PackageReference Include="BootstrapBlazor.Chart" Version="8.1.2" />
+    <PackageReference Include="BootstrapBlazor.Chart" Version="8.1.3" />
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="8.0.0" />
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="8.0.2" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="8.1.3" />

--- a/src/Extensions/Components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
+++ b/src/Extensions/Components/BootstrapBlazor.Chart/BootstrapBlazor.Chart.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.1.2</Version>
+    <Version>8.1.3</Version>
     <PackageTags>Bootstrap Blazor WebAssembly wasm UI Components Chart</PackageTags>
     <Description>Bootstrap UI components extensions of Chart.js</Description>
   </PropertyGroup>

--- a/src/Extensions/Components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
+++ b/src/Extensions/Components/BootstrapBlazor.Chart/Components/Chart/Chart.razor.js
@@ -5,6 +5,20 @@ import EventHandler from "../../../BootstrapBlazor/modules/event-handler.js"
 
 Chart.register(ChartDataLabels);
 
+const plugin = {
+    id: 'customCanvasBackgroundColor',
+    beforeDraw: (chart, args, options) => {
+        if (options.color) {
+            const { ctx } = chart;
+            ctx.save();
+            ctx.globalCompositeOperation = 'destination-over';
+            ctx.fillStyle = options.color;
+            ctx.fillRect(0, 0, chart.width, chart.height);
+            ctx.restore();
+        }
+    }
+};
+
 const chartOption = {
     options: {
         responsive: true,
@@ -41,7 +55,8 @@ const chartOption = {
                 }
             }
         }
-    }
+    },
+    plugins: [plugin]
 }
 
 const skipped = (ctx, value) => ctx.p0.skip || ctx.p1.skip ? value : undefined
@@ -315,6 +330,9 @@ const getChartOption = function (option) {
                         font: {
                             weight: 'bold'
                         }
+                    },
+                    customCanvasBackgroundColor: {
+                        color: option.options.canvasBackgroundColor,
                     }
                 },
                 scales: scale

--- a/src/Extensions/Components/BootstrapBlazor.Chart/Components/Chart/ChartOptions.cs
+++ b/src/Extensions/Components/BootstrapBlazor.Chart/Components/Chart/ChartOptions.cs
@@ -160,6 +160,11 @@ public class ChartOptions
     public string? YScalesGridTickColor { get; set; }
 
     /// <summary>
+    /// 获得/设置 图表背景颜色
+    /// </summary>
+    public string? CanvasBackgroundColor { get; set; }
+
+    /// <summary>
     /// 获得/设置 是否显示柱状图数据值
     /// </summary>
     public bool ShowDataLabel { get; set; }


### PR DESCRIPTION
## Add a CanvasBackgroundColor parameter

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description
Added a new plugin named `customCanvasBackgroundColor` to `Chart.razor.js` that allows setting a custom background color for the chart canvas. The `chartOption` object and `getChartOption` function were updated to include this new plugin. Also, a new property `CanvasBackgroundColor` was added to the `ChartOptions` class in `ChartOptions.cs` to get or set the background color of the chart canvas.

close #3457
