### PR TITLE
feat(Checkbox): use client click instead of server event

### DIFF
--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor
@@ -20,7 +20,7 @@ else
 @code {
     RenderFragment RenderCheckbox =>
     @<div @attributes="AdditionalAttributes" class="@ClassString">
-        <input class="@InputClassString" type="checkbox" id="@Id" disabled="@Disabled" checked="@CheckedString" data-bb-trigger-before="@TriggerBeforeValueString" />
+        <input class="@InputClassString" type="checkbox" id="@Id" disabled="@Disabled" checked="@CheckedString" data-bb-trigger-before="@TriggerBeforeValueString" data-bb-stop-propagation="@StopPropagationString" />
         @if (IsShowAfterLabel)
         {
             @RenderLabel

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor
@@ -20,7 +20,7 @@ else
 @code {
     RenderFragment RenderCheckbox =>
     @<div @attributes="AdditionalAttributes" class="@ClassString">
-        <DynamicElement TagName="input" class="@InputClassString" type="checkbox" id="@Id" disabled="@Disabled" checked="@CheckedString" data-bb-trigger-before="@TriggerBeforeValueString" TriggerClick="TriggerClick" OnClick="OnToggleClick" StopPropagation="StopPropagation" />
+        <input class="@InputClassString" type="checkbox" id="@Id" disabled="@Disabled" checked="@CheckedString" data-bb-trigger-before="@TriggerBeforeValueString" />
         @if (IsShowAfterLabel)
         {
             @RenderLabel

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
@@ -100,6 +100,8 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
     [Parameter]
     public bool StopPropagation { get; set; }
 
+    private string? StopPropagationString => StopPropagation ? "true" : null;
+
     private string? TriggerBeforeValueString => OnBeforeStateChanged == null ? null : "true";
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
@@ -164,6 +164,8 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
         SyncStateCallback = nameof(SyncStateCallback)
     });
 
+    private CheckboxState NextState => State == CheckboxState.Checked ? CheckboxState.UnChecked : CheckboxState.Checked;
+
     /// <summary>
     /// 触发 OnBeforeStateChanged 回调方法 由 JavaScript 调用
     /// </summary>
@@ -172,8 +174,7 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
     {
         if (OnBeforeStateChanged != null)
         {
-            var state = State == CheckboxState.Checked ? CheckboxState.UnChecked : CheckboxState.Checked;
-            var ret = await OnBeforeStateChanged(state);
+            var ret = await OnBeforeStateChanged(NextState);
             if (ret)
             {
                 await TriggerClick();
@@ -200,7 +201,7 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
     [JSInvokable]
     public async ValueTask TriggerClick()
     {
-        var render = await InternalStateChanged(State == CheckboxState.Checked ? CheckboxState.UnChecked : CheckboxState.Checked);
+        var render = await InternalStateChanged(NextState);
         if (render)
         {
             StateHasChanged();

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
@@ -157,13 +157,18 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new { Callback = nameof(TriggerOnBeforeStateChanged) });
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new
+    {
+        TriggerOnBeforeStateChanged = nameof(TriggerOnBeforeStateChanged),
+        TriggerClick = nameof(TriggerClick),
+        SyncStateCallback = nameof(SyncStateCallback)
+    });
 
     /// <summary>
     /// 触发 OnBeforeStateChanged 回调方法 由 JavaScript 调用
     /// </summary>
     [JSInvokable]
-    public async Task TriggerOnBeforeStateChanged()
+    public async ValueTask TriggerOnBeforeStateChanged()
     {
         if (OnBeforeStateChanged != null)
         {
@@ -171,31 +176,36 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
             var ret = await OnBeforeStateChanged(state);
             if (ret)
             {
-                var render = await InternalStateChanged(state);
-                if (render)
-                {
-                    StateHasChanged();
-                }
+                await TriggerClick();
             }
         }
     }
 
     /// <summary>
-    /// 点击选择框方法
+    /// 同步 <see cref="State"/> 值方法 由 JavaScript 调用
     /// </summary>
-    private async Task OnToggleClick()
+    /// <param name="state"></param>
+    /// <returns></returns>
+    [JSInvokable]
+    public ValueTask SyncStateCallback(CheckboxState state)
     {
-        if (!IsDisabled)
-        {
-            var render = await InternalStateChanged(State == CheckboxState.Checked ? CheckboxState.UnChecked : CheckboxState.Checked);
-            if (render)
-            {
-                StateHasChanged();
-            }
-        }
+        State = state;
+        return ValueTask.CompletedTask;
     }
 
-    private bool TriggerClick => !IsDisabled && OnBeforeStateChanged == null;
+    /// <summary>
+    /// 触发 Click 方法 由 JavaScript 调用
+    /// </summary>
+    /// <returns></returns>
+    [JSInvokable]
+    public async ValueTask TriggerClick()
+    {
+        var render = await InternalStateChanged(State == CheckboxState.Checked ? CheckboxState.UnChecked : CheckboxState.Checked);
+        if (render)
+        {
+            StateHasChanged();
+        }
+    }
 
     /// <summary>
     /// 此变量为了提高性能，避免循环更新

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
@@ -17,6 +17,13 @@ export function init(id, invoke, options) {
             el.removeAttribute('data-bb-state');
             await invoke.invokeMethodAsync(options.syncStateCallback, parseInt(state));
 
+            if (state === "1") {
+                el.parentElement.classList.remove('is-checked');
+            }
+            else {
+                el.parentElement.classList.add('is-checked');
+            }
+
             if (trigger !== "true") {
                 return;
             }

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
@@ -8,12 +8,27 @@ export function init(id, invoke, options) {
     }
 
     EventHandler.on(el, 'click', async e => {
-        e.preventDefault();
+        e.stopPropagation();
 
+        const state = el.getAttribute("data-bb-state");
         const trigger = el.getAttribute("data-bb-trigger-before");
-        if (trigger === 'true') {
-            await invoke.invokeMethodAsync(options.callback);
+
+        if (state) {
+            el.removeAttribute('data-bb-state');
+            invoke.invokeMethodAsync(options.syncStateCallback, parseInt(state));
+
+            if (trigger !== "true") {
+                return;
+            }
         }
+
+        if (trigger === 'true') {
+            e.preventDefault();
+            await invoke.invokeMethodAsync(options.triggerOnBeforeStateChanged);
+            return;
+        }
+
+        await invoke.invokeMethodAsync(options.triggerClick);
     });
 }
 

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
@@ -17,13 +17,6 @@ export function init(id, invoke, options) {
             el.removeAttribute('data-bb-state');
             await invoke.invokeMethodAsync(options.syncStateCallback, parseInt(state));
 
-            if (state === "1") {
-                el.parentElement.classList.add("is-checked");
-            }
-            else {
-                el.parentElement.classList.remove("is-checked");
-            }
-
             if (trigger !== "true") {
                 return;
             }

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
@@ -15,7 +15,14 @@ export function init(id, invoke, options) {
 
         if (state) {
             el.removeAttribute('data-bb-state');
-            invoke.invokeMethodAsync(options.syncStateCallback, parseInt(state));
+            await invoke.invokeMethodAsync(options.syncStateCallback, parseInt(state));
+
+            if (state === "1") {
+                el.parentElement.classList.add("is-checked");
+            }
+            else {
+                el.parentElement.classList.remove("is-checked");
+            }
 
             if (trigger !== "true") {
                 return;

--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.js
@@ -8,7 +8,10 @@ export function init(id, invoke, options) {
     }
 
     EventHandler.on(el, 'click', async e => {
-        e.stopPropagation();
+        const stopPropagation = el.getAttribute("data-bb-stop-propagation");
+        if (stopPropagation === "true") {
+            e.stopPropagation();
+        }
 
         const state = el.getAttribute("data-bb-state");
         const trigger = el.getAttribute("data-bb-trigger-before");

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -241,7 +241,7 @@
                                         <label>@CheckboxDisplayText</label>
                                         @if (GetShowRowCheckbox(item))
                                         {
-                                            <Checkbox TValue="TItem" Value="@item" State="@RowCheckState(item)" OnStateChanged="OnCheck" @onclick:stopPropagation></Checkbox>
+                                            <Checkbox TValue="TItem" Value="@item" State="@RowCheckState(item)" OnStateChanged="OnCheck" StopPropagation="true"></Checkbox>
                                         }
                                     </div>
                                 }

--- a/test/UnitTest/Components/CheckboxListTest.cs
+++ b/test/UnitTest/Components/CheckboxListTest.cs
@@ -208,7 +208,7 @@ public class CheckboxListTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void StringValue_Ok()
+    public async Task StringValue_Ok()
     {
         var cut = Context.RenderComponent<CheckboxList<string>>(builder =>
         {
@@ -236,13 +236,13 @@ public class CheckboxListTest : BootstrapBlazorTestBase
             });
         });
         // 字符串值选中事件
-        var item = cut.Find(".form-check-input");
-        item.Click();
+        var item = cut.FindComponent<Checkbox<bool>>();
+        await cut.InvokeAsync(item.Instance.TriggerClick);
         Assert.True(selected);
     }
 
     [Fact]
-    public void OnSelectedChanged_Ok()
+    public async Task OnSelectedChanged_Ok()
     {
         var selected = false;
         var foo = Foo.Generate(Localizer);
@@ -257,8 +257,8 @@ public class CheckboxListTest : BootstrapBlazorTestBase
             });
         });
 
-        var item = cut.Find(".form-check-input");
-        item.Click();
+        var item = cut.FindComponent<Checkbox<bool>>();
+        await cut.InvokeAsync(item.Instance.TriggerClick);
         Assert.True(selected);
     }
 
@@ -274,7 +274,7 @@ public class CheckboxListTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void IntValue_Ok()
+    public async Task IntValue_Ok()
     {
         var ret = new List<int>();
         var selectedIntValues = new List<int> { 1, 2 };
@@ -292,8 +292,8 @@ public class CheckboxListTest : BootstrapBlazorTestBase
                 return Task.CompletedTask;
             });
         });
-        var item = cut.Find(".form-check-input");
-        item.Click();
+        var item = cut.FindComponent<Checkbox<bool>>();
+        await cut.InvokeAsync(item.Instance.TriggerClick);
 
         // 选中 2 
         Assert.Equal(2, ret.First());

--- a/test/UnitTest/Components/CheckboxListTest.cs
+++ b/test/UnitTest/Components/CheckboxListTest.cs
@@ -28,6 +28,16 @@ public class CheckboxListTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void StopPropagation_Ok()
+    {
+        var cut = Context.RenderComponent<Checkbox<string>>(builder =>
+        {
+            builder.Add(a => a.StopPropagation, true);
+        });
+        Assert.Contains("data-bb-stop-propagation=\"true\"", cut.Markup);
+    }
+
+    [Fact]
     public async Task SyncStateCallback_Ok()
     {
         var cut = Context.RenderComponent<Checkbox<bool>>(builder =>

--- a/test/UnitTest/Components/CheckboxListTest.cs
+++ b/test/UnitTest/Components/CheckboxListTest.cs
@@ -28,6 +28,19 @@ public class CheckboxListTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task SyncStateCallback_Ok()
+    {
+        var cut = Context.RenderComponent<Checkbox<bool>>(builder =>
+        {
+            builder.Add(a => a.State, CheckboxState.UnChecked);
+        });
+        Assert.Equal(CheckboxState.UnChecked, cut.Instance.State);
+
+        await cut.InvokeAsync(() => cut.Instance.SyncStateCallback(CheckboxState.Checked));
+        Assert.Equal(CheckboxState.Checked, cut.Instance.State);
+    }
+
+    [Fact]
     public void ShowAfterLabel_Ok()
     {
         var cut = Context.RenderComponent<Checkbox<string>>(builder =>

--- a/test/UnitTest/Components/ConsoleTest.cs
+++ b/test/UnitTest/Components/ConsoleTest.cs
@@ -195,7 +195,7 @@ public class ConsoleTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void ClickAutoScroll_OK()
+    public async Task ClickAutoScroll_OK()
     {
         var cut = Context.RenderComponent<Console>(builder =>
         {
@@ -206,7 +206,8 @@ public class ConsoleTest : BootstrapBlazorTestBase
             builder.Add(a => a.ShowAutoScroll, true);
         });
 
-        cut.Find(".card-footer input").Click();
+        var item = cut.FindComponent<Checkbox<bool>>();
+        await cut.InvokeAsync(item.Instance.TriggerClick);
         var res = cut.Instance.IsAutoScroll;
         Assert.False(res);
     }

--- a/test/UnitTest/Components/TableDialogTest.cs
+++ b/test/UnitTest/Components/TableDialogTest.cs
@@ -62,8 +62,8 @@ public class TableDialogTest : TableDialogTestBase
 
         var table = cut.FindComponent<Table<Foo>>();
         // 选一个
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var checkbox = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(checkbox.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.EditAsync());
 
         cut.Contains("test-save");
@@ -128,7 +128,7 @@ public class TableDialogTest : TableDialogTestBase
         await cut.InvokeAsync(() => table.Instance.AddAsync());
 
         // 编辑弹窗逻辑
-        input = cut.Find(".modal-body form input.form-control");
+        var input = cut.Find(".modal-body form input.form-control");
         await cut.InvokeAsync(() => input.Change("Test_Name"));
 
         form = cut.Find(".modal-body form");
@@ -362,8 +362,8 @@ public class TableDialogTest : TableDialogTestBase
         var modal = cut.FindComponent<Modal>();
 
         // 选一个
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var item = cut.FindComponent<Checkbox<Foo>>();
+        await cut.InvokeAsync(item.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.AddAsync());
 
         var form = cut.Find(".modal-body form");

--- a/test/UnitTest/Components/TableDrawerTest.cs
+++ b/test/UnitTest/Components/TableDrawerTest.cs
@@ -43,8 +43,8 @@ public class TableDrawerTest : TableDialogTestBase
 
         var table = cut.FindComponent<Table<Foo>>();
         // 选一个
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var checkbox = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(checkbox.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.EditAsync());
 
         // 编辑弹窗逻辑
@@ -102,8 +102,8 @@ public class TableDrawerTest : TableDialogTestBase
         {
             pb.Add(a => a.OnSaveAsync, (foo, itemType) => Task.FromResult(false));
         });
-        input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        checkbox = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(checkbox.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.EditAsync());
         form = cut.Find("form");
         await cut.InvokeAsync(() => form.Submit());
@@ -119,7 +119,7 @@ public class TableDrawerTest : TableDialogTestBase
         await cut.InvokeAsync(() => table.Instance.AddAsync());
 
         // 编辑弹窗逻辑
-        input = cut.Find("form input.form-control");
+        var input = cut.Find("form input.form-control");
         await cut.InvokeAsync(() => input.Change("Test_Name"));
 
         form = cut.Find("form");

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
-using Bunit;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
@@ -762,6 +761,9 @@ public class TableTest : BootstrapBlazorTestBase
         var item = cut.FindComponents<Checkbox<bool>>()[0];
         await cut.InvokeAsync(item.Instance.TriggerClick);
         Assert.True(show);
+
+        await cut.InvokeAsync(item.Instance.TriggerClick);
+        Assert.False(show);
     }
 
     [Fact]

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Bunit;
 using Microsoft.AspNetCore.Components.Forms;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
@@ -758,9 +759,8 @@ public class TableTest : BootstrapBlazorTestBase
         });
         cut.Contains("Test_Column_List");
 
-        var item = cut.Find(".dropdown-item .form-check-input");
-        await cut.InvokeAsync(() => item.Click());
-
+        var item = cut.FindComponents<Checkbox<bool>>()[0];
+        await cut.InvokeAsync(item.Instance.TriggerClick);
         Assert.True(show);
     }
 
@@ -2478,8 +2478,8 @@ public class TableTest : BootstrapBlazorTestBase
         Assert.True(clickWithoutRender);
 
         // 选中一行
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         button = cut.FindComponents<Button>().First(b => b.Instance.Text == "test-async");
         await cut.InvokeAsync(() => button.Instance.OnClickWithoutRender!.Invoke());
@@ -2538,8 +2538,8 @@ public class TableTest : BootstrapBlazorTestBase
         Assert.True(button.Instance.IsDisabled);
 
         // 选中一行
-        var input = cut.Find("tbody tr input");
-        cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        cut.InvokeAsync(input.Instance.TriggerClick);
         Assert.False(button.Instance.IsDisabled);
     }
 
