### PR TITLE
perf(Table): skip call client column info when not set ClientTableName

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -918,15 +918,18 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private async Task ReloadColumnOrdersFromBrowserAsync(List<ITableColumn> columns)
     {
-        var orders = await InvokeAsync<List<string>?>("reloadColumnOrder", ClientTableName);
-        if (orders != null && orders.Count > 0)
+        if (!string.IsNullOrEmpty(ClientTableName))
         {
-            for (int i = 0; i < orders.Count; i++)
+            var orders = await InvokeAsync<List<string>?>("reloadColumnOrder", ClientTableName);
+            if (orders != null)
             {
-                var col = columns.Find(c => c.GetFieldName() == orders[i]);
-                if (col != null)
+                for (int i = 0; i < orders.Count; i++)
                 {
-                    col.Order = i + 1;
+                    var col = columns.Find(c => c.GetFieldName() == orders[i]);
+                    if (col != null)
+                    {
+                        col.Order = i + 1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## skip call client column info when not set ClientTableName

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #3521 
