### PR TITLE
feat(FileViewer): bump BootstrapBlazor.FileViewer version to v8.0.3

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="8.0.0" />
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="8.0.2" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="8.1.3" />
-    <PackageReference Include="BootstrapBlazor.FileViewer" Version="8.0.2" />
+    <PackageReference Include="BootstrapBlazor.FileViewer" Version="8.0.3" />
     <PackageReference Include="BootstrapBlazor.FontAwesome" Version="8.0.4" />
     <PackageReference Include="BootstrapBlazor.Gantt" Version="8.0.1" />
     <PackageReference Include="BootstrapBlazor.Holiday" Version="8.0.1" />

--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="8.0.0" />
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="8.0.2" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="8.1.3" />
-    <PackageReference Include="BootstrapBlazor.FileViewer" Version="8.0.1" />
+    <PackageReference Include="BootstrapBlazor.FileViewer" Version="8.0.2" />
     <PackageReference Include="BootstrapBlazor.FontAwesome" Version="8.0.4" />
     <PackageReference Include="BootstrapBlazor.Gantt" Version="8.0.1" />
     <PackageReference Include="BootstrapBlazor.Holiday" Version="8.0.1" />


### PR DESCRIPTION
BootstrapBlazor.FileViewer v8.0.3
- 修复 [依赖包日期格式转换错误](https://github.com/densen2014/BootstrapBlazor.FileViewer/issues/4)
- 修复 [组件依赖](https://github.com/densen2014/BootstrapBlazor.FileViewer/issues/2)

## BootstrapBlazor.FileViewer v8.0.2 修复 [依赖包日期格式转换错误]

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #3534