@@ -3392,8 +3392,8 @@ public class TableTest : BootstrapBlazorTestBase
                 });
             });
         });
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<FooTree>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         // 点击展开
         var node = cut.Find("tbody .is-tree");
@@ -3680,8 +3680,8 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
         cut.Contains("is-node");
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<FooNoKeyTree>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var table = cut.FindComponent<Table<FooNoKeyTree>>();
         await cut.InvokeAsync(() => table.Instance.QueryAsync());
@@ -3799,8 +3799,8 @@ public class TableTest : BootstrapBlazorTestBase
                 });
             });
         });
-        var input = cut.Find("tbody tr td button");
-        await cut.InvokeAsync(() => input.Click());
+        var button = cut.Find("tbody tr td button");
+        await cut.InvokeAsync(() => button.Click());
     }
 
     [Fact]
@@ -4462,20 +4462,20 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var btn = cut.Find("thead tr th input");
-        await cut.InvokeAsync(() => btn.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[0];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var checkboxs = cut.FindAll(".is-checked");
         Assert.Equal(3, checkboxs.Count);
 
-        await cut.InvokeAsync(() => btn.Click());
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         checkboxs = cut.FindAll(".is-checked");
         Assert.Empty(checkboxs);
 
         var table = cut.FindComponent<Table<Foo>>();
         table.SetParametersAndRender(pb => pb.Add(a => a.Items, Array.Empty<Foo>()));
-        btn = cut.Find("thead tr th input");
-        await cut.InvokeAsync(() => btn.Click());
+        input = cut.FindComponents<Checkbox<Foo>>()[0];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
     }
 
     [Fact]
