### PR TITLE
feat(ColorPicker): add Swatches parameter

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -28,14 +28,14 @@
     <PackageReference Include="BootstrapBlazor.BaiduSpeech" Version="8.1.1" />
     <PackageReference Include="BootstrapBlazor.BaiduOcr" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.BarCode" Version="8.2.0" />
-    <PackageReference Include="BootstrapBlazor.BarcodeGenerator" Version="8.2.0" />
+    <PackageReference Include="BootstrapBlazor.BarcodeGenerator" Version="8.4.0" />
     <PackageReference Include="BootstrapBlazor.BootstrapIcon" Version="8.0.3" />
     <PackageReference Include="BootstrapBlazor.BootstrapIcon.Extensions" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.Chart" Version="8.4.0" />
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="8.3.0" />
-    <PackageReference Include="BootstrapBlazor.DockView" Version="8.3.0" />
+    <PackageReference Include="BootstrapBlazor.DockView" Version="8.4.0" />
     <PackageReference Include="BootstrapBlazor.DriverJs" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.ElementIcon" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.FileViewer" Version="8.3.0" />
@@ -44,7 +44,7 @@
     <PackageReference Include="BootstrapBlazor.Holiday" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.Html2Pdf" Version="8.3.0" />
     <PackageReference Include="BootstrapBlazor.IconPark" Version="8.2.0" />
-    <PackageReference Include="BootstrapBlazor.ImageCropper" Version="8.2.0" />
+    <PackageReference Include="BootstrapBlazor.ImageCropper" Version="8.3.0" />
     <PackageReference Include="BootstrapBlazor.Live2DDisplay" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.Markdown" Version="8.2.1" />
     <PackageReference Include="BootstrapBlazor.MaterialDesign" Version="8.1.0" />
@@ -55,7 +55,7 @@
     <PackageReference Include="BootstrapBlazor.MouseFollower" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.OnScreenKeyboard" Version="8.0.4" />
     <PackageReference Include="BootstrapBlazor.PdfReader" Version="8.0.4" />
-    <PackageReference Include="BootstrapBlazor.Player" Version="8.2.0" />
+    <PackageReference Include="BootstrapBlazor.Player" Version="8.3.0" />
     <PackageReference Include="BootstrapBlazor.SignaturePad" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.Sortable" Version="8.2.0" />
     <PackageReference Include="BootstrapBlazor.Splitting" Version="8.2.0" />
@@ -68,7 +68,7 @@
     <PackageReference Include="BootstrapBlazor.WebAPI" Version="8.0.5" />
     <PackageReference Include="BootstrapBlazor.WinBox" Version="8.2.0" />
     <PackageReference Include="Longbow.Logging" Version="8.1.0" />
