### PR TITLE
fix(TreeView): all children node state is Indeterminate after expand node

### DIFF
--- a/src/BootstrapBlazor.Server/Data/TreeFoo.cs
+++ b/src/BootstrapBlazor.Server/Data/TreeFoo.cs
@@ -55,7 +55,7 @@ class TreeFoo
         var items = GetItems();
 
         // 算法获取属性结构数据
-        return CascadingTree(items).ToList();
+        return CascadingTree(items);
     }
 
     /// <summary>
@@ -91,12 +91,12 @@ class TreeFoo
     /// 树状数据层次化方法
     /// </summary>
     /// <param name="items">数据集合</param>
-    public static IEnumerable<TreeViewItem<TreeFoo>> CascadingTree(IEnumerable<TreeFoo> items) => items.CascadingTree(null,
+    public static List<TreeViewItem<TreeFoo>> CascadingTree(IEnumerable<TreeFoo> items) => items.CascadingTree(null,
         (foo, parent) => foo.ParentId == parent?.Value.Id,
         foo => new TreeViewItem<TreeFoo>(foo)
         {
             Text = foo.Text,
             Icon = foo.Icon,
             IsActive = foo.IsActive
-        }).ToList();
+        });
 }

--- a/src/BootstrapBlazor.Server/Data/TreeFoo.cs
+++ b/src/BootstrapBlazor.Server/Data/TreeFoo.cs
@@ -62,10 +62,9 @@ class TreeFoo
     /// TreeFoo 带选择框树状数据集
     /// </summary>
     /// <returns></returns>