@@ -4500,13 +4500,13 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var btn = cut.Find("tbody tr td input");
-        await cut.InvokeAsync(() => btn.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var checkboxs = cut.FindAll(".is-checked");
         Assert.Single(checkboxs);
 
-        await cut.InvokeAsync(() => btn.Click());
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         checkboxs = cut.FindAll(".is-checked");
         Assert.Empty(checkboxs);
     }
@@ -4541,8 +4541,8 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var btn = cut.Find("tbody tr td input");
-        await cut.InvokeAsync(() => btn.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var checkboxs = cut.FindAll(".is-checked");
         Assert.Single(checkboxs);
@@ -4559,8 +4559,8 @@ public class TableTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => nextBtn.Click());
 
         //点击表头CheckBox
-        btn = cut.Find("thead tr th input");
-        await cut.InvokeAsync(() => btn.Click());
+        input = cut.FindComponents<Checkbox<Foo>>()[0];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         //加上表头的复选框选中，结果有3项
         checkboxs = cut.FindAll(".is-checked");
@@ -5237,11 +5237,11 @@ public class TableTest : BootstrapBlazorTestBase
         });
         Assert.Empty(selectedRows);
 
-        var check = cut.Find("thead input");
-        await cut.InvokeAsync(() => check.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[0];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         Assert.Equal(2, selectedRows.Count);
 
-        await cut.InvokeAsync(() => check.Click());
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         Assert.Empty(selectedRows);
     }
 
