### PR TITLE
feat(Table): add DisableDelete/EditButtonCallback Parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Dockerfile
+++ b/src/BootstrapBlazor.Server/Dockerfile
@@ -1,11 +1,11 @@
 #Depending on the operating system of the host machines(s) that will build or run the containers, the image specified in the FROM statement may need to be changed.
 #For more information, please see https://aka.ms/containercompat
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
 EXPOSE 80
 
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
 WORKDIR /
 COPY . .
 

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0-rc.2.11.2.1</Version>
+    <Version>9.0.0-rc.2.11.3.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -724,6 +724,18 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     [NotNull]
     public string? AlignRightTooltipText { get; set; }
 
+    /// <summary>
+    /// 获得/设置 删除按钮是否禁用回调方法
+    /// </summary>
+    [Parameter]
+    public Func<List<TItem>, bool>? DisableDeleteButtonCallback { get; set; }
+
+    /// <summary>
+    /// 获得/设置 编辑按钮是否禁用回调方法
+    /// </summary>
+    [Parameter]
+    public Func<List<TItem>, bool>? DisableEditButtonCallback { get; set; }
+
     [CascadingParameter]
     private ContextMenuZone? ContextMenuZone { get; set; }
 
@@ -1461,13 +1473,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     /// 返回 true 时按钮禁用
     /// </summary>
     /// <returns></returns>
-    private bool GetEditButtonStatus() => ShowAddForm || AddInCell || SelectedRows.Count != 1;
+    private bool GetEditButtonStatus() => ShowAddForm || AddInCell || (DisableEditButtonCallback?.Invoke(SelectedRows) ?? SelectedRows.Count != 1);
 
     /// <summary>
     /// 返回 true 时按钮禁用
     /// </summary>
     /// <returns></returns>
-    private bool GetDeleteButtonStatus() => ShowAddForm || AddInCell || SelectedRows.Count == 0;
+    private bool GetDeleteButtonStatus() => ShowAddForm || AddInCell || (DisableDeleteButtonCallback?.Invoke(SelectedRows) ?? SelectedRows.Count == 0);
 
     private async Task InvokeItemsChanged()
     {

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6302,7 +6302,46 @@ public class TableTest : BootstrapBlazorTestBase
         {
             pb.Add(a => a.ShowEditButton, false);
         });
-        cut.WaitForAssertion(() => table.DoesNotContain("fa-regular fa-pen-to-square"));
+        table.DoesNotContain("fa-regular fa-pen-to-square");
+    }
+
+    [Fact]
+    public void DisableEditButtonCallback_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer, 2);
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.Items, items);
+                pb.Add(a => a.ShowToolbar, true);
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+                });
+                pb.Add(a => a.SelectedRows, [items[0]]);
+            });
+        });
+
+        var buttons = cut.FindComponents<Button>();
+        var editButton = buttons.First(i => i.Instance.Text == "编辑");
+        Assert.False(editButton.Instance.IsDisabled);
+
+        // 即使选中行，编辑按钮仍然被禁用
+        var table = cut.FindComponent<Table<Foo>>();
+        table.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.DisableEditButtonCallback, items =>
+            {
+                return true;
+            });
+        });
+        Assert.True(editButton.Instance.IsDisabled);
     }
 
     [Fact]
@@ -6335,6 +6374,44 @@ public class TableTest : BootstrapBlazorTestBase
             pb.Add(a => a.ShowDeleteButton, false);
         });
         cut.WaitForAssertion(() => cut.DoesNotContain("fa-solid fa-xmark"));
+    }
+
+    [Fact]
+    public void DisableDeleteButtonCallback_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer, 2);
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.Items, items);
+                pb.Add(a => a.ShowToolbar, true);
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+                });
+                pb.Add(a => a.SelectedRows, [items[0]]);
+            });
+        });
+
+        var deleteButton = cut.FindComponent<TableToolbarPopConfirmButton<Foo>>();
+        Assert.False(deleteButton.Instance.IsDisabled);
+
+        // 即使选中行，编辑按钮仍然被禁用
+        var table = cut.FindComponent<Table<Foo>>();
+        table.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.DisableDeleteButtonCallback, items =>
+            {
+                return true;
+            });
+        });
+        Assert.True(deleteButton.Instance.IsDisabled);
     }
 
     [Fact]


### PR DESCRIPTION
# add DisableDelete/EditButtonCallback Parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4602 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add new parameters to the Table component to allow conditional disabling of delete and edit buttons, update the Dockerfile to use .NET 9.0, and include tests for the new functionality.

New Features:
- Introduce DisableDeleteButtonCallback and DisableEditButtonCallback parameters to conditionally disable delete and edit buttons in the Table component.

Enhancements:
- Update the logic for determining the disabled status of edit and delete buttons to incorporate the new callback parameters.

Build:
- Upgrade Dockerfile base and build images from .NET 8.0 to .NET 9.0.

Tests:
- Add unit tests to verify the functionality of the DisableDeleteButtonCallback and DisableEditButtonCallback parameters.