### PR TITLE
feat(ModalDialog): support IsCenter when set IsDraggable to true

### DIFF
--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -17,6 +17,16 @@ export function init(id, invoke, shownCallback, closeCallback) {
     Data.set(id, modal)
 
     EventHandler.on(el, 'shown.bs.modal', () => {
+        const dialog = el.querySelector('.modal-dialog');
+        if (dialog.classList.contains('is-draggable-center')) {
+            const width = dialog.offsetWidth / 2;
+            const height = dialog.offsetHeight / 2;
+
+            dialog.style.setProperty("margin-left", `calc(50vw - ${width}px`);
+            dialog.style.setProperty("margin-top", `calc(50vh - ${height}px`);
+            dialog.classList.remove('is-draggable-center');
+        }
+
         invoke.invokeMethodAsync(shownCallback)
     })
     EventHandler.on(el, 'hidden.bs.modal', e => {

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -22,8 +22,8 @@ export function init(id, invoke, shownCallback, closeCallback) {
             const width = dialog.offsetWidth / 2;
             const height = dialog.offsetHeight / 2;
 
-            dialog.style.setProperty("margin-left", `calc(50vw - ${width}px`);
-            dialog.style.setProperty("margin-top", `calc(50vh - ${height}px`);
+            dialog.style.setProperty("margin-left", `calc(50vw - ${width}px)`);
+            dialog.style.setProperty("margin-top", `calc(50vh - ${height}px)`);
             dialog.classList.remove('is-draggable-center');
         }
 

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.scss
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.scss
@@ -1,5 +1,9 @@
-﻿.is-draggable .modal-header {
+.is-draggable .modal-header {
     cursor: pointer;
+}
+
+.is-draggable-center {
+    visibility: hidden;
 }
 
 .modal-header {

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -53,25 +53,25 @@ public partial class ModalDialog : IHandlerException
     public bool ShowResize { get; set; }
 
     /// <summary>
-    /// 获得/设置 弹窗大小
+    /// 获得/设置 弹窗大小 默认为 <see cref="Size.ExtraExtraLarge"/>
     /// </summary>
     [Parameter]
     public Size Size { get; set; } = Size.ExtraExtraLarge;
 
     /// <summary>
-    /// 获得/设置 弹窗大小
+    /// 获得/设置 弹窗大小 默认为 <see cref="FullScreenSize.None"/>
     /// </summary>
     [Parameter]
     public FullScreenSize FullScreenSize { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否垂直居中 默认为 true
+    /// 获得/设置 是否垂直居中 默认为 false
     /// </summary>
     [Parameter]
     public bool IsCentered { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否弹窗正文超长时滚动
+    /// 获得/设置 是否弹窗正文超长时滚动 默认为 false
     /// </summary>
     [Parameter]
     public bool IsScrolling { get; set; }
@@ -83,7 +83,7 @@ public partial class ModalDialog : IHandlerException
     public bool IsDraggable { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示最大化按钮
+    /// 获得/设置 是否显示最大化按钮 默认为 false
     /// </summary>
     [Parameter]
     public bool ShowMaximizeButton { get; set; }

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -65,10 +65,10 @@ public partial class ModalDialog : IHandlerException
     public FullScreenSize FullScreenSize { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否垂直居中 默认为 false
+    /// 获得/设置 是否垂直居中 默认为 true
     /// </summary>
     [Parameter]
-    public bool IsCentered { get; set; }
+    public bool IsCentered { get; set; } = true;
 
     /// <summary>
     /// 获得/设置 是否弹窗正文超长时滚动 默认为 false

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -24,6 +24,7 @@ public partial class ModalDialog : IHandlerException
         .AddClass("modal-dialog-scrollable", IsScrolling)
         .AddClass("modal-fullscreen", MaximizeStatus)
         .AddClass("is-draggable", IsDraggable)
+        .AddClass("is-draggable-center", IsCentered && IsDraggable)
         .AddClass("d-none", !IsShown)
         .AddClass(Class, !string.IsNullOrEmpty(Class))
         .Build();

--- a/test/UnitTest/Components/ModalDialogTest.cs
+++ b/test/UnitTest/Components/ModalDialogTest.cs
@@ -75,15 +75,15 @@ public class ModalDialogTest : BootstrapBlazorTestBase
             });
         });
         Assert.Contains("is-draggable", cut.Markup);
-        Assert.DoesNotContain("is-draggable-center", cut.Markup);
+        Assert.Contains("is-draggable-center", cut.Markup);
         Assert.Contains("test_class", cut.Markup);
 
         var dialog = cut.FindComponent<ModalDialog>();
         dialog.SetParametersAndRender(pb =>
         {
-            pb.Add(a => a.IsCentered, true);
+            pb.Add(a => a.IsCentered, false);
         });
-        Assert.Contains("is-draggable-center", cut.Markup);
+        Assert.DoesNotContain("is-draggable-center", cut.Markup);
     }
 
     [Fact]

--- a/test/UnitTest/Components/ModalDialogTest.cs
+++ b/test/UnitTest/Components/ModalDialogTest.cs
@@ -75,15 +75,15 @@ public class ModalDialogTest : BootstrapBlazorTestBase
             });
         });
         Assert.Contains("is-draggable", cut.Markup);
-        Assert.Contains("is-draggable-center", cut.Markup);
+        Assert.DoesNotContain("is-draggable-center", cut.Markup);
         Assert.Contains("test_class", cut.Markup);
 
         var dialog = cut.FindComponent<ModalDialog>();
         dialog.SetParametersAndRender(pb =>
         {
-            pb.Add(a => a.IsCentered, false);
+            pb.Add(a => a.IsCentered, true);
         });
-        Assert.DoesNotContain("is-draggable-center", cut.Markup);
+        Assert.Contains("is-draggable-center", cut.Markup);
     }
 
     [Fact]

--- a/test/UnitTest/Components/ModalDialogTest.cs
+++ b/test/UnitTest/Components/ModalDialogTest.cs
@@ -75,7 +75,15 @@ public class ModalDialogTest : BootstrapBlazorTestBase
             });
         });
         Assert.Contains("is-draggable", cut.Markup);
+        Assert.Contains("is-draggable-center", cut.Markup);
         Assert.Contains("test_class", cut.Markup);
+
+        var dialog = cut.FindComponent<ModalDialog>();
+        dialog.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.IsCentered, false);
+        });
+        Assert.DoesNotContain("is-draggable-center", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
# support IsCenter when set IsDraggable to true

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4571 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for centering modal dialogs when they are draggable and the IsCentered property is true. Update the default value of IsCentered to true and adjust unit tests to cover the new behavior.

New Features:
- Add support for centering draggable modal dialogs when both IsDraggable and IsCentered properties are set to true.

Enhancements:
- Set default value of IsCentered property to true for modal dialogs.

Tests:
- Update unit tests to verify the behavior of draggable and centered modal dialogs.