### PR TITLE
feat(Dialog): add ShowLiteralConfirmModal method

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Dialogs.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dialogs.razor
@@ -205,4 +205,8 @@ private async Task OnClick()
     </div>
 </DemoBlock>
 
+<DemoBlock Title="@Localizer["LiteralConfirmDialogTitle"]" Introduction="@Localizer["LiteralConfirmDialogIntro"]" Name="LiteralConfirmModal">
+    <Button Text="@Localizer["LiteralConfirmDialogButton"]" OnClick="@OnLiteralConfirmModalClick"></Button>
+</DemoBlock>
+
 <AttributeTable Items="@GetAttributes()" Title="@Localizer["Attribute"]" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Dialogs.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dialogs.razor.cs
@@ -303,6 +303,11 @@ public sealed partial class Dialogs
         }
     }
 
+    private async Task OnLiteralConfirmModalClick()
+    {
+        var result = await DialogService.ShowLiteralConfirmModal(Localizer["LiteralConfirmDialogModalContent"], Localizer["LiteralConfirmDialogModalTitle"]);
+    }
+
     /// <summary>
     /// 获得属性方法
     /// </summary>

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -902,7 +902,12 @@
     "ExportPdfDialogTitle": "Pop up window with export Pdf function",
     "ExportPdfDialogIntro": "Set <code>ShowExportPdfButtonInHeader</code> to display an export PDF button on the <code>Header</code>",
     "ExportPdfDialogTip": "More parameters can be set by setting <code>ExportPdfButtonOptions</code>",
-    "ExportPdfButton": "Export Pdf"
+    "ExportPdfButton": "Export Pdf",
+    "LiteralConfirmDialogTitle": "Literal Confirmation Modal",
+    "LiteralConfirmDialogIntro": "By passing in the string <code>content</code> , you can pop up a confirmation modal without creating a razor component.",
+    "LiteralConfirmDialogButton": "Popup Modal",
+    "LiteralConfirmDialogModalTitle": "Literal Confirmation Modal",
+    "LiteralConfirmDialogModalContent": "this is the prompt message."
   },
   "BootstrapBlazor.Server.Components.Samples.Dispatches": {
     "Title": "Dispatch message distribution",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -902,7 +902,12 @@
     "ExportPdfDialogTitle": "带导出 Pdf 功能的弹窗",
     "ExportPdfDialogIntro": "通过设置 <code>ShowExportPdfButtonInHeader</code> 使 <code>Header</code> 上显示一个导出 pdf 按钮",
     "ExportPdfDialogTip": "可通过设置 <code>ExportPdfButtonOptions</code> 对更多参数进行设置",
-    "ExportPdfButton": "导出 Pdf 弹窗"
+    "ExportPdfButton": "导出 Pdf 弹窗",
+    "LiteralConfirmDialogTitle": "文字确认模态框",
+    "LiteralConfirmDialogIntro": "通过传入字符串 <code>content</code> ，无需创建razor组件即可弹出确认模态框",
+    "LiteralConfirmDialogButton": "弹出模态框",
+    "LiteralConfirmDialogModalTitle": "文字确认模态框",
+    "LiteralConfirmDialogModalContent": "这是一个文字确认模态框，这是提示信息"
   },
   "BootstrapBlazor.Server.Components.Samples.Dispatches": {
     "Title": "Dispatch 消息分发",

--- a/test/UnitTest/Components/DialogTest.cs
+++ b/test/UnitTest/Components/DialogTest.cs
@@ -532,7 +532,43 @@ public class DialogTest : BootstrapBlazorTestBase
         }));
         await cut.InvokeAsync(() => modal.Instance.CloseCallback());
         #endregion
+
+        #region ShowLiteralConfirmModal
+        // 测试文本内容是否显示
+        _ = cut.InvokeAsync(() => dialog.ShowLiteralConfirmModal("test-content"));
+        cut.WaitForState(() => cut.Markup.Contains("test-content"));
+        closeButton = cut.Find(".btn-secondary");
+        await cut.InvokeAsync(() => closeButton.Click());
+        await cut.InvokeAsync(() => modal.Instance.CloseCallback());
+
+        // 测试标题是否显示
+        _ = cut.InvokeAsync(() => dialog.ShowLiteralConfirmModal("test-content","test-title"));
+        cut.WaitForState(() => cut.Markup.Contains("test-title"));
+        closeButton = cut.Find(".btn-secondary");
+        await cut.InvokeAsync(() => closeButton.Click());
+        await cut.InvokeAsync(() => modal.Instance.CloseCallback());
+
+        // 测试标题优先级
+        resultOption = new ResultDialogOption()
+        {
+            Title = "alter-title"
+        };
+        _ = cut.InvokeAsync(() => dialog.ShowLiteralConfirmModal("test-content", "test-title",option: resultOption));
+        cut.WaitForState(() => cut.Markup.Contains("alter-title"));
+        closeButton = cut.Find(".btn-secondary");
+        await cut.InvokeAsync(() => closeButton.Click());
+        await cut.InvokeAsync(() => modal.Instance.CloseCallback());
+
+        // 测试MarkupString是否正常显示，元素标签是否生效
+        _ = cut.InvokeAsync(() => dialog.ShowLiteralConfirmModal("<div>test-content</div>", isMarkUpString:true,elementType:"div"));
+        cut.WaitForState(() => cut.Markup.Contains("<div><div>test-content</div></div>"));
+        closeButton = cut.Find(".btn-secondary");
+        await cut.InvokeAsync(() => closeButton.Click());
+        await cut.InvokeAsync(() => modal.Instance.CloseCallback());
+        #endregion
     }
+
+
 
     private class MockValidateFormDialog : ComponentBase
     {


### PR DESCRIPTION
# add ShowLiteralConfirmModal method

为DialogService添加一个简易的弹出确认对话框的方法，仅需传入提示信息。

## Description

feat(Dialog): add ShowLiteralConfirmModal method

## Regression?

- [ ] Yes
- [√] No

## Risk

- [ ] High
- [ ] Medium
- [√] Low

## Verification

- [√] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [√] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [√] Doc is updated/provided or not needed
- [√] Demo is updated/provided or not needed
- [√] Merge the latest code from the main branch

## Summary by Sourcery

Add a new method ShowLiteralConfirmModal to DialogService for displaying a simple confirmation dialog with a string message, and update the documentation to reflect this new feature.

New Features:
- Introduce the ShowLiteralConfirmModal method in DialogService to display a simple confirmation dialog by passing a string message.

Documentation:
- Update user-facing documentation to include information about the new ShowLiteralConfirmModal method, including its usage and parameters.