### PR TITLE
fixing rendering for ShowAfterLabel property 

### DIFF
--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor
@@ -28,16 +28,5 @@ else
     </div>;
 
     RenderFragment RenderLabel =>
-    @<label class="form-check-label" for="@Id">
-        @if(ShowLabelTooltip is true)
-        {
-            <Tooltip Title="@DisplayText">
-                @DisplayText
-            </Tooltip>
-        }
-        else
-        {
-            @DisplayText
-        }
-    </label>;
+        @<BootstrapLabel required="@Required" for="@Id" ShowLabelTooltip="ShowLabelTooltip" Value="@DisplayText" ClassString="form-check-label"/>;
 }


### PR DESCRIPTION
## Show After Label rendering should be equal as the regular label.

I need help with the styling and margin on the After Label @ArgoZhang since my sass are not being compiled in my local. 

### Description

close #{bug number}
