### PR TITLE
Button add DisabledColor property

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Buttons.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Buttons.razor
@@ -100,6 +100,21 @@
             <Button Color="Color.Info" Text="@Localizer["ButtonAvailable"]" OnClickWithoutRender="@ClickButton2" class="ms-3"></Button>
         </div>
     </div>
+
+    <br />
+    <p><b>@Localizer["ButtonDisabledColorSubTitle"]</b></p>
+    <ul class="ul-demo mb-3">
+        <li>@((MarkupString)Localizer["ButtonDisabledColorTip"].Value)</li>
+    </ul>
+    <div class="row g-3">
+        <div class="col-12">
+            <Button DisabledColor="ButtonDisabledColor" Text="@Localizer["ButtonDisabled"]" OnClick="@ClickButton1" IsDisabled="@IsDisable"></Button>
+            <Button DisabledColor="ButtonDisabledColor" Color="Color.Danger" Text="@Localizer["ButtonDisabled"]" OnClick="@ClickButton1" IsDisabled="@IsDisable"></Button>
+            <Button Color="Color.Danger" DisabledColor="ButtonDisabledColor" Text="Outline" OnClick="@ClickButton1" IsDisabled="@IsDisable" IsOutline="true"></Button>
+            <Button Color="Color.Success" Text="@Localizer["ButtonAvailable"]" OnClick="@ClickButton2" class="ms-3"></Button>
+            <Button Color="Color.Dark" Text="@Localizer["ButtonDisabledColorChange"]" OnClick="@ClickButton3" class="ms-3"></Button>
+        </div>
+    </div>
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["Block6Title"]" Introduction="@Localizer["Block6Intro"]" Name="Color">

--- a/src/BootstrapBlazor.Server/Components/Samples/Buttons.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Buttons.razor.cs
@@ -14,6 +14,7 @@ public sealed partial class Buttons
     [NotNull]
     private ConsoleLogger? NormalLogger { get; set; }
 
+    private Color ButtonDisabledColor = Color.Secondary;
     /// <summary>
     ///
     /// </summary>
@@ -41,6 +42,12 @@ public sealed partial class Buttons
         return Task.CompletedTask;
     }
 
+    private void ClickButton3()
+    {
+        ButtonDisabledColor = ButtonDisabledColor == Color.None ? Color.Secondary : Color.None;
+
+        StateHasChanged();
+    }
     private string ButtonText { get; set; } = "";
 
     private Task ClickButtonShowText(string text)

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2302,7 +2302,10 @@
     "TooltipText": "Button",
     "TooltipTitle": "Tooltip",
     "TooltipIntro": "Set <code>TooltipText</code> <code>TooltipPlacement</code> <code>TooltipTrigger</code> shortcut button prompt bar information, position, and triggering method. For more functions, please use the <code>Tooltip</code> component to implement. In this example, the second button is in the <b>disabled</b> state, and the prompt bar is still available",
-    "TooltipDisabledText": "Disabled"
+    "TooltipDisabledText": "Disabled",
+    "ButtonDisabledColorSubTitle": "DisabledColor comparison",
+    "ButtonDisabledColorTip": "<code>DisabledColor</code> property will set disabled style",
+    "ButtonDisabledColorChange": "Click it change DisabledColor or none"
   },
   "BootstrapBlazor.Server.Components.Samples.PulseButtons": {
     "Block1Title": "Basic usage",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2302,7 +2302,10 @@
     "TooltipText": "按钮",
     "TooltipTitle": "按钮提示栏",
     "TooltipIntro": "通过设置 <code>TooltipText</code> <code>TooltipPlacement</code> <code>TooltipTrigger</code> 快捷设置按钮提示栏信息、位置、触发方式，更多功能请使用 <code>Tooltip</code> 组件实现，本例中第二个按钮是 <b>禁用</b> 状态，提示栏仍然可用",
-    "TooltipDisabledText": "禁用按钮"
+    "TooltipDisabledText": "禁用按钮",
+    "ButtonDisabledColorSubTitle": "DisabledColor 效果对比",
+    "ButtonDisabledColorTip": "<code>DisabledColor</code> 属性会影响禁用后的效果",
+    "ButtonDisabledColorChange": "点击切换DisabledColor属性"
   },
   "BootstrapBlazor.Server.Components.Samples.PulseButtons": {
     "Block1Title": "基础用法",

--- a/src/BootstrapBlazor/Components/Button/ButtonBase.cs
+++ b/src/BootstrapBlazor/Components/Button/ButtonBase.cs
@@ -17,8 +17,10 @@ public abstract class ButtonBase : TooltipWrapperBase
     /// </summary>
     /// <returns></returns>
     protected string? ClassName => CssBuilder.Default("btn")
-        .AddClass($"btn-outline-{Color.ToDescriptionString()}", IsOutline)
-        .AddClass($"btn-{Color.ToDescriptionString()}", !IsOutline && Color != Color.None)
+        .AddClass($"btn-outline-{Color.ToDescriptionString()}", IsOutline && (!IsDisabled || DisabledColor == Color.None))
+        .AddClass($"btn-outline-{DisabledColor.ToDescriptionString()}", IsOutline && IsDisabled && DisabledColor != Color.None)
+        .AddClass($"btn-{Color.ToDescriptionString()}", !IsOutline && Color != Color.None && (!IsDisabled || DisabledColor == Color.None))
+        .AddClass($"btn-{DisabledColor.ToDescriptionString()}", !IsOutline && IsDisabled && DisabledColor != Color.None)
         .AddClass($"btn-{Size.ToDescriptionString()}", Size != Size.None)
         .AddClass("btn-block", IsBlock)
         .AddClass("btn-round", ButtonStyle == ButtonStyle.Round)
@@ -75,6 +77,12 @@ public abstract class ButtonBase : TooltipWrapperBase
     /// </summary>
     [Parameter]
     public virtual Color Color { get; set; } = Color.Primary;
+
+    /// <summary>
+    /// 获得/设置 禁用之后的按钮颜色(默认None原始颜色)
+    /// </summary>
+    [Parameter]
+    public virtual Color DisabledColor { get; set; } = Color.None;
 
     /// <summary>
     /// 获得/设置 显示图标


### PR DESCRIPTION
button 添加一个属性DisabledColor, 默认为none,不影响原来button
当DisabledColor设置了颜色之后,  button 禁用后使用 DisabledColor颜色
添加原因: 现时button 禁用之后 和禁用之前颜色变化不明显
例如:
![5caeb919-919b-4b1e-9a29-817b9101a2d7](https://github.com/user-attachments/assets/2f852747-750a-447c-9ff3-cefc2c4ad642)
设置DisabledColor之后, 禁用按钮底色比原来明显
![QQ20240903-165653](https://github.com/user-attachments/assets/34de7686-3668-4856-935b-2012aa4cbe18)


