### PR TITLE
fix(TableColumn): GetTooltipTextCallback not work

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesWrap.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesWrap.razor
@@ -71,7 +71,7 @@
         <TableColumns>
             <TableColumn @bind-Field="@context.DateTime" Width="180" Text="@Localizer["TablesWrapDataResizingColumHeaderText_DateTime"]" />
             <TableColumn @bind-Field="@context.Name" Text="@Localizer["TablesWrapDataResizingColumHeaderText_Name"]" />
-            <TableColumn @bind-Field="@context.Address" Text="@Localizer["TablesWrapDataResizingColumHeaderText_Address"]" Width="200" TextEllipsis="true" ShowTips="true" GetTooltipText="GetTooltipText" />
+            <TableColumn @bind-Field="@context.Address" Text="@Localizer["TablesWrapDataResizingColumHeaderText_Address"]" Width="200" TextEllipsis="true" ShowTips="true" GetTooltipTextCallback="GetTooltipTextCallback" />
             <TableColumn @bind-Field="@context.Education" />
             <TableColumn @bind-Field="@context.Count" />
             <TableColumn @bind-Field="@context.Complete" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesWrap.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesWrap.razor.cs
@@ -38,12 +38,14 @@ public partial class TablesWrap
         return Task.FromResult(new QueryData<Foo>() { Items = items, TotalCount = total, IsSorted = true, IsFiltered = true, IsSearch = true });
     }
 
-    private static string? GetTooltipText(object? v)
+    private async Task<string?> GetTooltipTextCallback(object? v)
     {
+        await Task.Delay(0);
+
         var ret = string.Empty;
         if (v is Foo foo)
         {
-            ret = $"{foo.Name}-{foo.Address}";
+            ret = $"{foo.Name}-{DateTime.Now}";
         }
         return ret;
     }

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesWrap.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesWrap.razor.cs
@@ -38,14 +38,14 @@ public partial class TablesWrap
         return Task.FromResult(new QueryData<Foo>() { Items = items, TotalCount = total, IsSorted = true, IsFiltered = true, IsSearch = true });
     }
 
-    private async Task<string?> GetTooltipTextCallback(object? v)
+    private static async Task<string?> GetTooltipTextCallback(object? v)
     {
-        await Task.Delay(0);
+        await Task.Delay(5);
 
         var ret = string.Empty;
         if (v is Foo foo)
         {
-            ret = $"{foo.Name}-{DateTime.Now}";
+            ret = $"{foo.Name}-{foo.Address}";
         }
         return ret;
     }

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -5265,7 +5265,7 @@
     "TablesWrapDataResizingTips1": "You can drag the window size, and the <b>address</b> column will be automatically omitted if the window is too small",
     "TablesWrapDataResizingTips2": "Enable text ellipsis by setting <code>TextEllipsis</code>",
     "TablesWrapDataResizingTips3": "<b>Note:</b> It is recommended to use <code>Width</code> to set the column width. If the column width is not set, it will automatically use 200px width inside",
-    "TablesWrapDataResizingTips4": "After the text in the cell is omitted, you can use the <code>ShowTips</code> property to control whether to display all the text on mouse hover, the default is <code>false</code>, You can customize the display content of <code>Tooltip</code> by setting the <code>GetTooltipText</code> callback method",
+    "TablesWrapDataResizingTips4": "After the text in the cell is omitted, you can use the <code>ShowTips</code> property to control whether to display all the text on mouse hover, the default is <code>false</code>, You can customize the display content of <code>Tooltip</code> by setting the <code>GetTooltipTextCallback</code> callback method",
     "TablesWrapDataResizingTips5": "Drag the address column, the cell display content will automatically increase and decrease",
     "TablesWrapCustomCellTitle": "Custom in-cell typography",
     "TablesWrapCustomCellIntro": "Use templates for special layout of in-cell data",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -5265,7 +5265,7 @@
     "TablesWrapDataResizingTips1": "可以拖动窗口大小，窗口过小时 <b>地址</b> 列自动进行省略处理",
     "TablesWrapDataResizingTips2": "通过设置 <code>TextEllipsis</code> 来开启文本超长省略功能",
     "TablesWrapDataResizingTips3": "<b>注意：</b>推荐使用 <code>Width</code> 对列宽度进行设置，如未设置列宽内部自动使用 200px 宽度",
