### PR TITLE
feat(Table): Table add button to add disabled callback

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0-rc.2.11.3.0</Version>
+    <Version>9.0.0-rc.2.11.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -48,7 +48,7 @@
                     {
                         @if (ShowAddButton)
                         {
-                            <TableToolbarButton TItem="TItem" Color="Color.Success" OnClick="AddAsync" Icon="@AddButtonIcon" Text="@AddButtonText" />
+                            <TableToolbarButton TItem="TItem" Color="Color.Success" OnClick="AddAsync" Icon="@AddButtonIcon" Text="@AddButtonText" IsDisabled="GetAddButtonStatus()" />
                         }
                         @if (!IsExcel && ShowEditButton)
                         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -725,13 +725,19 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     public string? AlignRightTooltipText { get; set; }
 
     /// <summary>
-    /// 获得/设置 删除按钮是否禁用回调方法
+    /// 获得/设置 新建按钮是否禁用回调方法 默认 null 未设置
+    /// </summary>
+    [Parameter]
+    public Func<List<TItem>, bool>? DisableAddButtonCallback { get; set; }
+
+    /// <summary>
+    /// 获得/设置 删除按钮是否禁用回调方法 默认 null 未设置
     /// </summary>
     [Parameter]
     public Func<List<TItem>, bool>? DisableDeleteButtonCallback { get; set; }
 
     /// <summary>
-    /// 获得/设置 编辑按钮是否禁用回调方法
+    /// 获得/设置 编辑按钮是否禁用回调方法 默认 null 未设置
     /// </summary>
     [Parameter]
     public Func<List<TItem>, bool>? DisableEditButtonCallback { get; set; }
@@ -1468,6 +1474,8 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
         await QueryData();
     }
+
+    private bool GetAddButtonStatus() => DisableAddButtonCallback?.Invoke(SelectedRows) ?? false;
 
     /// <summary>
     /// 返回 true 时按钮禁用

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6345,6 +6345,45 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void DisableAddButtonCallback_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer, 2);
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.Items, items);
+                pb.Add(a => a.ShowToolbar, true);
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+                });
+                pb.Add(a => a.SelectedRows, [items[0]]);
+            });
+        });
+
+        var buttons = cut.FindComponents<Button>();
+        var editButton = buttons.First(i => i.Instance.Text == "新建");
+        Assert.False(editButton.Instance.IsDisabled);
+
+        // 新建按钮被禁用
+        var table = cut.FindComponent<Table<Foo>>();
+        table.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.DisableAddButtonCallback, items =>
+            {
+                return true;
+            });
+        });
+        Assert.True(editButton.Instance.IsDisabled);
+    }
+
+    [Fact]
     public void ShowDeleteButton_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();


### PR DESCRIPTION
# Table add button to add disabled callback

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4604 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a callback function to the Table component to allow disabling the 'Add' button based on custom logic, and include a unit test to ensure its correct functionality.

New Features:
- Introduce a callback function to disable the 'Add' button in the Table component.

Tests:
- Add a unit test to verify the functionality of the 'DisableAddButtonCallback' in the Table component.