### PR TITLE
refactor(DockViewV2): move component back into template when group removed

### DIFF
--- a/src/Extensions/Components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
+++ b/src/Extensions/Components/BootstrapBlazor.DockView/BootstrapBlazor.DockView.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.0.8</Version>
+    <Version>8.0.9</Version>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/Extensions/Components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/Extensions/Components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -5,8 +5,8 @@ const onAddPanel = panel => {
     updateCloseButton(panel);
     updateTitle(panel);
     panel.api.onDidActiveChange(({ isActive }) => {
-        if(panel.group.panels.length < 2) return
-        if(isActive){
+        if (panel.group.panels.length < 2) return
+        if (isActive) {
             saveConfig(panel.accessor)
             panel.group.panels.filter(p => p != panel.group.activePanel).forEach(p => {
                 appendTemplatePanelEle(p)

--- a/src/Extensions/Components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/Extensions/Components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -8,9 +8,9 @@ const onAddPanel = panel => {
         if(panel.group.panels.length < 2) return
         if(isActive){
             saveConfig(panel.accessor)
-        }
-        if (!isActive && panel.group.activePanel != panel) {
-            appendTemplatePanelEle(panel)
+            panel.group.panels.filter(p => p != panel.group.activePanel).forEach(p => {
+                appendTemplatePanelEle(p)
+            })
         }
     })
 }

--- a/src/Extensions/Components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
+++ b/src/Extensions/Components/BootstrapBlazor.DockView/wwwroot/js/dockview-panel.js
@@ -5,8 +5,11 @@ const onAddPanel = panel => {
     updateCloseButton(panel);
     updateTitle(panel);
     panel.api.onDidActiveChange(({ isActive }) => {
-        if (!isActive && panel.group.panels.length > 1) {
+        if(panel.group.panels.length < 2) return
+        if(isActive){
             saveConfig(panel.accessor)
+        }
+        if (!isActive && panel.group.activePanel != panel) {
             appendTemplatePanelEle(panel)
         }
     })


### PR DESCRIPTION
## move component back into template when group removed

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

close #3920 
