### PR TITLE
fix(ValidateForm): validate all validation from MetadataType

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/ValidateForms.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ValidateForms.razor.cs
@@ -163,12 +163,12 @@ public partial class ValidateForms
                     _validMemberNames.AddRange([nameof(model.Email), nameof(model.ConfirmEmail)]);
                 }
             }
-            return InvalidMemberNames();
+            return GetInvalidMemberNames();
         }
 
-        public List<string> ValidMemberNames() => _validMemberNames;
+        public List<string> GetValidMemberNames() => _validMemberNames;
 
-        public List<ValidationResult> InvalidMemberNames() => _invalidMemberNames;
+        public List<ValidationResult> GetInvalidMemberNames() => _invalidMemberNames;
     }
 
     class ComplexFoo : Foo

--- a/src/BootstrapBlazor.Server/Data/CustomValidateCollectionModel.cs
+++ b/src/BootstrapBlazor.Server/Data/CustomValidateCollectionModel.cs
@@ -61,11 +61,11 @@ public class CustomValidateCollectionModel : IValidateCollection
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    public List<string> ValidMemberNames() => _validMemberNames;
+    public List<string> GetValidMemberNames() => _validMemberNames;
 
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    public List<ValidationResult> InvalidMemberNames() => _invalidMemberNames;
+    public List<ValidationResult> GetInvalidMemberNames() => _invalidMemberNames;
 }

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.9.4-beta05</Version>
+    <Version>8.9.4-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">

--- a/src/BootstrapBlazor/Components/Validate/IValidateCollection.cs
+++ b/src/BootstrapBlazor/Components/Validate/IValidateCollection.cs
@@ -20,11 +20,11 @@ public interface IValidateCollection
     /// 返回合法成员集合
     /// </summary>
     /// <returns></returns>
-    List<string> ValidMemberNames();
+    List<string> GetValidMemberNames();
 
     /// <summary>
     /// 返回非法成员集合
     /// </summary>
     /// <returns></returns>
-    List<ValidationResult> InvalidMemberNames();
+    List<ValidationResult> GetInvalidMemberNames();
 }

--- a/src/BootstrapBlazor/Components/Validate/ValidateBase.cs
+++ b/src/BootstrapBlazor/Components/Validate/ValidateBase.cs
@@ -301,6 +301,7 @@ public abstract class ValidateBase<TValue> : DisplayBase<TValue>, IValidateCompo
 
         if (ValidateForm != null)
         {
+            // IValidateCollection 支持组件间联动验证
             var fieldName = FieldIdentifier?.FieldName;
             if (!string.IsNullOrEmpty(fieldName))
             {

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -516,10 +516,10 @@ public partial class ValidateForm
                 //验证后的错误字段名集合。
                 var newNames = messages.SelectMany(x => x.MemberNames).ToList();
                 //计算新增的验证错误字段名称集合。
-                var removeNames = newNames.Where(x => oldNames.Contains(x)).ToArray();
+                var removeNames = newNames.Where(x => oldNames.Contains(x)).ToList();
                 //从验证通过的字段集合内移除后续验证错误的字段名。
-                foreach (var name in removeNames)
-                    ValidMemberNames.Remove(name);
+                ValidMemberNames.RemoveAll(x => removeNames.Contains(x));
+
                 _tcs.TrySetResult(messages.Count == 0);
             }
 

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -262,6 +262,43 @@ public class ValidateFormTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task MetadataTypeIValidateCollection_Ok()
+    {
+        var model = new Dummy2() { Value1 = 0, Value2 = 0 };
+        var cut = Context.RenderComponent<ValidateForm>(pb =>
+        {
+            pb.Add(a => a.Model, model);
+            pb.AddChildContent<MockInput<int>>(pb =>
+            {
+                pb.Add(a => a.Value, model.Value1);
+                pb.Add(a => a.ValueExpression, Utility.GenerateValueExpression(model, "Value1", typeof(int)));
+            });
+            pb.AddChildContent<MockInput<int>>(pb =>
+            {
+                pb.Add(a => a.Value, model.Value2);
+                pb.Add(a => a.ValueExpression, Utility.GenerateValueExpression(model, "Value2", typeof(int)));
+            });
+        });
+        var form = cut.Find("form");
+        await cut.InvokeAsync(() => form.Submit());
+        var input = cut.FindComponent<MockInput<int>>();
+        var all = cut.FindComponents<MockInput<int>>();
+        var input2 = all[all.Count - 1];
+        Assert.Null(input.Instance.GetErrorMessage());
+        Assert.Equal("Value2 必须大于 0", input2.Instance.GetErrorMessage());
+
+        model.Value1 = 0;
+        model.Value2 = 2;
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.Model, model);
+        });
+        await cut.InvokeAsync(() => form.Submit());
+        Assert.Equal("Value1 必须大于 Value2", input.Instance.GetErrorMessage());
+        Assert.Equal("Value1 必须大于 Value2", input2.Instance.GetErrorMessage());
+    }
+
+    [Fact]
     public void Validate_Class_Ok()
     {
         var dummy = new Dummy();
@@ -698,6 +735,7 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         public string? File { get; set; }
 
         public string? Password1 { get; set; }
+
         public string? Password2 { get; set; }
     }
 
