### PR TITLE
doc(DemoBlock): add Height parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Components/DemoBlock.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/DemoBlock.razor
@@ -6,7 +6,7 @@
     <p>@(new MarkupString(Introduction))</p>
 
     <div class="card">
-        <div class="card-body">
+        <div class="card-body" style="@BodyStyleString">
             @ChildContent
         </div>
         @if (ShowCode)

--- a/src/BootstrapBlazor.Server/Components/Components/DemoBlock.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/DemoBlock.razor.cs
@@ -6,7 +6,7 @@
 namespace BootstrapBlazor.Server.Components.Components;
 
 /// <summary>
-/// 
+/// DemoBlock 组件
 /// </summary>
 public sealed partial class DemoBlock
 {
@@ -47,12 +47,22 @@ public sealed partial class DemoBlock
     [Parameter]
     public string? Name { get; set; }
 
+    /// <summary>
+    /// 获得/设置 CardBody 高度 默认 null
+    /// </summary>
+    [Parameter]
+    public string? Height { get; set; }
+
     [CascadingParameter(Name = "RazorFileName")]
     private string? CodeFile { get; set; }
 
     [Inject]
     [NotNull]
     private IStringLocalizer<DemoBlock>? Localizer { get; set; }
+
+    private string? BodyStyleString => CssBuilder.Default()
+        .AddClass($"height: {Height};", !string.IsNullOrEmpty(Height))
+        .Build();
 
     /// <summary>
     /// <inheritdoc/>


### PR DESCRIPTION
# add Height parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4557 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce a new Height parameter to the DemoBlock component, enabling users to set the CardBody height. Update the component's documentation to reflect this new feature.

New Features:
- Add a Height parameter to the DemoBlock component to allow customization of the CardBody height.

Documentation:
- Update the documentation to include the new Height parameter for the DemoBlock component.