### PR TITLE
feat(BootstrapInputNumber): add OnBlurAsync parameter

### DIFF
--- a/src/BootstrapBlazor/Components/InputNumber/BootstrapInputNumber.razor.cs
+++ b/src/BootstrapBlazor/Components/InputNumber/BootstrapInputNumber.razor.cs
@@ -83,6 +83,12 @@ public partial class BootstrapInputNumber<TValue>
     [Parameter]
     public string? PlusIcon { get; set; }
 
+    /// <summary>
+    /// 获得/设置 失去焦点回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<TValue, Task>? OnBlurAsync { get; set; }
+
     [Inject]
     [NotNull]
     private IStringLocalizer<BootstrapInputNumber<TValue>>? Localizer { get; set; }
@@ -280,6 +286,11 @@ public partial class BootstrapInputNumber<TValue>
         {
             // set component value empty
             await InvokeVoidAsync("clear", Id);
+        }
+
+        if (OnBlurAsync != null)
+        {
+            await OnBlurAsync(Value);
         }
     }
 

--- a/test/UnitTest/Components/InputNumberTest.cs
+++ b/test/UnitTest/Components/InputNumberTest.cs
@@ -139,6 +139,23 @@ public class InputNumberTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task OnBlurAsync_Ok()
+    {
+        var blur = false;
+        var cut = Context.RenderComponent<BootstrapInputNumber<int>>(builder =>
+        {
+            builder.Add(a => a.OnBlurAsync, v =>
+            {
+                blur = true;
+                return Task.CompletedTask;
+            });
+        });
+        var input = cut.Find("input");
+        await cut.InvokeAsync(() => { input.Blur(); });
+        Assert.True(blur);
+    }
+
+    [Fact]
     public async Task ShowButton_Ok()
     {
         var inc = false;


### PR DESCRIPTION
# add OnBlurAsync parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4294 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an `OnBlurAsync` callback for the `BootstrapInputNumber` component, allowing users to trigger actions when the input loses focus.
  
- **Tests**
	- Added a new test to verify the functionality of the `OnBlurAsync` event in the `InputNumber` component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->