@@ -5352,8 +5352,8 @@ public class TableTest : BootstrapBlazorTestBase
                 });
             });
         });
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var button = cut.FindComponent<TableToolbarPopConfirmButton<Foo>>();
         await cut.InvokeAsync(() => button.Instance.OnConfirm.Invoke());
@@ -5402,8 +5402,8 @@ public class TableTest : BootstrapBlazorTestBase
                 });
             });
         });
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var button = cut.FindComponent<TableToolbarPopConfirmButton<Foo>>();
         await cut.InvokeAsync(() => button.Instance.OnConfirm.Invoke());
@@ -5875,8 +5875,8 @@ public class TableTest : BootstrapBlazorTestBase
         });
 
         // 选中行
-        var btn = cut.Find("tbody tr td input");
-        await cut.InvokeAsync(() => btn.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var button = cut.FindComponents<Button>().First(i => i.Instance.Icon == "fa-solid fa-arrows-rotate");
         await cut.InvokeAsync(() => button.Instance.OnClickWithoutRender!.Invoke());
@@ -6016,8 +6016,8 @@ public class TableTest : BootstrapBlazorTestBase
         });
 
         // 选中行
-        var input = cut.Find("tbody input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<DynamicObject>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         Assert.True(compared);
     }
 
@@ -6062,8 +6062,8 @@ public class TableTest : BootstrapBlazorTestBase
         var table = cut.FindComponent<Table<DynamicObject>>();
 
         // 选中第一行数据