@@ -712,10 +750,65 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             if (validationContext.ObjectInstance is Dummy dy)
             {
                 if (!string.Equals(dy.Password1, dy.Password2, StringComparison.InvariantCultureIgnoreCase))
-                    result.Add(new ValidationResult("两次密码必须一致。",
-                        [nameof(Dummy.Password1), nameof(Dummy.Password2)]));
+                {
+                    result.Add(new ValidationResult("两次密码必须一致。", [nameof(Dummy.Password1), nameof(Dummy.Password2)]));
+                }
             }
             return result;
+        }
+    }
+
+    [MetadataType(typeof(Dummy2MetadataCollection))]
+    private class Dummy2
+    {
+        public int Value1 { get; set; }
+
+        public int Value2 { get; set; }
+    }
+
+    public class Dummy2MetadataCollection : IValidateCollection
+    {
+        [Required]
+        public int Value1 { get; set; }
+
+        [CustomValidation(typeof(Dummy2MetadataCollection), nameof(CustomValidate), ErrorMessage = "{0} 必须大于 0")]
+        [Required]
+        public int Value2 { get; set; }
+
+        private readonly List<string> _validMemberNames = [];
+
+        public List<string> GetValidMemberNames() => _validMemberNames;
+
+        private readonly List<ValidationResult> _invalidMemberNames = [];
+
+        public List<ValidationResult> GetInvalidMemberNames() => _invalidMemberNames;
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            _invalidMemberNames.Clear();
+            _validMemberNames.Clear();
+            if (validationContext.ObjectInstance is Dummy2 dummy)
+            {
+                if (dummy.Value1 < dummy.Value2)
+                {
+                    _invalidMemberNames.Add(new ValidationResult("Value1 必须大于 Value2", [nameof(Dummy2.Value1), nameof(Dummy2.Value2)]));
+                }
+                else
+                {
+                    _validMemberNames.AddRange([nameof(Dummy2.Value1), nameof(Dummy2.Value2)]);
+                }
+            }
+            return _invalidMemberNames;
+        }
+
+        public static ValidationResult? CustomValidate(object value, ValidationContext context)
+        {
+            ValidationResult? ret = null;
+            if (value is int v && v < 1)
+            {
+                ret = new ValidationResult("Value2 必须大于 0", ["Value2"]);
+            }
+            return ret;
         }
     }
 
@@ -803,13 +896,13 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         /// <inheritdoc/>
         /// </summary>
         /// <returns></returns>
-        public List<string> ValidMemberNames() => _validMemberNames;
+        public List<string> GetValidMemberNames() => _validMemberNames;
 
         /// <summary>
         /// <inheritdoc/>
         /// </summary>
         /// <returns></returns>
-        public List<ValidationResult> InvalidMemberNames() => _invalidMemberNames;
+        public List<ValidationResult> GetInvalidMemberNames() => _invalidMemberNames;
     }
 
     private class MockInput<TValue> : BootstrapInput<TValue>


### PR DESCRIPTION
# fix(ValidateForm):MetadataType 方式且继承 IValidateCollection 接口后对涉及属性单独验证在特定条件下不显示错误

## MetadataType 方式继承 IValidateCollection 接口验证后又对其中涉及的属性进行了单独验证，在特定情况下会忽略单独验证的错误提示。

fixes #4359

## Regression?

- [ ] Yes
- [x] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [x] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
