### PR TITLE
fix(Checkbox): not trigger OnStateChanged callback when set TValue to bool

### DIFF
--- a/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/Checkbox.razor.cs
@@ -215,21 +215,23 @@ public partial class Checkbox<TValue> : ValidateBase<TValue>
         if (IsBoolean)
         {
             CurrentValue = (TValue)(object)(state == CheckboxState.Checked);
-        }
 
-        if (State != state)
-        {
-            State = state;
-            if (StateChanged.HasDelegate)
+            if (ValueChanged.HasDelegate)
             {
-                await StateChanged.InvokeAsync(State);
                 ret = false;
             }
+        }
 
-            if (OnStateChanged != null)
-            {
-                await OnStateChanged(State, Value);
-            }
+        State = state;
+        if (StateChanged.HasDelegate)
+        {
+            await StateChanged.InvokeAsync(State);
+            ret = false;
+        }
+
+        if (OnStateChanged != null)
+        {
+            await OnStateChanged(State, Value);
         }
         return ret;
     }

--- a/test/UnitTest/Components/CheckboxListTest.cs
+++ b/test/UnitTest/Components/CheckboxListTest.cs
@@ -95,6 +95,27 @@ public class CheckboxListTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task Bool_TriggerStateChanged_Ok()
+    {
+        bool value = false;
+        // 测试 bool 值改变值时触发 StateChanged 回调方法
+        var cut = Context.RenderComponent<Checkbox<bool>>(pb =>
+        {
+            pb.Add(a => a.Value, false);
+            pb.Add(a => a.OnStateChanged, (state, v) =>
+            {
+                value = v;
+                return Task.CompletedTask;
+            });
+        });
+
+        // JavaScript 调用 OnTriggerClickAsync 方法
+        await cut.InvokeAsync(() => cut.Instance.OnTriggerClickAsync());
+        Assert.Equal(CheckboxState.Checked, cut.Instance.State);
+        Assert.True(value);
+    }
+
+    [Fact]
     public void Checkbox_Dispose()
     {
         var cut = Context.RenderComponent<Checkbox<string>>();


### PR DESCRIPTION
# not trigger OnStateChanged callback when set TValue to bool

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4666 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix the Checkbox component to prevent the OnStateChanged callback from being triggered when TValue is set to a boolean, and add a corresponding unit test to ensure correct behavior.

Bug Fixes:
- Fix the issue where the OnStateChanged callback was triggered when setting TValue to a boolean value in the Checkbox component.

Tests:
- Add a unit test to verify that the OnStateChanged callback is correctly triggered when the TValue is set to a boolean value.