-    public static List<TreeViewItem<TreeFoo>> GetCheckedTreeItems(string? parentId=null)
+    public static List<TreeViewItem<TreeFoo>> GetCheckedTreeItems(string? parentId = null)
     {
-        return new List<TreeViewItem<TreeFoo>>
-            {
+        return [
             new(new TreeFoo()
             {
                 Id = $"{parentId}-101",
@@ -84,7 +83,7 @@ class TreeFoo
                 Text = "navigation two",
                 CheckedState = CheckboxState.Checked
             }
-        };
+        ];
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.5.8-beta02</Version>
+    <Version>8.5.8-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/Button/Button.razor.js
+++ b/src/BootstrapBlazor/Components/Button/Button.razor.js
@@ -26,7 +26,7 @@ const dispose = id => {
     removeTooltip(id)
 }
 
-const share = (id, context) => {
+const share = context => {
     navigator.share(context)
 }
 

--- a/src/BootstrapBlazor/Components/Button/ShareButton.cs
+++ b/src/BootstrapBlazor/Components/Button/ShareButton.cs
@@ -19,5 +19,5 @@ public class ShareButton : Button
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task HandlerClick() => InvokeVoidAsync("share", Id, ShareContext);
+    protected override Task HandlerClick() => InvokeVoidAsync("share", ShareContext);
 }

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -490,7 +490,10 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
         if (AutoCheckChildren)
         {
             // 向下级联操作
-            item.SetChildrenCheck(item.CheckedState, TreeNodeStateCache);
+            if (item.CheckedState != CheckboxState.Indeterminate)
+            {
+                item.SetChildrenCheck(item.CheckedState, TreeNodeStateCache);
+            }
         }
 
         if (AutoCheckParent)

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -45,7 +45,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     /// <param name="item"></param>
     /// <returns></returns>
     private string? GetCaretClassString(TreeViewItem<TItem> item) => CssBuilder.Default("node-icon")
-        .AddClass("visible", item.HasChildren || item.Items.Any())
+        .AddClass("visible", item.HasChildren || item.Items.Count > 0)
         .AddClass(NodeIcon, !item.IsExpand)
         .AddClass(ExpandNodeIcon, item.IsExpand)
         .AddClass("disabled", !CanExpandWhenDisabled && GetItemDisabledState(item))
@@ -74,7 +74,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
         .AddClass("disabled", GetItemDisabledState(item))
         .Build();
 
-    private bool TriggerNodeArrow(TreeViewItem<TItem> item) => (CanExpandWhenDisabled || !GetItemDisabledState(item)) && (item.HasChildren || item.Items.Any());
+    private bool TriggerNodeArrow(TreeViewItem<TItem> item) => (CanExpandWhenDisabled || !GetItemDisabledState(item)) && (item.HasChildren || item.Items.Count > 0);
 
     private bool TriggerNodeLabel(TreeViewItem<TItem> item) => !GetItemDisabledState(item);
 
@@ -299,7 +299,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
             }
             else
             {
-                if (Items.Any())
+                if (Items.Count > 0)
                 {
                     await CheckExpand(Items);
                 }
@@ -330,7 +330,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
         {
             await TreeNodeStateCache.CheckExpandAsync(node, GetChildrenRowAsync);
 
-            if (node.Items.Any())
+            if (node.Items.Count > 0)
             {
                 await CheckExpand(node.Items);
             }
@@ -463,7 +463,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
 
         if (ShowCheckbox)
         {
-            if (!AutoCheckChildren && AutoCheckParent && node.Items.Any())
+            if (!AutoCheckChildren && AutoCheckParent && node.Items.Count > 0)
             {
                 node.Items[0].SetParentCheck(node.Items[0].CheckedState, TreeNodeStateCache);
             }

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -463,7 +463,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
 
         if (ShowCheckbox)
         {
-            if(!AutoCheckChildren&&AutoCheckParent&&node.Items.Any())
+            if (!AutoCheckChildren && AutoCheckParent && node.Items.Any())
             {
                 node.Items[0].SetParentCheck(node.Items[0].CheckedState, TreeNodeStateCache);
             }

--- a/src/BootstrapBlazor/Extensions/ExpandableNodeExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ExpandableNodeExtensions.cs
@@ -122,13 +122,13 @@ public static class ExpandableNodeExtensions
     /// <param name="parent">父级节点</param>
     /// <param name="predicate">查找子节点 Lambda 表达式</param>
     /// <param name="valueFactory"></param>
-    public static IEnumerable<TreeViewItem<TItem>> CascadingTree<TItem>(this IEnumerable<TItem> items, TreeViewItem<TItem>? parent, Func<TItem, TreeViewItem<TItem>?, bool> predicate, Func<TItem, TreeViewItem<TItem>> valueFactory) => items
+    public static List<TreeViewItem<TItem>> CascadingTree<TItem>(this IEnumerable<TItem> items, TreeViewItem<TItem>? parent, Func<TItem, TreeViewItem<TItem>?, bool> predicate, Func<TItem, TreeViewItem<TItem>> valueFactory) => items
         .Where(i => predicate(i, parent))
         .Select(i =>
         {
             var item = valueFactory(i);
-            item.Items = CascadingTree(items, item, predicate, valueFactory).ToList();
+            item.Items = items.CascadingTree(item, predicate, valueFactory);
             item.Parent = parent;
             return item;
-        });
+        }).ToList();
 }

--- a/src/BootstrapBlazor/Misc/TreeNodeCache.cs
+++ b/src/BootstrapBlazor/Misc/TreeNodeCache.cs
@@ -9,7 +9,7 @@ namespace BootstrapBlazor.Components;
 /// </summary>
 /// <typeparam name="TNode"></typeparam>
 /// <typeparam name="TItem"></typeparam>
-public class TreeNodeCache<TNode, TItem> : ExpandableNodeCache<TNode, TItem> where TNode : ICheckableNode<TItem>
+public class TreeNodeCache<TNode, TItem>(Func<TItem, TItem, bool> comparer) : ExpandableNodeCache<TNode, TItem>(comparer) where TNode : ICheckableNode<TItem>
 {
     /// <summary>
     /// 获得 所有选中节点集合 作为缓存使用
@@ -25,14 +25,6 @@ public class TreeNodeCache<TNode, TItem> : ExpandableNodeCache<TNode, TItem> whe
     /// 获得 所有未选中节点集合 作为缓存使用
     /// </summary>
     protected List<TItem> IndeterminateNodeCache { get; } = new(50);
-
-    /// <summary>
-    /// 构造函数
-    /// </summary>
-    public TreeNodeCache(Func<TItem, TItem, bool> comparer) : base(comparer)
-    {
-
-    }
 
     /// <summary>
     /// <inheritdoc/>

--- a/test/UnitTest/Components/ButtonTest.cs
+++ b/test/UnitTest/Components/ButtonTest.cs
@@ -434,5 +434,9 @@ public class ButtonTest : BootstrapBlazorTestBase
             var button = cut.Find("button");
             button.Click();
         });
+
+        Assert.Equal("test-share-text", cut.Instance.ShareContext?.Text);
+        Assert.Equal("test-share-title", cut.Instance.ShareContext?.Title);
+        Assert.Equal("www.blazor.zone", cut.Instance.ShareContext?.Url);
     }
 }

