### PR TITLE
Fixed adding 'CustomClass' in multiselect component

### DIFF
--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -14,7 +14,8 @@ public partial class MultiSelect<TValue>
 {
     private List<SelectedItem> SelectedItems { get; } = [];
 
-    private static string? ClassString => CssBuilder.Default("select dropdown multi-select")
+    private string? ClassString => CssBuilder.Default("select dropdown multi-select")
+        .AddClass(base.CustomClass)
         .Build();
 
     private string? ToggleClassString => CssBuilder.Default("dropdown-toggle scroll")


### PR DESCRIPTION
## Add custom user's css class to multiselect component

Fixed adding custom user's css class to multiselect component

### Description

When user set 'CustomClass', this css class isn't adding to multiselect component. It's fixed.
