### PR TITLE
fix(Layout): layout main overflow when set IsFullSide to false

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.1.5-beta01</Version>
+    <Version>9.1.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
@@ -95,6 +95,11 @@
         .layout-menu {
             height: 100%;
         }
+
+        .layout-main {
+            width: 1%;
+            min-width: 0;
+        }
     }
 
     .layout-menu {
@@ -125,8 +130,6 @@
         padding: 1rem;
         position: relative;
         flex: 1;
-        width: 1%;
-        min-width: 0;
 
         .tabs.tabs-border-card {
             box-shadow: none;


### PR DESCRIPTION
# layout main overflow when set IsFullSide to false

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4865 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix layout main overflow issue when IsFullSide is set to false by adjusting CSS properties.