### PR TITLE
fix(PopConfirmButton): can't remove pop in table extension button

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.9.4-beta04</Version>
+    <Version>8.9.4-beta05</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/BootstrapBlazor/Components/Button/PopConfirmButton.razor.js
+++ b/src/BootstrapBlazor/Components/Button/PopConfirmButton.razor.js
@@ -49,7 +49,7 @@ export function init(id) {
             clearTimeout(handler);
             const hasConfirm = el.hasAttribute('data-bb-confirm');
             if (hasConfirm) {
-                if (confirm.popover.tip) {
+                if (confirm.popover._element) {
                     confirm.popover.dispose();
                 }
                 delete confirm.popover;


### PR DESCRIPTION
# can't remove pop in table extension button

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4335 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
