### PR TITLE
fix(SelectTable): validate component shoud be skip validate in search panel

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>8.11.1-beta02</Version>
+    <Version>8.11.1-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -995,7 +995,7 @@
                     }
                     else
                     {
-                        <BootstrapInput class="table-toolbar-search" placeholder="@SearchPlaceholderText" @onkeyup="OnSearchKeyUp" @bind-Value="@SearchText">
+                        <BootstrapInput class="table-toolbar-search" placeholder="@SearchPlaceholderText" @onkeyup="OnSearchKeyUp" @bind-Value="@SearchText" SkipValidate="true">
                         </BootstrapInput>
                     }
                 }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -537,7 +537,7 @@ public static class Utility
         // 设置 SkipValidate 参数
         if (IsValidComponent(componentType))
         {
-            builder.AddAttribute(160, nameof(IEditorItem.SkipValidate), item.SkipValidate);
+            builder.AddAttribute(160, nameof(IEditorItem.SkipValidate), isSearch || item.SkipValidate);
         }
 
         builder.AddMultipleAttributes(170, CreateMultipleAttributes(fieldType, model, fieldName, item));

--- a/test/UnitTest/Components/DateTimePickerTest.cs
+++ b/test/UnitTest/Components/DateTimePickerTest.cs
@@ -929,7 +929,7 @@ public class DateTimePickerTest : BootstrapBlazorTestBase
             pb.Add(a => a.AutoClose, true);
         });
         await cut.InvokeAsync(() => button.Click());
-        Assert.Equal(val, DateTime.Today.AddMonths(-1));
+        Assert.Equal(val, DateTime.MinValue);
     }
 
     [Fact]


### PR DESCRIPTION
# validate component shoud be skip validate in search panel

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4577 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Ensure the 'SkipValidate' attribute is set to true for the search input in the SelectTable component to prevent validation in the search panel.