### PR TITLE
chore(TargetFrameworks): revert multiple frameworks on debug mode

### DIFF
--- a/src/BootstrapBlazor/Directory.Build.props
+++ b/src/BootstrapBlazor/Directory.Build.props
@@ -2,7 +2,6 @@
 
   <Import Project="..\Directory.Build.props" />
   <Import Project="..\Logo.props" />
-  <Import Project="..\..\Framework.props" />
   <Import Project="..\SourceLink.targets" />
 
   <PropertyGroup>
@@ -17,12 +16,7 @@
     <IsPackable>true</IsPackable>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <TargetFramework>$(RunTargetFramework)</TargetFramework>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <TargetFramework></TargetFramework>
+  <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
# revert multiple frameworks on debug mode

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4700 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Chores:
- Revert the configuration to use a single target framework in debug mode.