### PR TITLE
feat(ContextMenu): Add OnClickBefore callback event

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor
@@ -53,3 +53,31 @@
         </ContextMenu>
     </ContextMenuZone>
 </DemoBlock>
+
+<DemoBlock Title="@Localizer["ContextMenuCallbackTitle"]" Introduction="@Localizer["ContextMenuCallbackIntro"]" Name="Callback">
+    <ContextMenuZone>
+        <TreeView TItem="TreeFoo" Items="@TreeItems" />
+        <ContextMenu OnBeforeShowCallback="OnBeforeShowCallback">
+            <ContextMenuItem Text="拷贝" OnClick="OnCopy"></ContextMenuItem>
+            <ContextMenuItem Icon="fa-solid fa-paste" Text="粘贴" OnClick="OnPaste"></ContextMenuItem>
+        </ContextMenu>
+    </ContextMenuZone>
+    <ConsoleLogger @ref="_callbackLogger"></ConsoleLogger>
+</DemoBlock>
+
+<DemoBlock Title="@Localizer["ContextMenuDisabledTitle"]" Introduction="@Localizer["ContextMenuDisabledIntro"]" Name="DisabledCallback">
+    <ContextMenuZone>
+        <Table TItem="Foo" Items="@Items.Take(3)">
+            <TableColumns>
+                <TableColumn @bind-Field="@context.DateTime" Width="180" />
+                <TableColumn @bind-Field="@context.Name" />
+                <TableColumn @bind-Field="@context.Address" />
+            </TableColumns>
+        </Table>
+        <ContextMenu>
+            <ContextMenuItem Text="拷贝" OnClick="OnCopy" OnDisabledCallback="OnDisabledCallback"></ContextMenuItem>
+            <ContextMenuItem Icon="fa-solid fa-paste" Text="粘贴" OnDisabledCallback="OnDisabledCallback" OnClick="OnPaste"></ContextMenuItem>
+        </ContextMenu>
+    </ContextMenuZone>
+    <ConsoleLogger @ref="_disabledLogger"></ConsoleLogger>
+</DemoBlock>