-    "TablesWrapDataResizingTips4": "单元格内文本被省略后，可以通过 <code>ShowTips</code> 属性来控制鼠标悬停是否显示全部文本，默认为 <code>false</code>，通过设置 <code>GetTooltipText</code> 回调方法可以自定义 <code>Tooltip</code> 显示内容；注意异步方法 <code>GetTooltipTextCallback</code> 已弃用请勿使用",
+    "TablesWrapDataResizingTips4": "单元格内文本被省略后，可以通过 <code>ShowTips</code> 属性来控制鼠标悬停是否显示全部文本，默认为 <code>false</code>，通过设置 <code>GetTooltipTextCallback</code> 回调方法可以自定义 <code>Tooltip</code> 显示内容",
     "TablesWrapDataResizingTips5": "拖动地址列，单元格显示内容自动增加与减少",
     "TablesWrapCustomCellTitle": "自定义单元格内排版",
     "TablesWrapCustomCellIntro": "使用模板对单元格内数据进行特殊布局",

--- a/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
@@ -203,14 +203,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    [Obsolete("已弃用，请使用同步方法 GetTooltipText；Deprecated, please use the synchronous method GetTooltipText")]
-    [ExcludeFromCodeCoverage]
     Func<object?, Task<string?>>? ITableColumn.GetTooltipTextCallback { get; set; }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    Func<object?, string?>? ITableColumn.GetTooltipText { get; set; }
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/Table/ITableColumn.cs
+++ b/src/BootstrapBlazor/Components/Table/ITableColumn.cs
@@ -143,14 +143,7 @@ public interface ITableColumn : IEditorItem
     /// <summary>
     /// 获得/设置 鼠标悬停提示自定义内容回调委托 默认 null 使用当前值
     /// </summary>
-    [Obsolete("已弃用，请使用同步方法 GetTooltipText；Deprecated, please use the synchronous method GetTooltipText")]
-    [ExcludeFromCodeCoverage]
     Func<object?, Task<string?>>? GetTooltipTextCallback { get; set; }
-
-    /// <summary>
-    /// 获得/设置 鼠标悬停提示自定义内容回调委托 默认 null 使用当前值
-    /// </summary>
-    Func<object?, string?>? GetTooltipText { get; set; }
 
     /// <summary>
     /// 获得/设置 单元格回调方法