--- a/test/UnitTest/Components/ButtonTest.cs
+++ b/test/UnitTest/Components/ButtonTest.cs
@@ -434,14 +434,5 @@ public class ButtonTest : BootstrapBlazorTestBase
             var button = cut.Find("button");
             button.Click();
         });
-
-        var invocation = Context.JSInterop.VerifyInvoke("share");
-        if (invocation.Arguments[0]?.ToString() == cut.Instance.Id)
-        {
-            var context = invocation.Arguments[1] as ShareButtonContext;
-            Assert.Equal("test-share-text", context?.Text);
-            Assert.Equal("test-share-title", context?.Title);
-            Assert.Equal("www.blazor.zone", context?.Url);
-        }
     }
 }

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -270,7 +270,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Find(".fa-caret-right.visible").Click());
         Assert.True(expanded);
 
-        cut.WaitForAssertion(() => cut.Instance.Items[0].Items.Any());
+        cut.WaitForState(() => cut.Instance.Items[0].Items.Count > 0);
 
         // 展开状态-级联选中-子级
         checkboxes = cut.FindComponents<Checkbox<CheckboxState>>();
@@ -315,7 +315,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Find(".fa-caret-right.visible").Click());
         Assert.True(expanded);
 
-        cut.WaitForAssertion(() => cut.Instance.Items[0].Items.Any());
+        cut.WaitForState(() => cut.Instance.Items[0].Items.Count > 0);
 
         // 展开状态
         checkboxes = cut.FindComponents<Checkbox<CheckboxState>>();
@@ -357,7 +357,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Find(".fa-caret-right.visible").Click());
         Assert.True(expanded);
 
-        cut.WaitForAssertion(() => cut.Instance.Items[0].Items.Any());
+        cut.WaitForState(() => cut.Instance.Items[0].Items.Count > 0);
 
         // 展开状态
         checkboxes = cut.FindComponents<Checkbox<CheckboxState>>();

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -153,7 +153,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
         };
 
         // 根节点
-        var nodes = TreeFoo.CascadingTree(items).ToList();
+        var nodes = TreeFoo.CascadingTree(items);
         nodes[0].IsExpand = true;
         nodes[1].IsExpand = true;
 
@@ -252,7 +252,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
             pb.Add(a => a.AutoCheckParent, true);
             pb.Add(a => a.Items, items);
             pb.Add(a => a.ShowCheckbox, true);
-            pb.Add(a => a.OnExpandNodeAsync,async (item) =>
+            pb.Add(a => a.OnExpandNodeAsync, async (item) =>
             {
                 expanded = true;
 
@@ -676,7 +676,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
             new() { Text = "SubItem11", Id = "10111", ParentId = "1011" },
             new() { Text = "SubItem21", Id = "10121", ParentId = "1012" }
         ];
-        nodes = TreeFoo.CascadingTree(items).ToList();
+        nodes = TreeFoo.CascadingTree(items);
 
         cut.SetParametersAndRender(pb => pb.Add(a => a.Items, nodes));
         // 子节点
@@ -834,7 +834,7 @@ public class TreeViewTest : BootstrapBlazorTestBase
         public IExpandableNode<TreeFoo>? Parent { get; set; }
 
         [NotNull]
-        public IEnumerable<IExpandableNode<TreeFoo>>? Items { get; set; } = Enumerable.Empty<IExpandableNode<TreeFoo>>();
+        public IEnumerable<IExpandableNode<TreeFoo>>? Items { get; set; } = [];
 
         [NotNull]
         public TreeFoo? Value { get; set; } = foo;
@@ -855,24 +855,6 @@ public class TreeViewTest : BootstrapBlazorTestBase
             new(new TreeFoo(){ Id = $"{item.Id}-102", ParentId = item.Id })
             {
                 Text = "懒加载子节点2"
-            }
-        };
-    }
-
-    private static async Task<IEnumerable<TreeViewItem<TreeFoo>>> OnExpandNodeWithCheckedStateAsync(TreeFoo item)
-    {
-        await Task.Yield();
-        return new TreeViewItem<TreeFoo>[]
-        {
-            new(new TreeFoo() { Id = $"{item.Id}-101", ParentId = item.Id })
-            {
-                Text = "懒加载子节点1",
-                HasChildren = true
-            },
-            new(new TreeFoo(){ Id = $"{item.Id}-102", ParentId = item.Id })
-            {
-                Text = "懒加载子节点2",
-                CheckedState=CheckboxState.Checked
             }
         };
     }


### PR DESCRIPTION
## all children node state is Indeterminate after expand node

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #3516 
link #3505