--- a/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
@@ -7,6 +7,10 @@ public partial class ContextMenus
 {
     private List<TreeViewItem<TreeFoo>> TreeItems { get; set; } = TreeFoo.GetTreeItems();
 
+    private ConsoleLogger _callbackLogger = default!;
+
+    private ConsoleLogger _disabledLogger = default!;
+
     private static Task OnCopy(ContextMenuItem item, object value)
     {
         return Task.CompletedTask;
@@ -30,5 +34,25 @@ public partial class ContextMenus
     {
         Foo = Foo.Generate(LocalizerFoo);
         Items = Foo.GenerateFoo(LocalizerFoo);
+    }
+
+    private Task OnBeforeShowCallback(object? item)
+    {
+        if (item is TreeFoo foo)
+        {
+            _callbackLogger.Log($"{foo.Text} trigger");
+        }
+        return Task.CompletedTask;
+    }
+
+    private bool OnDisabledCallback(object? item)
+    {
+        var ret = false;
+        if (item is Foo foo)
+        {
+            ret = foo.Id == 1;
+            _disabledLogger.Log($"{foo.Name} trigger Disabled: {ret}");
+        }
+        return ret;
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
@@ -51,7 +51,7 @@ public partial class ContextMenus
         if (context is Foo foo)
         {
             ret = foo.Id == 1;
-            _disabledLogger.Log($"{foo.Name} trigger Disabled: {ret}");
+            _disabledLogger.Log($"{foo.Name} trigger {item.Text} Disabled: {ret}");
         }
         return ret;
     }

--- a/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
@@ -45,10 +45,10 @@ public partial class ContextMenus
         return Task.CompletedTask;
     }
 
-    private bool OnDisabledCallback(object? item)
+    private bool OnDisabledCallback(ContextMenuItem item, object? context)
     {
         var ret = false;
-        if (item is Foo foo)
+        if (context is Foo foo)
         {
             ret = foo.Id == 1;
             _disabledLogger.Log($"{foo.Name} trigger Disabled: {ret}");

--- a/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
@@ -7,9 +7,9 @@ public partial class ContextMenus
 {
     private List<TreeViewItem<TreeFoo>> TreeItems { get; set; } = TreeFoo.GetTreeItems();
 
-    private readonly ConsoleLogger _callbackLogger = default!;
+    private ConsoleLogger _callbackLogger = default!;
 
-    private readonly ConsoleLogger _disabledLogger = default!;
+    private ConsoleLogger _disabledLogger = default!;
 
     private static Task OnCopy(ContextMenuItem item, object value)
     {

--- a/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ContextMenus.razor.cs
@@ -7,9 +7,9 @@ public partial class ContextMenus
 {
     private List<TreeViewItem<TreeFoo>> TreeItems { get; set; } = TreeFoo.GetTreeItems();
 
-    private ConsoleLogger _callbackLogger = default!;
+    private readonly ConsoleLogger _callbackLogger = default!;
 
-    private ConsoleLogger _disabledLogger = default!;
+    private readonly ConsoleLogger _disabledLogger = default!;
 
     private static Task OnCopy(ContextMenuItem item, object value)
     {

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -6042,7 +6042,11 @@
     "ContextMenuTableTitle": "Table",
     "ContextMenuTableIntro": "Right click on the <code>Table</code> to pop up a context menu",
     "ContextMenuTreeTitle": "Tree",
-    "ContextMenuTreeIntro": "Right click on the <code>Tree</code> to pop up a context menu"
+    "ContextMenuTreeIntro": "Right click on the <code>Tree</code> to pop up a context menu",
+    "ContextMenuCallbackTitle": "ContextMenu Callback",
+    "ContextMenuCallbackIntro": "By setting the <code>ContextMenu</code> component parameter <code>OnBeforeShowCallback</code>, you can get the callback event before the right-click menu pops up, which can be used for data preparation",
+    "ContextMenuDisabledTitle": "OnDisabledCallback",
+    "ContextMenuDisabledIntro": "By setting the <code>ContextMenuItem</code> component parameter <code>OnDisabledCallback</code> callback method, you can set whether the current right-click option is disabled."
   },
   "BootstrapBlazor.Server.Components.Samples.DockViews.Index": {
     "DockViewTitle": "DockView",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -6042,7 +6042,11 @@
     "ContextMenuTableTitle": "Table 组件",
     "ContextMenuTableIntro": "点击 <code>Table</code> 组件行数据右键，弹出上下文关联菜单",
     "ContextMenuTreeTitle": "Tree 组件",
-    "ContextMenuTreeIntro": "点击 <code>Tree</code> 组件行数据右键，弹出上下文关联菜单"
+    "ContextMenuTreeIntro": "点击 <code>Tree</code> 组件行数据右键，弹出上下文关联菜单",
+    "ContextMenuCallbackTitle": "ContextMenu 回调",
+    "ContextMenuCallbackIntro": "通过设置 <code>ContextMenu</code> 组件参数 <code>OnBeforeShowCallback</code> 获得右键菜单弹出前回调事件，可用于数据准备工作",
+    "ContextMenuDisabledTitle": "禁止回调方法",
+    "ContextMenuDisabledIntro": "通过设置 <code>ContextMenuItem</code> 组件参数 <code>OnDisabledCallback</code> 回调方法可用于设置当前右键选项是否禁用逻辑"
   },
   "BootstrapBlazor.Server.Components.Samples.DockViews.Index": {
     "DockViewTitle": "DockView 可停靠视图",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.8.4-beta02</Version>
+    <Version>8.8.4-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor
@@ -6,4 +6,14 @@
     <CascadingValue Value="this" IsFixed="true">
         @ChildContent
     </CascadingValue>
+    <RenderTemplate>
+        @foreach (var item in _contextMenuItems)
+        {
+            <DynamicElement @key="item" TagName="div" class="@GetItemClassString(item)"
+                            TriggerClick="!GetItemTriggerClick(item)" OnClick="() => OnClickItem(item)">
+                <i class="@GetItemIconString(item)"></i>
+                <span>@item.Text</span>
+            </DynamicElement>
+        }
+    </RenderTemplate>
 </div>

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor
@@ -9,8 +9,9 @@
     <RenderTemplate>
         @foreach (var item in _contextMenuItems)
         {
-            <DynamicElement @key="item" TagName="div" class="@GetItemClassString(item)"
-                            TriggerClick="!GetItemTriggerClick(item)" OnClick="() => OnClickItem(item)">
+            var disabled = GetItemTriggerClick(item);
+            <DynamicElement @key="item" TagName="div" class="@GetItemClassString(disabled)"
+                            TriggerClick="!disabled" OnClick="() => OnClickItem(item)">
                 <i class="@GetItemIconString(item)"></i>
                 <span>@item.Text</span>
             </DynamicElement>

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor.cs
@@ -42,8 +42,8 @@ public partial class ContextMenu
 
     private List<ContextMenuItem> _contextMenuItems = [];
 
-    private string? GetItemClassString(ContextMenuItem item) => CssBuilder.Default("dropdown-item")
-        .AddClass("disabled", GetItemTriggerClick(item))
+    private static string? GetItemClassString(bool disabled) => CssBuilder.Default("dropdown-item")
+        .AddClass("disabled", disabled)
         .Build();
 
     private bool GetItemTriggerClick(ContextMenuItem item) => item.OnDisabledCallback?.Invoke(item, _contextItem) ?? item.Disabled;

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor.cs
@@ -34,6 +34,12 @@ public partial class ContextMenu
     [Parameter]
     public bool ShowShadow { get; set; } = true;
 
+    /// <summary>
+    /// 获得/设置 弹出前回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<object?, Task>? OnBeforeShowCallback { get; set; }
+
     private string ZoneId => ContextMenuZone.Id;
 
     /// <summary>
@@ -55,6 +61,10 @@ public partial class ContextMenu
     internal async Task Show(MouseEventArgs args, object? contextItem)
     {
         ContextItem = contextItem;
+        if (OnBeforeShowCallback != null)
+        {
+            await OnBeforeShowCallback(contextItem);
+        }
         await InvokeVoidAsync("show", Id, args);
     }
 

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenu.razor.cs
@@ -12,6 +12,18 @@ namespace BootstrapBlazor.Components;
 public partial class ContextMenu
 {
     /// <summary>
+    /// 获得/设置 是否显示阴影 默认 true
+    /// </summary>
+    [Parameter]
+    public bool ShowShadow { get; set; } = true;
+
+    /// <summary>
+    /// 获得/设置 弹出前回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<object?, Task>? OnBeforeShowCallback { get; set; }
+
+    /// <summary>
     /// 获得/设置 子组件
     /// </summary>
     [Parameter]
@@ -26,21 +38,23 @@ public partial class ContextMenu
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
-    private object? ContextItem { get; set; }
-
-    /// <summary>
-    /// 获得/设置 是否显示阴影 默认 true
-    /// </summary>
-    [Parameter]
-    public bool ShowShadow { get; set; } = true;
-
-    /// <summary>
-    /// 获得/设置 弹出前回调方法 默认 null
-    /// </summary>
-    [Parameter]
-    public Func<object?, Task>? OnBeforeShowCallback { get; set; }
-
     private string ZoneId => ContextMenuZone.Id;
+
+    private List<ContextMenuItem> _contextMenuItems = [];
+
+    private string? GetItemClassString(ContextMenuItem item) => CssBuilder.Default("dropdown-item")
+        .AddClass("disabled", GetItemTriggerClick(item))
+        .Build();
+
+    private bool GetItemTriggerClick(ContextMenuItem item) => item.OnDisabledCallback?.Invoke(item, _contextItem) ?? item.Disabled;
+
+    private static string? GetItemIconString(ContextMenuItem item) => CssBuilder.Default("cm-icon")
+        .AddClass(item.Icon, !string.IsNullOrEmpty(item.Icon))
+        .Build();
+
+    private MouseEventArgs? _mouseEventArgs;
+
+    private object? _contextItem;
 
     /// <summary>
     /// <inheritdoc/>
@@ -53,6 +67,22 @@ public partial class ContextMenu
     }
 
     /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="firstRender"></param>
+    /// <returns></returns>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (_mouseEventArgs != null)
+        {
+            await InvokeVoidAsync("show", Id, _mouseEventArgs);
+            _mouseEventArgs = null;
+        }
+    }
+
+    /// <summary>
     /// 弹出 ContextMenu
     /// </summary>
     /// <param name="args"></param>
@@ -60,17 +90,32 @@ public partial class ContextMenu
     /// <returns></returns>
     internal async Task Show(MouseEventArgs args, object? contextItem)
     {
-        ContextItem = contextItem;
+        _contextItem = contextItem;
+        _mouseEventArgs = args;
         if (OnBeforeShowCallback != null)
         {
             await OnBeforeShowCallback(contextItem);
         }
-        await InvokeVoidAsync("show", Id, args);
+        StateHasChanged();
+    }
+
+    private async Task OnClickItem(ContextMenuItem item)
+    {
+        if (item.OnClick != null)
+        {
+            await item.OnClick(item, _contextItem);
+        }
     }
 
     /// <summary>
-    /// 获取 ContextItem 值
+    /// 增加 ContextMenuItem 方法
     /// </summary>
-    /// <returns></returns>
-    internal object? GetContextItem() => ContextItem;
+    /// <param name="item"></param>
+    internal void AddItem(ContextMenuItem item) => _contextMenuItems.Add(item);
+
+    /// <summary>
+    /// 移除 ContextMenuItem 方法
+    /// </summary>
+    /// <param name="item"></param>
+    internal void RemoveItem(ContextMenuItem item) => _contextMenuItems.Remove(item);
 }

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.cs
@@ -7,7 +7,7 @@ namespace BootstrapBlazor.Components;
 /// <summary>
 /// ContextMenuItem 类
 /// </summary>
-public partial class ContextMenuItem
+public class ContextMenuItem : ComponentBase, IDisposable
 {
     /// <summary>
     /// 获得/设置 显示文本
@@ -31,7 +31,7 @@ public partial class ContextMenuItem
     /// 获得/设置 是否被禁用回调方法 默认 null 优先级高于 <see cref="Disabled"/>
     /// </summary>
     [Parameter]
-    public Func<object?, Task<bool>>? OnDisabledCallback { get; set; }
+    public Func<ContextMenuItem, object?, bool>? OnDisabledCallback { get; set; }
 
     /// <summary>
     /// 获得/设置 点击回调方法 默认 null
@@ -43,37 +43,40 @@ public partial class ContextMenuItem
     [NotNull]
     private ContextMenu? ContextMenu { get; set; }
 
-    private bool _disabled;
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
 
-    private string? ClassString => CssBuilder.Default("dropdown-item")
-        .AddClass("disabled", _disabled)
-        .AddClassFromAttributes(AdditionalAttributes)
-        .Build();
+        ContextMenu.AddItem(this);
+    }
 
-    private string? IconString => CssBuilder.Default("cm-icon")
-        .AddClass(Icon, !string.IsNullOrEmpty(Icon))
-        .Build();
+    private bool disposedValue;
+
+    /// <summary>
+    /// 释放资源方法
+    /// </summary>
+    /// <param name="disposing"></param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!disposedValue)
+        {
+            if (disposing)
+            {
+                ContextMenu.RemoveItem(this);
+            }
+            disposedValue = true;
+        }
+    }
 
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    /// <returns></returns>
-    protected override async Task OnParametersSetAsync()
+    public void Dispose()
     {
-        await base.OnParametersSetAsync();
-
-        _disabled = Disabled;
-        if (OnDisabledCallback != null)
-        {
-            _disabled = await OnDisabledCallback(ContextMenu.GetContextItem());
-        }
-    }
-
-    private async Task OnClickItem()
-    {
-        if (!Disabled && OnClick != null)
-        {
-            await OnClick(this, ContextMenu.GetContextItem());
-        }
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.razor
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.razor
@@ -1,7 +1,8 @@
 ﻿@namespace BootstrapBlazor.Components
 @inherits BootstrapComponentBase
 
-<div @attributes="AdditionalAttributes" class="@ClassString" @onclick="OnClickItem">
+<DynamicElement TagName="div" @attributes="AdditionalAttributes" class="@ClassString"
+    TriggerClick="!_disabled" OnClick="OnClickItem">
     <i class="@IconString"></i>
     <span>@Text</span>
-</div>
+</DynamicElement>

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.razor
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.razor
@@ -1,8 +1,0 @@
-﻿@namespace BootstrapBlazor.Components
-@inherits BootstrapComponentBase
-
-<DynamicElement TagName="div" @attributes="AdditionalAttributes" class="@ClassString"
-    TriggerClick="!_disabled" OnClick="OnClickItem">
-    <i class="@IconString"></i>
-    <span>@Text</span>
-</DynamicElement>

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.razor.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenuItem.razor.cs
@@ -22,10 +22,16 @@ public partial class ContextMenuItem
     public string? Icon { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否被禁用 默认 false
+    /// 获得/设置 是否被禁用 默认 false 优先级低于 <see cref="OnDisabledCallback"/>
     /// </summary>
     [Parameter]
     public bool Disabled { get; set; }
+
+    /// <summary>
+    /// 获得/设置 是否被禁用回调方法 默认 null 优先级高于 <see cref="Disabled"/>
+    /// </summary>
+    [Parameter]
+    public Func<object?, Task<bool>>? OnDisabledCallback { get; set; }
 
     /// <summary>
     /// 获得/设置 点击回调方法 默认 null
@@ -37,13 +43,31 @@ public partial class ContextMenuItem
     [NotNull]
     private ContextMenu? ContextMenu { get; set; }
 
+    private bool _disabled;
+
     private string? ClassString => CssBuilder.Default("dropdown-item")
+        .AddClass("disabled", _disabled)
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
     private string? IconString => CssBuilder.Default("cm-icon")
         .AddClass(Icon, !string.IsNullOrEmpty(Icon))
         .Build();
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override async Task OnParametersSetAsync()
+    {
+        await base.OnParametersSetAsync();
+
+        _disabled = Disabled;
+        if (OnDisabledCallback != null)
+        {
+            _disabled = await OnDisabledCallback(ContextMenu.GetContextItem());
+        }
+    }
 
     private async Task OnClickItem()
     {

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenuZone.razor.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenuZone.razor.cs
@@ -18,6 +18,12 @@ public partial class ContextMenuZone
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
+    /// 获得/设置 弹出前回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<object?, Task>? OnClickBefore { get; set; }
+
+    /// <summary>
     /// 获得/设置 上下文菜单组件集合
     /// </summary>
     private ContextMenu? ContextMenu { get; set; }
@@ -37,6 +43,10 @@ public partial class ContextMenuZone
         // 弹出关联菜单
         if (ContextMenu != null)
         {
+            if (OnClickBefore is not null)
+            {
+                await OnClickBefore(contextItem);
+            }
             await ContextMenu.Show(args, contextItem);
         }
     }

--- a/src/BootstrapBlazor/Components/ContextMenu/ContextMenuZone.razor.cs
+++ b/src/BootstrapBlazor/Components/ContextMenu/ContextMenuZone.razor.cs
@@ -18,12 +18,6 @@ public partial class ContextMenuZone
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// 获得/设置 弹出前回调方法 默认 null
-    /// </summary>
-    [Parameter]
-    public Func<object?, Task>? OnClickBefore { get; set; }
-
-    /// <summary>
     /// 获得/设置 上下文菜单组件集合
     /// </summary>
     private ContextMenu? ContextMenu { get; set; }
@@ -43,10 +37,6 @@ public partial class ContextMenuZone
         // 弹出关联菜单
         if (ContextMenu != null)
         {
-            if (OnClickBefore is not null)
-            {
-                await OnClickBefore(contextItem);
-            }
             await ContextMenu.Show(args, contextItem);
         }
     }

--- a/test/UnitTest/Components/ContextMenuTest.cs
+++ b/test/UnitTest/Components/ContextMenuTest.cs
@@ -17,6 +17,8 @@ public class ContextMenuTest : BootstrapBlazorTestBase
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var foo = Foo.Generate(localizer);
+        var clicked = false;
+
         var cut = Context.RenderComponent<ContextMenuZone>(pb =>
         {
             pb.AddChildContent<ContextMenuTrigger>(pb =>
@@ -41,6 +43,7 @@ public class ContextMenuTest : BootstrapBlazorTestBase
                     pb.Add(a => a.Disabled, true);
                     pb.Add(a => a.OnClick, (item, value) =>
                     {
+                        clicked = true;
                         return Task.CompletedTask;
                     });
                 });
@@ -100,6 +103,7 @@ public class ContextMenuTest : BootstrapBlazorTestBase
 
         await Task.Delay(500);
         row.TouchEnd();
+        Assert.True(clicked);
     }
 
     [Theory]

--- a/test/UnitTest/Components/ContextMenuTest.cs
+++ b/test/UnitTest/Components/ContextMenuTest.cs
@@ -13,12 +13,10 @@ namespace UnitTest.Components;
 public class ContextMenuTest : BootstrapBlazorTestBase
 {
     [Fact]
-    public async Task ContextMenu_Ok()
+    public void ContextMenu_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var foo = Foo.Generate(localizer);
-        var clicked = false;
-
         var cut = Context.RenderComponent<ContextMenuZone>(pb =>
         {
             pb.AddChildContent<ContextMenuTrigger>(pb =>
@@ -43,36 +41,25 @@ public class ContextMenuTest : BootstrapBlazorTestBase
                     pb.Add(a => a.Disabled, true);
                     pb.Add(a => a.OnClick, (item, value) =>
                     {
-                        clicked = true;
                         return Task.CompletedTask;
                     });
                 });
             });
         });
 
-        await cut.InvokeAsync(async () =>
-        {
-            var row = cut.Find(".context-trigger");
-            row.ContextMenu(0, 10, 10, 10, 10, 2, 2);
+        var row = cut.Find(".context-trigger");
+        row.ContextMenu(0, 10, 10, 10, 10, 2, 2);
 
-            var menu = cut.FindComponent<ContextMenu>();
-            menu.Contains("shadow");
-            var pi = typeof(ContextMenu).GetProperty("ContextItem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            Assert.NotNull(pi);
+        var menu = cut.FindComponent<ContextMenu>();
+        menu.Contains("shadow");
+        var pi = typeof(ContextMenu).GetField("_contextItem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(pi);
 
-            var v = pi.GetValue(menu.Instance);
-            Assert.NotNull(v);
+        var v = pi.GetValue(menu.Instance);
+        Assert.NotNull(v);
 
-            var item = menu.Find(".dropdown-item");
-            item.Click();
-            Assert.False(clicked);
-
-            // 测试 Touch 事件
-            TriggerTouchStart(row);
-
-            await Task.Delay(500);
-            row.TouchEnd();
-        });
+        var item = menu.Find(".dropdown-item");
+        Assert.DoesNotContain("blazor:onclick", item.OuterHtml);
     }
 
     [Theory]
@@ -114,29 +101,26 @@ public class ContextMenuTest : BootstrapBlazorTestBase
             });
         });
 
-        await cut.InvokeAsync(async () =>
-        {
-            var row = renderMode == TableRenderMode.CardView ? cut.Find(".table-row") : cut.Find("tbody tr");
-            row.ContextMenu(0, 10, 10, 10, 10, 2, 2);
+        var row = renderMode == TableRenderMode.CardView ? cut.Find(".table-row") : cut.Find("tbody tr");
+        row.ContextMenu(0, 10, 10, 10, 10, 2, 2);
 
-            var menu = cut.FindComponent<ContextMenu>();
-            var pi = typeof(ContextMenu).GetProperty("ContextItem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            Assert.NotNull(pi);
+        var menu = cut.FindComponent<ContextMenu>();
+        var pi = typeof(ContextMenu).GetField("_contextItem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(pi);
 
-            var v = pi.GetValue(menu.Instance);
-            Assert.NotNull(v);
+        var v = pi.GetValue(menu.Instance);
+        Assert.NotNull(v);
 
-            var item = menu.Find(".dropdown-item");
-            item.Click();
-            Assert.True(clicked);
+        var item = menu.Find(".dropdown-item");
+        item.Click();
+        Assert.True(clicked);
 
-            TriggerTouchStart(row);
-            TriggerTouchStart(row);
+        TriggerTouchStart(row);
+        TriggerTouchStart(row);
 
-            var options = Context.Services.GetRequiredService<IOptions<BootstrapBlazorOptions>>();
-            await Task.Delay(100 + options.Value.ContextMenuOptions.OnTouchDelay);
-            row.TouchEnd();
-        });
+        var options = Context.Services.GetRequiredService<IOptions<BootstrapBlazorOptions>>();
+        await Task.Delay(100 + options.Value.ContextMenuOptions.OnTouchDelay);
+        row.TouchEnd();
     }
 
     [Fact]
@@ -180,29 +164,26 @@ public class ContextMenuTest : BootstrapBlazorTestBase
             });
         });
 
