### PR TITLE
fix(Select): can not switch Value when data type is SelectedItem on Virtual mode

### DIFF
--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -390,9 +390,9 @@ public partial class Select<TValue> : ISelect
         SelectedItem? item = null;
         if (_result.Items != null)
         {
-            item = _result.Items.FirstOrDefault(i => i.Value == value);
+            item = _result.Items.FirstOrDefault(i => i.Value == value) ?? new SelectedItem(value, DefaultVirtualizeItemText ?? value);
         }
-        return item ?? new SelectedItem(value, DefaultVirtualizeItemText ?? value);
+        return item;
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -266,17 +266,14 @@ public partial class Select<TValue> : ISelect
             ?? Rows.Where(i => !i.IsDisabled).FirstOrDefault()
             ?? GetVirtualizeItem(CurrentValueAsString);
 
-        if (item != null)
+        if (_init && DisableItemChangedWhenFirstRender)
         {
-            if (_init && DisableItemChangedWhenFirstRender)
-            {
 
-            }
-            else
-            {
-                _ = SelectedItemChanged(item);
-                _init = false;
-            }
+        }
+        else
+        {
+            _ = SelectedItemChanged(item);
+            _init = false;
         }
         return item;
     }
@@ -380,12 +377,12 @@ public partial class Select<TValue> : ISelect
             ?? GetVirtualizeItem(value);
 
         // support SelectedItem? type
-        result = SelectedItem != null ? (TValue)(object)SelectedItem : default;
+        result = (TValue)(object)SelectedItem;
         validationErrorMessage = "";
         return SelectedItem != null;
     }
 
-    private SelectedItem? GetVirtualizeItem(string value)
+    private SelectedItem GetVirtualizeItem(string value)
     {
         SelectedItem? item = null;
         if (_result.Items != null)

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -266,14 +266,17 @@ public partial class Select<TValue> : ISelect
             ?? Rows.Where(i => !i.IsDisabled).FirstOrDefault()
             ?? GetVirtualizeItem(CurrentValueAsString);
 
-        if (_init && DisableItemChangedWhenFirstRender)
+        if (item != null)
         {
+            if (_init && DisableItemChangedWhenFirstRender)
+            {
 
-        }
-        else
-        {
-            _ = SelectedItemChanged(item);
-            _init = false;
+            }
+            else
+            {
+                _ = SelectedItemChanged(item);
+                _init = false;
+            }
         }
         return item;
     }
@@ -377,12 +380,12 @@ public partial class Select<TValue> : ISelect
             ?? GetVirtualizeItem(value);
 
         // support SelectedItem? type
-        result = (TValue)(object)SelectedItem;
+        result = SelectedItem != null ? (TValue)(object)SelectedItem : default;
         validationErrorMessage = "";
         return SelectedItem != null;
     }
 
-    private SelectedItem GetVirtualizeItem(string value)
+    private SelectedItem? GetVirtualizeItem(string value)
     {
         SelectedItem? item = null;
         if (_result.Items != null)

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -264,7 +264,7 @@ public partial class Select<TValue> : ISelect
         var item = Rows.Find(i => i.Value == CurrentValueAsString)
             ?? Rows.Find(i => i.Active)
             ?? Rows.Where(i => !i.IsDisabled).FirstOrDefault()
-            ?? GetVirtualizeItem();
+            ?? GetVirtualizeItem(CurrentValueAsString);
 
         if (item != null)
         {
@@ -376,8 +376,8 @@ public partial class Select<TValue> : ISelect
 
     private bool TryParseSelectItem(string value, [MaybeNullWhen(false)] out TValue result, out string? validationErrorMessage)
     {
-        SelectedItem = Items.FirstOrDefault(i => i.Value == value)
-            ?? GetVirtualizeItem();
+        SelectedItem = Rows.FirstOrDefault(i => i.Value == value)
+            ?? GetVirtualizeItem(value);
 
         // support SelectedItem? type
         result = SelectedItem != null ? (TValue)(object)SelectedItem : default;
@@ -385,13 +385,14 @@ public partial class Select<TValue> : ISelect
         return SelectedItem != null;
     }
 
-    private SelectedItem? GetVirtualizeItem()
+    private SelectedItem? GetVirtualizeItem(string value)
     {
-        return OnQueryAsync == null ? null : GetSelectedItem();
-
-        SelectedItem? GetSelectedItem() => ValueType == typeof(SelectedItem)
-            ? (SelectedItem)(object)Value
-            : new SelectedItem(CurrentValueAsString, DefaultVirtualizeItemText ?? CurrentValueAsString);
+        SelectedItem? item = null;
+        if (_result.Items != null)
+        {
+            item = _result.Items.FirstOrDefault(i => i.Value == value);
+        }
+        return item ?? new SelectedItem(value, DefaultVirtualizeItemText ?? value);
     }
 
     /// <summary>

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -747,7 +747,7 @@ public class SelectTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void IsVirtualize_BindValue()
+    public async Task IsVirtualize_BindValue()
     {
         var value = new SelectedItem("3", "Test 3");
         var cut = Context.RenderComponent<Select<SelectedItem>>(pb =>
@@ -772,24 +772,21 @@ public class SelectTest : BootstrapBlazorTestBase
             });
         });
 
-        cut.InvokeAsync(() =>
-        {
-            var input = cut.Find(".form-select");
-            Assert.Equal("Test 3", input.GetAttribute("value"));
-        });
-        cut.Contains("Test 3");
+        var input = cut.Find(".form-select");
+        Assert.Equal("3", input.GetAttribute("value"));
+
         var select = cut.Instance;
         Assert.Equal("3", select.Value?.Value);
 
-        cut.InvokeAsync(() =>
+        var item = cut.Find(".dropdown-item");
+        await cut.InvokeAsync(() =>
         {
-            var item = cut.Find(".dropdown-item");
             item.Click();
-            Assert.Equal("1", value.Value);
-
-            var input = cut.Find(".form-select");
-            Assert.Equal("Test1", input.GetAttribute("value"));
         });
+        Assert.Equal("1", value.Value);
+
+        input = cut.Find(".form-select");
+        Assert.Equal("Test1", input.GetAttribute("value"));
     }
 
     [Fact]

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -773,7 +773,7 @@ public class SelectTest : BootstrapBlazorTestBase
         });
 
         var input = cut.Find(".form-select");
-        Assert.Equal("3", input.GetAttribute("value"));
+        Assert.Null(input.GetAttribute("value"));
 
         var select = cut.Instance;
         Assert.Equal("3", select.Value?.Value);


### PR DESCRIPTION
# can not switch Value when data type is SelectedItem on Virtual mode

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4849 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the Select component could not switch values when the data type is SelectedItem in Virtual mode.