### PR TITLE
fix(AutoComplete): click event also trigger focus event

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -18,14 +18,14 @@ public partial class AutoComplete
     /// <summary>
     /// 获得/设置 当前下拉框是否显示
     /// </summary>
-    private bool IsShown { get; set; }
+    private bool _isShown;
 
     /// <summary>
     /// 获得 组件样式
     /// </summary>
     protected virtual string? ClassString => CssBuilder.Default("auto-complete")
         .AddClass("is-loading", IsLoading)
-        .AddClass("show", IsShown && !IsPopover)
+        .AddClass("show", _isShown && !IsPopover)
         .Build();
 
     /// <summary>
@@ -149,7 +149,7 @@ public partial class AutoComplete
     protected override async Task OnBlur()
     {
         CurrentSelectedItem = "";
-        IsShown = false;
+        _isShown = false;
 
         if (OnBlurAsync != null)
         {
@@ -185,7 +185,7 @@ public partial class AutoComplete
             else
             {
                 FilterItems = DisplayCount == null ? Items.ToList() : Items.Take(DisplayCount.Value).ToList();
-                IsShown = true;
+                _isShown = true;
 
                 if (IsPopover)
                 {
@@ -222,7 +222,7 @@ public partial class AutoComplete
             IsLoading = false;
         }
 
-        IsShown = true;
+        _isShown = true;
 
         var source = FilterItems;
         if (source.Count > 0)

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -186,6 +186,11 @@ public partial class AutoComplete
             {
                 FilterItems = DisplayCount == null ? Items.ToList() : Items.Take(DisplayCount.Value).ToList();
                 IsShown = true;
+
+                if (IsPopover)
+                {
+                    await InvokeVoidAsync("triggerFocus", Id);
+                }
             }
         }
     }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -68,6 +68,17 @@ export function composition(id) {
     }
 }
 
+export function triggerFocus(id) {
+    const ac = Data.get(id)
+    if (ac.popover) {
+        const handler = setTimeout(() => {
+            clearTimeout(handler);
+
+            ac.popover.show();
+        }, 200);
+    }
+}
+
 export function dispose(id) {
     const ac = Data.get(id)
     Data.remove(id)

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -14,9 +14,6 @@ export function init(id, invoke) {
 
     if (el.querySelector('[data-bs-toggle="bb.dropdown"]')) {
         ac.popover = Popover.init(el, { toggleClass: '[data-bs-toggle="bb.dropdown"]' });
-        EventHandler.on(input, 'focus', e => {
-            input.click();
-        });
     }
 
     // debounce

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -70,13 +70,7 @@ export function composition(id) {
 
 export function triggerFocus(id) {
     const ac = Data.get(id)
-    if (ac.popover) {
-        const handler = setTimeout(() => {
-            clearTimeout(handler);
-
-            ac.popover.show();
-        }, 200);
-    }
+    ac.popover?.show();
 }
 
 export function dispose(id) {


### PR DESCRIPTION
# click event also trigger focus event

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4572 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix the AutoComplete component to prevent the click event from triggering the focus event. Refactor the component to use a private field for dropdown visibility management and update the unit tests to handle focus events asynchronously.

Bug Fixes:
- Fix the issue where the click event also triggers the focus event in the AutoComplete component.

Enhancements:
- Refactor the AutoComplete component to use a private field '_isShown' instead of 'IsShown' for managing dropdown visibility.

Tests:
- Update the AutoComplete unit tests to use asynchronous methods for focus events and verify dropdown visibility.