-    <PackageReference Include="Longbow.Tasks" Version="8.1.0" />
+    <PackageReference Include="Longbow.Tasks" Version="8.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor.Server/Components/Samples/ColorPickers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ColorPickers.razor.cs
@@ -63,17 +63,41 @@ public partial class ColorPickers
     [
         new()
         {
-            Name = "OnValueChanged",
-            Description = Localizer["Event1"],
-            Type = "Func<string, Task>",
+            Name = nameof(ColorPicker.Template),
+            Description = Localizer["AttributeTemplate"],
+            Type = "RenderFragment<string>",
             ValueList = " — ",
             DefaultValue = " — "
         },
         new()
         {
-            Name = nameof(ColorPicker.Template),
-            Description = Localizer["EventTemplate"],
-            Type = "Func<string>",
+            Name = nameof(ColorPicker.Formatter),
+            Description = Localizer["AttributeFormatter"],
+            Type = "Func<string, Task<string>>",
+            ValueList = " — ",
+            DefaultValue = " — "
+        },
+        new()
+        {
+            Name = nameof(ColorPicker.IsSupportOpacity),
+            Description = Localizer["AttributeIsSupportOpacity"],
+            Type = "bool",
+            ValueList = "true|false",
+            DefaultValue = "false"
+        },
+        new()
+        {
+            Name = nameof(ColorPicker.Swatches),
+            Description = Localizer["AttributeSwatches"],
+            Type = "bool",
+            ValueList = "true|false",
+            DefaultValue = "false"
+        },
+        new()
+        {
+            Name = nameof(ColorPicker.OnValueChanged),
+            Description = Localizer["EventOnValueChanged"],
+            Type = "Func<string, Task>",
             ValueList = " — ",
             DefaultValue = " — "
         }

--- a/src/BootstrapBlazor.Server/Components/Samples/ColorPickers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ColorPickers.razor.cs
@@ -90,8 +90,8 @@ public partial class ColorPickers
             Name = nameof(ColorPicker.Swatches),
             Description = Localizer["AttributeSwatches"],
             Type = "bool",
-            ValueList = "true|false",
-            DefaultValue = "false"
+            ValueList = " — ",
+            DefaultValue = " — "
         },
         new()
         {

--- a/src/BootstrapBlazor.Server/Components/Samples/Dialogs.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dialogs.razor.cs
@@ -165,7 +165,7 @@ public sealed partial class Dialogs
 
     private async Task OnConfirmModalClick()
     {
-        var result = await DialogService.ShowModal(Localizer["ConfirmDialogModalContent"], Localizer["ConfirmDialogModalTitle"]);
+        var result = await DialogService.ShowModal(Localizer["ConfirmDialogModalTitle"], Localizer["ConfirmDialogModalContent"]);
 
         ModalDialogLogger.Log($"The return value of the popup window is: {result} no component provider");
     }

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2490,7 +2490,11 @@
     "ValidateFormIntro": "Built in <code>ValidateForm</code> to use",
     "IsSupportOpacityTitle": "Support Opacity",
     "IsSupportOpacityIntro": "Enable transparency support by setting <code>IsSupportOpacity=\"true\"</code>",
-    "Event1": "Color change callback delegate method"
+    "EventOnValueChanged": "Color change callback delegate method",
+    "AttributeTemplate": "The template for display",
+    "AttributeFormatter": "Display color value formatting callback method",
+    "AttributeIsSupportOpacity": "Whether to support transparency",
+    "AttributeAttributeSwatches": "Preset candidate colors"
   },
   "BootstrapBlazor.Server.Components.Samples.DateTimePickers": {
     "Title": "DatePicker",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2494,7 +2494,7 @@
     "AttributeTemplate": "The template for display",
     "AttributeFormatter": "Display color value formatting callback method",
     "AttributeIsSupportOpacity": "Whether to support transparency",
-    "AttributeAttributeSwatches": "Preset candidate colors"
+    "AttributeSwatches": "Preset candidate colors"
   },
   "BootstrapBlazor.Server.Components.Samples.DateTimePickers": {
     "Title": "DatePicker",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2494,7 +2494,7 @@
     "AttributeTemplate": "显示模板",
     "AttributeFormatter": "显示颜色值格式化回调方法",
     "AttributeIsSupportOpacity": "是否支持透明度",
-    "AttributeAttributeSwatches": "预设候选颜色"
+    "AttributeSwatches": "预设候选颜色"
   },
   "BootstrapBlazor.Server.Components.Samples.DateTimePickers": {
     "Title": "DatePicker 日期选择器",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2490,7 +2490,11 @@
     "ValidateFormIntro": "内置于 <code>ValidateForm</code> 中使用",
     "IsSupportOpacityTitle": "支持透明度",
     "IsSupportOpacityIntro": "通过设置 <code>IsSupportOpacity=\"true\"</code> 开启透明度支持",
-    "Event1": "颜色改变回调委托方法"
+    "EventOnValueChanged": "颜色改变回调委托方法",
+    "AttributeTemplate": "显示模板",
+    "AttributeFormatter": "显示颜色值格式化回调方法",
+    "AttributeIsSupportOpacity": "是否支持透明度",
+    "AttributeAttributeSwatches": "预设候选颜色"
   },
   "BootstrapBlazor.Server.Components.Samples.DateTimePickers": {
     "Title": "DatePicker 日期选择器",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.11.0</Version>
+    <Version>8.11.1-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/ColorPicker/ColorPicker.razor.js
+++ b/src/BootstrapBlazor/Components/ColorPicker/ColorPicker.razor.js
@@ -86,6 +86,9 @@ const getOptions = (el, options) => {
         options.default = options.value;
         delete options.value;
     }
+    if (options.swatches === null) {
+        delete options.swatches;
+    }
     const config = {
         el,
         theme: 'nano',

--- a/src/BootstrapBlazor/Directory.Build.props
+++ b/src/BootstrapBlazor/Directory.Build.props
@@ -64,7 +64,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="AspNetCore.SassCompiler" Version="1.79.5" Condition="'$(Configuration)'=='Debug' and '$(TargetFramework)' == 'net8.0'" />
+    <PackageReference Include="AspNetCore.SassCompiler" Version="1.80.4" Condition="'$(Configuration)'=='Debug' and '$(TargetFramework)' == 'net8.0'" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# add Swatches parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4561 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a 'Swatches' parameter to the ColorPicker component to enable selection from preset colors and enhance the component with opacity support. Update localization files to reflect these changes.

New Features:
- Introduce a 'Swatches' parameter to the ColorPicker component, allowing users to select from preset candidate colors.

Enhancements:
- Add support for opacity in the ColorPicker component with the 'IsSupportOpacity' parameter.

Documentation:
- Update English and Chinese localization files to include descriptions for new ColorPicker attributes.