### PR TITLE
chore(JsonEnumConverter): remove core namespace

### DIFF
--- a/src/BootstrapBlazor/Components/ThemeProvider/ThemeValue.cs
+++ b/src/BootstrapBlazor/Components/ThemeProvider/ThemeValue.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using BootstrapBlazor.Core.Converter;
-
 namespace BootstrapBlazor.Components;
 
 /// <summary>

--- a/src/BootstrapBlazor/Converter/JsonDescriptionEnumConverter.cs
+++ b/src/BootstrapBlazor/Converter/JsonDescriptionEnumConverter.cs
@@ -6,7 +6,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace BootstrapBlazor.Core.Converter;
+namespace BootstrapBlazor.Components;
 
 /// <summary>
 /// 枚举类型转换器 序列化时把枚举类型的 [Description] 标签内容序列化成字符串 推荐使用 <see cref="JsonEnumConverter"/> 转换器

--- a/src/BootstrapBlazor/Converter/JsonEnumConverter.cs
+++ b/src/BootstrapBlazor/Converter/JsonEnumConverter.cs
@@ -6,7 +6,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
-namespace BootstrapBlazor.Core.Converter;
+namespace BootstrapBlazor.Components;
 
 /// <summary>
 /// JsonEnumConverter 枚举转换器

--- a/src/BootstrapBlazor/Options/ScrollIntoViewOptions.cs
+++ b/src/BootstrapBlazor/Options/ScrollIntoViewOptions.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using BootstrapBlazor.Core.Converter;
-
 namespace BootstrapBlazor.Components;
 
 /// <summary>

--- a/src/BootstrapBlazor/Services/Bluetooth/BluetoothServices.cs
+++ b/src/BootstrapBlazor/Services/Bluetooth/BluetoothServices.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using BootstrapBlazor.Core.Converter;
 using System.Text.Json.Serialization;
 
 namespace BootstrapBlazor.Components;

--- a/src/BootstrapBlazor/Services/Serial/SerialPortFlowControlType.cs
+++ b/src/BootstrapBlazor/Services/Serial/SerialPortFlowControlType.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using BootstrapBlazor.Core.Converter;
-
 namespace BootstrapBlazor.Components;
 
 /// <summary>

--- a/src/BootstrapBlazor/Services/Serial/SerialPortParityType.cs
+++ b/src/BootstrapBlazor/Services/Serial/SerialPortParityType.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using BootstrapBlazor.Core.Converter;
-
 namespace BootstrapBlazor.Components;
 
 /// <summary>

--- a/test/UnitTest/Converters/JsonDescriptionEnumConverterTest.cs
+++ b/test/UnitTest/Converters/JsonDescriptionEnumConverterTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using BootstrapBlazor.Core.Converter;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;


### PR DESCRIPTION
# remove core namespace

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4530 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Chores:
- Remove the usage of the 'BootstrapBlazor.Core.Converter' namespace across multiple files.