-        var input = cut.Find("tbody .form-check-input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<DynamicObject>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         var selectedRow = table.Instance.SelectedRows.FirstOrDefault();
         Assert.NotNull(selectedRow);
 
@@ -6088,8 +6088,8 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<DynamicObject>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
 
         var table = cut.FindComponent<MockDynamicTable>();
         var saved = await table.Instance.SaveModelTest();
@@ -6647,8 +6647,8 @@ public class TableTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => table.Instance.EditAsync());
 
         // 选一个
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.EditAsync());
         var modal = cut.FindComponent<Modal>();
         await cut.InvokeAsync(() => modal.Instance.CloseCallback());
@@ -6661,8 +6661,8 @@ public class TableTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => modal.Instance.CloseCallback());
 
         // 选两个
-        input = cut.Find("thead input");
-        await cut.InvokeAsync(() => input.Click());
+        input = cut.FindComponents<Checkbox<Foo>>()[0];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.EditAsync());
         await cut.InvokeAsync(() => modal.Instance.CloseCallback());
     }
@@ -6737,8 +6737,8 @@ public class TableTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => deleteButton.Instance.OnBeforeClick());
 
         // 选一个
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         await cut.InvokeAsync(() => deleteButton.Instance.OnBeforeClick());
 
         table.SetParametersAndRender(pb =>
@@ -6776,8 +6776,8 @@ public class TableTest : BootstrapBlazorTestBase
         var table = cut.FindComponent<Table<Foo>>();
         var deleteButton = table.FindComponent<TableToolbarPopConfirmButton<Foo>>();
         // 选一个
-        var input = cut.Find("tbody tr input");
-        cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        cut.InvokeAsync(input.Instance.TriggerClick);
         cut.InvokeAsync(() => deleteButton.Instance.OnConfirm());
 
         table.SetParametersAndRender(pb =>
@@ -6876,8 +6876,8 @@ public class TableTest : BootstrapBlazorTestBase
         });
         var table = cut.FindComponent<Table<Foo>>();
         // 选一个
