### PR TITLE
增加支持处理原生控件的异常和生命周期内异常

### DIFF
--- a/src/BootstrapBlazor/Components/ErrorLogger/ErrorLogger.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/ErrorLogger.cs
@@ -178,7 +178,7 @@ public class ErrorLogger
                 builder.OpenComponent<ErrorLoggerExceptionHandler>(sequence++);
                 builder.AddAttribute(sequence++, "ToastTitle", ToastTitle);
                 builder.AddAttribute(sequence++, "ShowToast", ShowToast);
-                builder.AddAttribute(sequence++, "Exception", CurrentException);
+                builder.AddAttribute(sequence++, "Exception", ex);
                 builder.AddAttribute(sequence++, "OnErrorHandleAsync", OnErrorHandleAsync);
                 builder.AddAttribute(sequence++, "ExceptionHandled", EventCallback.Factory.Create(this, ExceptionHandled));
                 builder.CloseComponent();

--- a/src/BootstrapBlazor/Components/ErrorLogger/ErrorLogger.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/ErrorLogger.cs
@@ -71,7 +71,6 @@ public class ErrorLogger
 #endif
     private Exception? Exception { get; set; }
 
-    private bool firstRender = true;
     private int errorRenderCount = 0;
 
     /// <summary>
@@ -95,17 +94,6 @@ public class ErrorLogger
 #if NET6_0_OR_GREATER
         Recover();
 #endif
-    }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <param name="firstRender"></param>
-    protected override void OnAfterRender(bool firstRender)
-    {
-        base.OnAfterRender(firstRender);
-
-        this.firstRender = firstRender;
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/ErrorLogger/ErrorLoggerExceptionHandler.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/ErrorLoggerExceptionHandler.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Argo Zhang (argo@163.com). All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+// Website: https://www.blazor.zone or https://argozhang.github.io/
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace BootstrapBlazor.Components;
+
+internal class ErrorLoggerExceptionHandler : BootstrapComponentBase
+{
+    [Inject]
+    [NotNull]
+    private ILogger<ErrorLogger>? Logger { get; set; }
+
+    [Inject]
+    [NotNull]
+    private ToastService? ToastService { get; set; }
+
+    [Parameter]
+    [NotNull]
+    public string? ToastTitle { get; set; }
+
+    [Parameter]
+    [NotNull]
+    public Exception? Exception { get; set; }
+
+    [Parameter]
+    public bool ShowToast { get; set; } = true;
+
+    [Parameter]
+    public EventCallback ExceptionHandled { get; set; }
+
+    [Parameter]
+    public Func<ILogger, Exception, Task>? OnErrorHandleAsync { get; set; }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await base.OnInitializedAsync();
+
+        if (OnErrorHandleAsync != null)
+        {
+            await OnErrorHandleAsync(Logger, Exception);
+        }
+        else if (ShowToast)
+        {
+            await ToastService.Error(ToastTitle, Exception.Message);
+        }
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (ExceptionHandled.HasDelegate)
+        {
+            await InvokeAsync(async () => await ExceptionHandled.InvokeAsync());
+        }
+    }
+}


### PR DESCRIPTION
## 增加支持处理原生控件的异常和生命周期内异常

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description

父组件标记的ErrorBoundary可以捕获子组件生命周期内的异常和原生控件异常，因此在MainLayout中设置ErrorBoundary可以很好的全局处理，本PR调整的逻辑如下：
1. 增加错误渲染次数记录，如果发现错误渲染超过1次，说明可能是生命周期内的异常或者是异常Handler时还是有异常，这种情况只能用ErrorBoundary的错误css样式显示
2. 增加`ErrorLoggerExceptionHandler`组件，将 `ErrorLogger` 的异常弹窗显示抽到这个组件中，并且这个组件渲染成功后重置错误渲染次数