### PR TITLE
fix(Table): throw exception when click delete button in table row

### DIFF
--- a/src/BootstrapBlazor/Components/Button/PopConfirmButton.razor.js
+++ b/src/BootstrapBlazor/Components/Button/PopConfirmButton.razor.js
@@ -54,7 +54,7 @@ export function init(id) {
                 }
                 delete confirm.popover;
             }
-        }, 50);
+        }, 200);
     }
 
     EventHandler.on(el, 'show.bs.popover', confirm.show)


### PR DESCRIPTION
# throw exception when click delete button in table row

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4621 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix the issue where clicking the delete button in a table row does not throw an exception as expected.