### PR TITLE
feat(Ribbon): update menu body height default value to 84.5

### DIFF
--- a/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
@@ -442,7 +442,7 @@ $bb-rate-transition: .3s;
 // Ribbon Tab
 $bb-ribbon-menu-height: 30px;
 $bb-ribbon-menu-margin-top: 5px;
-$bb-ribbon-menu-body-height: 82.5px;
+$bb-ribbon-menu-body-height: 84.5px;
 $bb-ribbon-menu-body-padding: .5rem;
 $bb-ribbon-menu-radius: var(--bs-border-radius);
 $bb-ribbon-menu-padding: .5rem;


### PR DESCRIPTION
# update menu body height default value to 84.5

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4534 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

New Features:
- Update the default value of the ribbon menu body height to 84.5px.