### PR TITLE
feat(Cascader): add OnBlurAsync parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Cascader/Cascader.razor
+++ b/src/BootstrapBlazor/Components/Cascader/Cascader.razor
@@ -4,10 +4,10 @@
 
 @if (IsShowLabel)
 {
-    <BootstrapLabel required="@Required" for="@Id" ShowLabelTooltip="ShowLabelTooltip" Value="@DisplayText" />
+    <BootstrapLabel required="@Required" for="@Id" ShowLabelTooltip="ShowLabelTooltip" Value="@DisplayText"></BootstrapLabel>
 }
 <div @attributes="AdditionalAttributes" id="@Id" class="@ClassString" tabindex="-1">
-    <input type="text" id="@InputId" readonly disabled="@Disabled" class="@InputClassName" data-bs-toggle="dropdown" placeholder="@PlaceHolder" value="@DisplayTextString" />
+    <input type="text" id="@InputId" readonly disabled="@Disabled" class="@InputClassName" data-bs-toggle="dropdown" placeholder="@PlaceHolder" value="@DisplayTextString" @onblur="OnBlur" />
     <span class="@AppendClassName"><i class="@Icon"></i></span>
     <div class="dropdown-menu shadow">
         <CascadingValue Value="SelectedItems">

--- a/src/BootstrapBlazor/Components/Cascader/Cascader.razor.cs
+++ b/src/BootstrapBlazor/Components/Cascader/Cascader.razor.cs
@@ -45,9 +45,7 @@ public partial class Cascader<TValue>
     /// </summary>
     [Parameter]
     [NotNull]
-#if NET6_0_OR_GREATER
     [EditorRequired]
-#endif
     public IEnumerable<CascaderItem>? Items { get; set; }
 
     /// <summary>
@@ -79,6 +77,12 @@ public partial class Cascader<TValue>
     /// </summary>
     [Parameter]
     public string? SubMenuIcon { get; set; }
+
+    /// <summary>
+    /// 获得/设置 失去焦点回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<TValue, Task>? OnBlurAsync { get; set; }
 
     [Inject]
     [NotNull]
@@ -112,6 +116,17 @@ public partial class Cascader<TValue>
         {
             _lastValue = CurrentValueAsString;
             SetDefaultValue(CurrentValueAsString);
+        }
+    }
+
+    /// <summary>
+    /// 失去焦点时回调方法
+    /// </summary>
+    private async Task OnBlur()
+    {
+        if (OnBlurAsync != null)
+        {
+            await OnBlurAsync(Value);
         }
     }
 

--- a/test/UnitTest/Components/CascaderTest.cs
+++ b/test/UnitTest/Components/CascaderTest.cs
@@ -218,6 +218,29 @@ public class CascaderTest : BootstrapBlazorTestBase
         Assert.Equal("Test1/Test11", cut.Instance.MockDisplayText);
     }
 
+    [Fact]
+    public async Task OnBlurAsync_Ok()
+    {
+        var value = "";
+        var items = new List<CascaderItem>()
+        {
+            new() { Text = "test1", Value = "1" }
+        };
+        var cut = Context.RenderComponent<Cascader<string>>(pb =>
+        {
+            pb.Add(a => a.Items, items);
+            pb.Add(a => a.Value, "1");
+            pb.Add(a => a.OnBlurAsync, v =>
+            {
+                value = v;
+                return Task.CompletedTask;
+            });
+        });
+        var input = cut.Find("input");
+        await cut.InvokeAsync(() => input.Blur());
+        Assert.Equal("1", value);
+    }
+
     class MockCascader : Cascader<string>
     {
         public string? MockDisplayText => DisplayTextString;


### PR DESCRIPTION
# add OnBlurAsync parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4598 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add the OnBlurAsync parameter to the Cascader component to support asynchronous operations on blur events and include a corresponding unit test to ensure its functionality.

New Features:
- Introduce the OnBlurAsync parameter to the Cascader component, allowing asynchronous operations to be triggered when the component loses focus.

Tests:
- Add a unit test to verify the functionality of the OnBlurAsync parameter in the Cascader component.