--- a/src/BootstrapBlazor/Components/Table/InternalTableColumn.cs
+++ b/src/BootstrapBlazor/Components/Table/InternalTableColumn.cs
@@ -133,17 +133,7 @@ class InternalTableColumn(string fieldName, Type fieldType, string? fieldText = 
 
     public bool? ShowTips { get; set; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    [Obsolete("已弃用，请使用同步方法 GetTooltipText；Deprecated, please use the synchronous method GetTooltipText")]
-    [ExcludeFromCodeCoverage]
     public Func<object?, Task<string?>>? GetTooltipTextCallback { get; set; }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    public Func<object?, string?>? GetTooltipText { get; set; }
 
     public Type PropertyType { get; } = fieldType;
 

--- a/src/BootstrapBlazor/Components/Table/TableColumn.cs
+++ b/src/BootstrapBlazor/Components/Table/TableColumn.cs
@@ -269,15 +269,7 @@ public class TableColumn<TItem, TType> : BootstrapComponentBase, ITableColumn
     /// <inheritdoc/>
     /// </summary>
     [Parameter]
-    [Obsolete("已弃用，请使用同步方法 GetTooltipText；Deprecated, please use the synchronous method GetTooltipText")]
-    [ExcludeFromCodeCoverage]
     public Func<object?, Task<string?>>? GetTooltipTextCallback { get; set; }
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    [Parameter]
-    public Func<object?, string?>? GetTooltipText { get; set; }
 
     /// <summary>
     /// 获得/设置 列 td 自定义样式 默认为 null 未设置

--- a/src/BootstrapBlazor/Components/Tooltip/Tooltip.razor.cs
+++ b/src/BootstrapBlazor/Components/Tooltip/Tooltip.razor.cs
@@ -56,6 +56,12 @@ public partial class Tooltip : ITooltip
     public string? Title { get; set; }
 
     /// <summary>
+    /// 获得/设置 获得显示内容异步回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<Task<string>>? GetTitleCallback { get; set; }
+
+    /// <summary>
     /// 获得/设置 显示文字是否为 Html 默认为 false
     /// </summary>
     [Parameter]
@@ -117,6 +123,20 @@ public partial class Tooltip : ITooltip
         base.OnParametersSet();
 
         Trigger ??= "focus hover";
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override async Task OnParametersSetAsync()
+    {
+        await base.OnParametersSetAsync();
+
+        if (string.IsNullOrEmpty(Title) && GetTitleCallback != null)
+        {
+            Title ??= await GetTitleCallback();
+        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
@@ -238,36 +238,40 @@ public static class IEditItemExtensions
         builder.CloseElement();
     };
 
-    private static RenderFragment RenderTooltip<TItem>(this ITableColumn col, string? text, TItem item) => async pb =>
+    private static RenderFragment RenderTooltip<TItem>(this ITableColumn col, string? text, TItem item) => pb =>
     {
         if (col.GetShowTips())
         {
+            pb.OpenComponent<Tooltip>(0);
+            pb.SetKey(item);
             var tooltipText = text;
             if (col.GetTooltipTextCallback != null)
             {
-                tooltipText = await col.GetTooltipTextCallback(item);
-            }
-            pb.OpenComponent<Tooltip>(0);
-            pb.AddAttribute(1, nameof(Tooltip.Title), tooltipText);
-            pb.AddAttribute(2, "class", "text-truncate d-block");
-            if (col.IsMarkupString)
-            {
-                pb.AddAttribute(3, nameof(Tooltip.ChildContent), new RenderFragment(builder => builder.AddMarkupContent(0, text)));
-                pb.AddAttribute(4, nameof(Tooltip.IsHtml), true);
+                pb.AddAttribute(10, nameof(Tooltip.GetTitleCallback), new Func<Task<string?>>(() => col.GetTooltipTextCallback(item)));
             }
             else
             {
-                pb.AddAttribute(3, nameof(Tooltip.ChildContent), new RenderFragment(builder => builder.AddContent(0, text)));
+                pb.AddAttribute(11, nameof(Tooltip.Title), tooltipText);
+            }
+            pb.AddAttribute(12, "class", "text-truncate d-block");
+            if (col.IsMarkupString)
+            {
+                pb.AddAttribute(13, nameof(Tooltip.ChildContent), new RenderFragment(builder => builder.AddMarkupContent(0, text)));
+                pb.AddAttribute(14, nameof(Tooltip.IsHtml), true);
+            }
+            else
+            {
+                pb.AddAttribute(15, nameof(Tooltip.ChildContent), new RenderFragment(builder => builder.AddContent(0, text)));
             }
             pb.CloseComponent();
         }
         else if (col.IsMarkupString)
         {
-            pb.AddMarkupContent(3, text);
+            pb.AddMarkupContent(20, text);
         }
         else
         {
-            pb.AddContent(4, text);
+            pb.AddContent(30, text);
         }
     };
 

--- a/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
@@ -105,7 +105,7 @@ public static class IEditItemExtensions
         if (col.IsVisibleWhenEdit.HasValue) dest.IsVisibleWhenEdit = col.IsVisibleWhenEdit;
         if (col.IsReadonlyWhenAdd.HasValue) dest.IsReadonlyWhenAdd = col.IsReadonlyWhenAdd;
         if (col.IsReadonlyWhenEdit.HasValue) dest.IsReadonlyWhenEdit = col.IsReadonlyWhenEdit;
-        if (col.GetTooltipText != null) dest.GetTooltipText = col.GetTooltipText;
+        if (col.GetTooltipTextCallback != null) dest.GetTooltipTextCallback = col.GetTooltipTextCallback;
         if (col.CustomSearch != null) dest.CustomSearch = col.CustomSearch;
         if (col.ToolboxTemplate != null) dest.ToolboxTemplate = col.ToolboxTemplate;
         if (col.IsRequiredWhenAdd.HasValue) dest.IsRequiredWhenAdd = col.IsRequiredWhenAdd;
@@ -238,14 +238,14 @@ public static class IEditItemExtensions
         builder.CloseElement();
     };
 
-    private static RenderFragment RenderTooltip<TItem>(this ITableColumn col, string? text, TItem item) => pb =>
+    private static RenderFragment RenderTooltip<TItem>(this ITableColumn col, string? text, TItem item) => async pb =>
     {
         if (col.GetShowTips())
         {
             var tooltipText = text;
-            if (col.GetTooltipText != null)
+            if (col.GetTooltipTextCallback != null)
             {
-                tooltipText = col.GetTooltipText(item);
+                tooltipText = await col.GetTooltipTextCallback(item);
             }
             pb.OpenComponent<Tooltip>(0);
             pb.AddAttribute(1, nameof(Tooltip.Title), tooltipText);

--- a/test/UnitTest/Attributes/AutoGenerateClassTest.cs
+++ b/test/UnitTest/Attributes/AutoGenerateClassTest.cs
@@ -156,8 +156,8 @@ public class AutoGenerateClassTest
         attrInterface.IsReadonlyWhenEdit = true;
         Assert.True(attrInterface.IsReadonlyWhenEdit);
 
-        attrInterface.GetTooltipText = _ => "Test";
-        Assert.NotNull(attrInterface.GetTooltipText);
+        attrInterface.GetTooltipTextCallback = _ => Task.FromResult((string?)"Test");
+        Assert.NotNull(attrInterface.GetTooltipTextCallback);
 
         attrInterface.CustomSearch = (_, _) => new SearchFilterAction("test", "test");
         Assert.NotNull(attrInterface.CustomSearch);

--- a/test/UnitTest/Components/TableColumnTest.cs
+++ b/test/UnitTest/Components/TableColumnTest.cs
@@ -77,7 +77,7 @@ public class TableColumnTest
         SetValue("HeaderTextTooltip", "Test");
         SetValue("HeaderTextEllipsis", true);
         SetValue("IsMarkupString", true);
-        SetValue("GetTooltipText", new Func<object, string?>(_ => ""));
+        SetValue("GetTooltipTextCallback", new Func<object, Task<string?>>(_ => Task.FromResult((string?)"")));
         SetValue("CustomSearch", new Func<ITableColumn, string?, SearchFilterAction>((_, _) => new SearchFilterAction("test", "test")));
 
         SetValue("Required", true);

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -4916,7 +4916,7 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void GetTooltipText_Ok()
+    public void GetTooltipTextCallback_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var items = Foo.GenerateFoo(localizer, 2);
@@ -4934,8 +4934,9 @@ public class TableTest : BootstrapBlazorTestBase
                     builder.AddAttribute(3, "Editable", true);
                     builder.AddAttribute(7, "Text", "test");
                     builder.AddAttribute(9, "ShowTips", true);
-                    builder.AddAttribute(10, "GetTooltipText", new Func<object, string?>(v =>
+                    builder.AddAttribute(10, "GetTooltipTextCallback", new Func<object, Task<string?>>(async v =>
                     {
+                        await Task.Delay(0);
                         return "test-tips-callback";
                     }));
                     builder.CloseComponent();

--- a/test/UnitTest/Extensions/ITableColumnExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ITableColumnExtensionsTest.cs
@@ -106,7 +106,7 @@ public class ITableColumnExtensionsTest
             Step = "0.01",
             Order = -1,
             IsMarkupString = true,
-            GetTooltipText = _ => null,
+            GetTooltipTextCallback = _ => Task.FromResult<string?>(null),
             CustomSearch = (_, _) => new SearchFilterAction("test", "test"),
 
             Required = true,
@@ -169,7 +169,7 @@ public class ITableColumnExtensionsTest
         Assert.True(col.ShowCopyColumn);
         Assert.Equal("0.01", col.Step);
         Assert.Equal(-1, col.Order);
-        Assert.NotNull(col.GetTooltipText);
+        Assert.NotNull(col.GetTooltipTextCallback);
         Assert.True(col.IsMarkupString);
         Assert.NotNull(col.CustomSearch);
 


### PR DESCRIPTION
# GetTooltipTextCallback not work

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4888

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix the tooltip text callback functionality by replacing the synchronous GetTooltipText method with the asynchronous GetTooltipTextCallback method across the codebase. Update related unit tests to ensure the new callback method is properly tested.

Bug Fixes:
- Fix the issue where GetTooltipTextCallback was not functioning correctly by replacing GetTooltipText with GetTooltipTextCallback in the tooltip rendering logic.

Enhancements:
- Deprecate the synchronous GetTooltipText method in favor of the asynchronous GetTooltipTextCallback method for better performance and flexibility.

Tests:
- Update unit tests to reflect the change from GetTooltipText to GetTooltipTextCallback, ensuring the new callback method is tested.