### PR TITLE
fix(ModalDialog): not shown after close previous window when set IsDraggable and IsCenter to true

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.0-beta01</Version>
+    <Version>9.0.0-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -17,16 +17,6 @@ export function init(id, invoke, shownCallback, closeCallback) {
     Data.set(id, modal)
 
     EventHandler.on(el, 'shown.bs.modal', () => {
-        const dialog = el.querySelector('.modal-dialog');
-        if (dialog.classList.contains('is-draggable-center')) {
-            const width = dialog.offsetWidth / 2;
-            const height = dialog.offsetHeight / 2;
-
-            dialog.style.setProperty("margin-left", `calc(50vw - ${width}px)`);
-            dialog.style.setProperty("margin-top", `calc(50vh - ${height}px)`);
-            dialog.classList.remove('is-draggable-center');
-        }
-
         invoke.invokeMethodAsync(shownCallback)
     })
     EventHandler.on(el, 'hidden.bs.modal', e => {

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -24,7 +24,7 @@ public partial class ModalDialog : IHandlerException
         .AddClass("modal-dialog-scrollable", IsScrolling)
         .AddClass("modal-fullscreen", MaximizeStatus)
         .AddClass("is-draggable", IsDraggable)
-        .AddClass("is-draggable-center", IsCentered && IsDraggable)
+        .AddClass("is-draggable-center", IsCentered && IsDraggable && _firstRender)
         .AddClass("d-none", !IsShown)
         .AddClass(Class, !string.IsNullOrEmpty(Class))
         .Build();
@@ -291,6 +291,8 @@ public partial class ModalDialog : IHandlerException
 
     private DialogResult _result = DialogResult.Close;
 
+    private bool _firstRender = true;
+
     /// <summary>
     /// OnInitialized 方法
     /// </summary>
@@ -327,6 +329,20 @@ public partial class ModalDialog : IHandlerException
         ExportPdfButtonOptions.Icon ??= IconTheme.GetIconByKey(ComponentIcons.TableExportPdfIcon);
 
         MaximizeIconString = MaximizeWindowIcon;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="firstRender"></param>
+    protected override void OnAfterRender(bool firstRender)
+    {
+        base.OnAfterRender(firstRender);
+
+        if (firstRender)
+        {
+            _firstRender = false;
+        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.js
@@ -119,6 +119,15 @@ export function init(id) {
             }
         )
     }
+
+    if (el.classList.contains('is-draggable-center')) {
+        const width = el.offsetWidth / 2;
+        const height = el.offsetHeight / 2;
+
+        el.style.setProperty("margin-left", `calc(50vw - ${width}px)`);
+        el.style.setProperty("margin-top", `calc(50vh - ${height}px)`);
+        el.classList.remove('is-draggable-center');
+    }
 }
 
 export function dispose(id) {


### PR DESCRIPTION
# not shown after close previous window when set IsDraggable and IsCenter to true

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4658 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the ModalDialog component was not shown after closing a previous window when both IsDraggable and IsCenter were set to true.