-        var input = cut.Find("tbody tr input");
-        await cut.InvokeAsync(() => input.Click());
+        var input = cut.FindComponents<Checkbox<Foo>>()[1];
+        await cut.InvokeAsync(input.Instance.TriggerClick);
         await cut.InvokeAsync(() => table.Instance.EditAsync());
     }
 
@@ -7976,8 +7976,8 @@ public class TableTest : BootstrapBlazorTestBase
         Assert.Equal(2, table.FindComponents<Checkbox<Foo>>().Count);
 
         // click header 第二行不可选择
-        var header = table.Find("thead tr th input");
-        table.InvokeAsync(() => header.Click());
+        var header = table.FindComponents<Checkbox<Foo>>()[0];
+        table.InvokeAsync(header.Instance.TriggerClick);
         Assert.Single(table.Instance.SelectedRows);
     }
 

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -196,8 +196,8 @@ public class TreeViewTest : BootstrapBlazorTestBase
             pb.Add(a => a.Items, items);
         });
 
-        var checkbox = cut.Find("[type=\"checkbox\"]");
-        await cut.InvokeAsync(() => checkbox.Click());
+        var checkbox = cut.FindComponent<Checkbox<CheckboxState>>();
+        await cut.InvokeAsync(checkbox.Instance.TriggerClick);
         cut.DoesNotContain("fa-solid fa-font-awesome");
         cut.Contains("Test-Class");
 
@@ -784,9 +784,8 @@ public class TreeViewTest : BootstrapBlazorTestBase
             pb.Add(a => a.ShowCheckbox, true);
         });
 
-        var checkbox = cut.FindAll(".tree-root > .tree-item > .tree-content > .form-check > .form-check-input");
-
-        await cut.InvokeAsync(() => checkbox[0].Click());
+        var checkbox = cut.FindComponent<Checkbox<CheckboxState>>();
+        await cut.InvokeAsync(checkbox.Instance.TriggerClick);
 
         Assert.Contains("is-checked", cut.Markup);
         var isChecked = cut.Instance.GetCheckedItems().Any();


### PR DESCRIPTION
# use client click instead of server event

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4619 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Switch checkbox click handling from server-side to client-side to improve performance and responsiveness. Add support for stopping event propagation in checkboxes and update tests to cover these changes.

New Features:
- Introduce client-side click handling for checkboxes, replacing server-side event handling.

Enhancements:
- Add support for stopping event propagation in checkboxes.

Tests:
- Add tests for the new client-side click handling and event propagation stopping features in checkboxes.