-        await cut.InvokeAsync(async () =>
-        {
-            var row = cut.Find(".tree-content");
-            row.ContextMenu(0, 10, 10, 10, 10, 2, 2);
+        var row = cut.Find(".tree-content");
+        row.ContextMenu(0, 10, 10, 10, 10, 2, 2);
 
-            var menu = cut.FindComponent<ContextMenu>();
-            var pi = typeof(ContextMenu).GetProperty("ContextItem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-            Assert.NotNull(pi);
+        var menu = cut.FindComponent<ContextMenu>();
+        var pi = typeof(ContextMenu).GetField("_contextItem", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(pi);
 
-            var v = pi.GetValue(menu.Instance);
-            Assert.NotNull(v);
+        var v = pi.GetValue(menu.Instance);
+        Assert.NotNull(v);
 
-            var item = menu.Find(".dropdown-item");
-            item.Click();
-            Assert.True(clicked);
+        var item = menu.Find(".dropdown-item");
+        item.Click();
+        Assert.True(clicked);
 
-            TriggerTouchStart(row);
-            TriggerTouchStart(row);
+        TriggerTouchStart(row);
+        TriggerTouchStart(row);
 
-            var options = Context.Services.GetRequiredService<IOptions<BootstrapBlazorOptions>>();
-            await Task.Delay(100 + options.Value.ContextMenuOptions.OnTouchDelay);
-            row.TouchEnd();
-        });
+        var options = Context.Services.GetRequiredService<IOptions<BootstrapBlazorOptions>>();
+        await Task.Delay(100 + options.Value.ContextMenuOptions.OnTouchDelay);
+        row.TouchEnd();
     }
 
     private void TriggerTouchStart(IElement row)


### PR DESCRIPTION
## Add OnClickBefore callback event

<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the ASP.NET Core repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

<!-- Summary of the changes (Less than 80 chars) -->

### Description
I would like to propose a new feature for the `ContextMenu` component: an `OnClickBefore` callback event. This event should be triggered right before the context menu is displayed when the user right-clicks. It would allow developers to perform actions or checks before the menu is rendered to the user.

### Use Case
The `OnClickBefore` event would be extremely useful for dynamic context menu content, where menu items need to be determined based on the state of the application or specific conditions at the time of the right-click. For example, it could be used to enable or disable menu items, add new ones, or even cancel the display of the context menu altogether based on certain criteria.

### Proposed Signature
```csharp
[Parameter]
public Func<object?, Task>? OnClickBefore { get; set; }
```

close #4111
