### PR TITLE
fix(AutoFill): support numberpad enter key

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -256,7 +256,7 @@ public partial class AutoComplete
                     await OnEscAsync(Value);
                 }
             }
-            else if (key == "Enter")
+            else if (IsEnterKey(key))
             {
                 if (!string.IsNullOrEmpty(CurrentSelectedItem))
                 {

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -23,7 +23,7 @@ export function init(id, invoke) {
         EventHandler.on(input, 'keyup', debounce(e => {
             invoke.invokeMethodAsync('OnKeyUp', e.code)
         }, duration, e => {
-            return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Escape', 'Enter'].indexOf(e.key) > -1
+            return ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'Escape', 'Enter', 'NumpadEnter'].indexOf(e.key) > -1
         }))
     }
     else {

--- a/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
@@ -156,4 +156,11 @@ public abstract class PopoverCompleteBase<TValue> : BootstrapInputBase<TValue>, 
     /// </summary>
     /// <returns></returns>
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop);
+
+    /// <summary>
+    /// 判断是否为回车键
+    /// </summary>
+    /// <param name="key"></param>
+    /// <returns></returns>
+    protected bool IsEnterKey(string key) => key == "Enter" || key == "NumpadEnter";
 }

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -257,7 +257,7 @@ public partial class AutoFill<TValue>
                     await OnEscAsync(Value);
                 }
             }
-            else if (key == "Enter")
+            else if (IsEnterKey(key))
             {
                 ActiveSelectedItem ??= _filterItems.FirstOrDefault();
                 if (ActiveSelectedItem != null)

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -13,9 +13,10 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
     [Fact]
     public void Parameter_Ok()
     {
+        var items = new List<string>() { "test1", "test2" };
         var cut = Context.RenderComponent<AutoComplete>(builder =>
         {
-            builder.Add(a => a.Items, new string[] { "test1", "test2" });
+            builder.Add(a => a.Items, items);
             builder.Add(a => a.NoDataTip, "test3");
             builder.Add(a => a.ShowNoDataTip, true);
             builder.Add(a => a.DisplayCount, 10);
@@ -175,7 +176,7 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
 
         cut.InvokeAsync(() => cut.Instance.OnKeyUp("t"));
         cut.InvokeAsync(() => cut.Instance.OnKeyUp("ArrowDown"));
-        cut.InvokeAsync(() => cut.Instance.OnKeyUp("Enter"));
+        cut.InvokeAsync(() => cut.Instance.OnKeyUp("NumpadEnter"));
         Assert.True(enter);
     }
 


### PR DESCRIPTION
# support numberpad enter key

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4622 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix support for the number pad enter key in the AutoComplete and AutoFill components and update related unit tests.

Bug Fixes:
- Fix support for the number pad enter key in the AutoComplete and AutoFill components.

Tests:
- Update unit tests to include scenarios for the number pad enter key.