### PR TITLE
bug(DialogCloseButton): missing theme button icon

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.2</Version>
+    <Version>9.1.3-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Dialog/DialogCloseButton.cs
+++ b/src/BootstrapBlazor/Components/Dialog/DialogCloseButton.cs
@@ -30,10 +30,10 @@ public partial class DialogCloseButton : Button
     /// </summary>
     protected override void OnParametersSet()
     {
-        base.OnParametersSet();
-
         Icon ??= IconTheme.GetIconByKey(ComponentIcons.DialogCloseButtonIcon);
         Text ??= Localizer[nameof(ModalDialog.CloseButtonText)];
+
+        base.OnParametersSet();
     }
 
     /// <summary>

--- a/test/UnitTest/Components/DialogCloseButtonTest.cs
+++ b/test/UnitTest/Components/DialogCloseButtonTest.cs
@@ -1,0 +1,19 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+namespace UnitTest.Components;
+
+public class DialogCloseButtonTest : BootstrapBlazorTestBase
+{
+    [Fact]
+    public void Icon_Ok()
+    {
+        var cut = Context.RenderComponent<DialogCloseButton>();
+        Assert.Equal("fa-solid fa-xmark", cut.Instance.Icon);
+
+        cut.SetParametersAndRender(pb => pb.Add(p => p.Icon, "test-icon"));
+        Assert.Equal("test-icon", cut.Instance.Icon);
+    }
+}

--- a/test/UnitTest/Components/DialogCloseButtonTest.cs
+++ b/test/UnitTest/Components/DialogCloseButtonTest.cs
@@ -12,8 +12,10 @@ public class DialogCloseButtonTest : BootstrapBlazorTestBase
     {
         var cut = Context.RenderComponent<DialogCloseButton>();
         Assert.Equal("fa-solid fa-xmark", cut.Instance.Icon);
+        cut.Contains("fa-solid fa-xmark");
 
         cut.SetParametersAndRender(pb => pb.Add(p => p.Icon, "test-icon"));
         Assert.Equal("test-icon", cut.Instance.Icon);
+        cut.Contains("test-icon");
     }
 }


### PR DESCRIPTION
# missing theme button icon

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4808 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix the missing theme button icon in the DialogCloseButton component and add a unit test to verify the icon functionality.

Bug Fixes:
- Fix the missing theme button icon in the DialogCloseButton component by ensuring the icon is set using the IconTheme.

Tests:
- Add a unit test for the DialogCloseButton component to verify the correct icon is applied.