### PR TITLE
fix(Table): ItemChangedType doesn't pass correct value to EditTemplate on Drawer mode

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.0.2-beta03</Version>
+    <Version>9.0.2-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Dialog/EditDialog.razor
+++ b/src/BootstrapBlazor/Components/Dialog/EditDialog.razor
@@ -4,24 +4,26 @@
 @attribute [BootstrapModuleAutoLoader("Dialog/EditDialog.razor.js", AutoInvokeInit = false, AutoInvokeDispose = false)]
 
 <ValidateForm Model="@Model" OnValidSubmit="@OnValidSubmitAsync" DisableAutoSubmitFormByEnter="@DisableAutoSubmitFormByEnter">
-    @if (BodyTemplate != null)
-    {
-        <div class="form-body">
-            @BodyTemplate(Model)
-        </div>
-        <div class="form-footer">
-            @RenderFooter
-        </div>
-    }
-    else
-    {
-        <EditorForm TModel="TModel" Items="Items" ItemChangedType="ItemChangedType" ItemsPerRow="ItemsPerRow" RowType="RowType" LabelAlign="LabelAlign" ShowLabel="ShowLabel" ShowUnsetGroupItemsOnTop="ShowUnsetGroupItemsOnTop">
-            <Buttons>
+    <CascadingValue Value="ItemChangedType" IsFixed="true">
+        @if (BodyTemplate != null)
+        {
+            <div class="form-body">
+                @BodyTemplate(Model)
+            </div>
+            <div class="form-footer">
                 @RenderFooter
-            </Buttons>
-        </EditorForm>
-    }
-    <div class="form-loader fade" id="@Id">
-        <Spinner Color="Color.Primary" />
-    </div>
+            </div>
+        }
+        else
+        {
+            <EditorForm TModel="TModel" Items="Items" ItemChangedType="ItemChangedType" ItemsPerRow="ItemsPerRow" RowType="RowType" LabelAlign="LabelAlign" ShowLabel="ShowLabel" ShowUnsetGroupItemsOnTop="ShowUnsetGroupItemsOnTop">
+                <Buttons>
+                    @RenderFooter
+                </Buttons>
+            </EditorForm>
+        }
+        <div class="form-loader fade" id="@Id">
+            <Spinner Color="Color.Primary" />
+        </div>
+    </CascadingValue>
 </ValidateForm>


### PR DESCRIPTION
# ItemChangedType doesn't pass correct value to EditTemplate on Drawer mode

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4721 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix the issue where ItemChangedType does not pass the correct value to EditTemplate in Drawer mode by wrapping the form content in a CascadingValue component.