### PR TITLE
doc(Safari): add theme color for safari on mac 

### DIFF
--- a/src/BootstrapBlazor.Server/Components/App.razor
+++ b/src/BootstrapBlazor.Server/Components/App.razor
@@ -6,6 +6,7 @@
 <html lang="en" data-bs-theme='light'>
 
 <head>
+    <meta name="theme-color" content="#712ce9">
     <meta charset="utf-8" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -13,7 +14,6 @@
     <meta name="keywords" content="bootstrapblazor,bootstrap,blazor,wasm,webassembly,UI,netcore,web,assembly">
     <meta name="description" content="基于 Bootstrap 风格的 Blazor UI 组件库，用于研发企业级中后台产品。">
     <meta name="author" content="argo (argo@live.ca)">
-    <meta name="theme-color" content="#712cf9">
     <title>@Localizer["SiteTitle"]</title>
     <base href="/" />
     <link rel="icon" href="favicon.ico" type="image/x-icon">

--- a/src/BootstrapBlazor.Server/Components/App.razor
+++ b/src/BootstrapBlazor.Server/Components/App.razor
@@ -13,6 +13,7 @@
     <meta name="keywords" content="bootstrapblazor,bootstrap,blazor,wasm,webassembly,UI,netcore,web,assembly">
     <meta name="description" content="基于 Bootstrap 风格的 Blazor UI 组件库，用于研发企业级中后台产品。">
     <meta name="author" content="argo (argo@live.ca)">
+    <meta name="theme-color" content="#712cf9">
     <title>@Localizer["SiteTitle"]</title>
     <base href="/" />
     <link rel="icon" href="favicon.ico" type="image/x-icon">

--- a/src/BootstrapBlazor.Server/Components/App.razor
+++ b/src/BootstrapBlazor.Server/Components/App.razor
@@ -6,7 +6,6 @@
 <html lang="en" data-bs-theme='light'>
 
 <head>
-    <meta name="theme-color" content="#712cf9">
     <meta charset="utf-8" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -14,6 +13,7 @@
     <meta name="keywords" content="bootstrapblazor,bootstrap,blazor,wasm,webassembly,UI,netcore,web,assembly">
     <meta name="description" content="基于 Bootstrap 风格的 Blazor UI 组件库，用于研发企业级中后台产品。">
     <meta name="author" content="argo (argo@live.ca)">
+    <meta name="theme-color" content="#712cf9">
     <title>@Localizer["SiteTitle"]</title>
     <base href="/" />
     <link rel="icon" href="favicon.ico" type="image/x-icon">

--- a/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor
+++ b/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor
@@ -29,7 +29,7 @@ else
                 <Checkbox TValue="bool" IsDisabled="GetDisabledState(item)"
                           ShowAfterLabel="true" ShowLabel="false" ShowLabelTooltip="ShowLabelTooltip"
                           DisplayText="@item.Text" OnBeforeStateChanged="_onBeforeStateChangedCallback!"
-                          Value="@item.Active" OnStateChanged="@((state, v) => OnStateChanged(item, v))"></Checkbox>
+                          Value="@item.Active" OnStateChanged="@((_, v) => OnStateChanged(item, v))"></Checkbox>
             </div>
         }
     </div>

--- a/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor
+++ b/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor
@@ -1,6 +1,6 @@
 ﻿@namespace BootstrapBlazor.Components
 @typeparam TValue
-@inherits ValidateBase<List<TValue?>>
+@inherits ValidateBase<List<TValue>>
 
 @if (IsShowLabel)
 {

--- a/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor.cs
@@ -97,7 +97,7 @@ public partial class CheckboxListGeneric<TValue> : IModelEqualityComparer<TValue
     /// 获得/设置 SelectedItemChanged 方法
     /// </summary>
     [Parameter]
-    public Func<IEnumerable<SelectedItem<TValue>>, List<TValue?>, Task>? OnSelectedChanged { get; set; }
+    public Func<IEnumerable<SelectedItem<TValue>>, List<TValue>, Task>? OnSelectedChanged { get; set; }
 
     /// <summary>
     /// 获得/设置 最多选中数量
@@ -204,7 +204,7 @@ public partial class CheckboxListGeneric<TValue> : IModelEqualityComparer<TValue
     private async Task OnStateChanged(SelectedItem<TValue> item, bool v)
     {
         item.Active = v;
-        var items = new List<TValue?>();
+        var items = new List<TValue>();
         if (Value != null)
         {
             items.AddRange(Value);
@@ -217,7 +217,7 @@ public partial class CheckboxListGeneric<TValue> : IModelEqualityComparer<TValue
         }
         else
         {
-            items.Remove(val);
+            items.Remove(val!);
         }
 
         CurrentValue = items;

--- a/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor.cs
@@ -25,7 +25,7 @@ public partial class CheckboxListGeneric<TValue> : IModelEqualityComparer<TValue
     /// <summary>
     /// 获得 组件内部 Checkbox 项目样式
     /// </summary>
-    protected string? CheckboxItemClassString => CssBuilder.Default("checkbox-item")
+    private string? CheckboxItemClassString => CssBuilder.Default("checkbox-item")
         .AddClass(CheckboxItemClass)
         .Build();
 
@@ -210,7 +210,7 @@ public partial class CheckboxListGeneric<TValue> : IModelEqualityComparer<TValue
             items.AddRange(Value);
         }
 
-        var val = items.Find(i => IsEquals(item.Value));
+        var val = items.Find(i => Equals(item.Value, i));
         if (v && val == null)
         {
             items.Add(item.Value);

--- a/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/Checkbox/CheckboxListGeneric.razor.cs
@@ -204,23 +204,23 @@ public partial class CheckboxListGeneric<TValue> : IModelEqualityComparer<TValue
     private async Task OnStateChanged(SelectedItem<TValue> item, bool v)
     {
         item.Active = v;
-        var vals = new List<TValue?>();
+        var items = new List<TValue?>();
         if (Value != null)
         {
-            vals.AddRange(Value);
+            items.AddRange(Value);
         }
 
-        var val = vals.Find(i => IsEquals(item.Value));
+        var val = items.Find(i => IsEquals(item.Value));
         if (v && val == null)
         {
-            vals.Add(item.Value);
+            items.Add(item.Value);
         }
         else
         {
-            vals.Remove(val);
+            items.Remove(val);
         }
 
-        CurrentValue = vals;
+        CurrentValue = items;
 
         if (OnSelectedChanged != null)
         {

--- a/src/BootstrapBlazor/Components/Radio/RadioListGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/Radio/RadioListGeneric.razor.cs
@@ -120,7 +120,7 @@ public partial class RadioListGeneric<TValue> : IModelEqualityComparer<TValue>
         var t = NullableUnderlyingType ?? typeof(TValue);
         if (t.IsEnum && Items == null)
         {
-            Items = t.ToSelectList<TValue>((NullableUnderlyingType != null && IsAutoAddNullItem) ? new SelectedItem<TValue>(default, NullItemText) : null);
+            Items = t.ToSelectList<TValue>((NullableUnderlyingType != null && IsAutoAddNullItem) ? new SelectedItem<TValue>(default!, NullItemText) : null);
         }
 
         Items ??= [];

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
@@ -566,7 +566,7 @@ public partial class SelectGeneric<TValue> : ISelectGeneric<TValue>, IModelEqual
 
             if (item == null)
             {
-                TValue? val = default;
+                TValue val = default!;
                 if (TextConvertToValueCallback != null)
                 {
                     val = await TextConvertToValueCallback(v);

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectOptionGeneric.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectOptionGeneric.cs
@@ -58,7 +58,7 @@ public class SelectOptionGeneric<TValue> : ComponentBase
         Container?.Add(ToSelectedItem());
     }
 
-    private SelectedItem<TValue> ToSelectedItem() => new(Value, Text ?? "")
+    private SelectedItem<TValue> ToSelectedItem() => new(Value!, Text ?? "")
     {
         Active = Active,
         GroupName = GroupName ?? "",

--- a/src/BootstrapBlazor/Misc/SelectedItemOfT.cs
+++ b/src/BootstrapBlazor/Misc/SelectedItemOfT.cs
@@ -13,14 +13,14 @@ public class SelectedItem<T>
     /// <summary>
     /// 构造函数
     /// </summary>
-    public SelectedItem() { }
+    public SelectedItem() { Value = default!; }
 
     /// <summary>
     /// 构造函数
     /// </summary>
     /// <param name="value"></param>
     /// <param name="text"></param>
-    public SelectedItem(T? value, string text)
+    public SelectedItem(T value, string text)
     {
         Value = value;
         Text = text;
@@ -34,7 +34,7 @@ public class SelectedItem<T>
     /// <summary>
     /// 获得/设置 选项值
     /// </summary>
-    public T? Value { get; set; }
+    public T Value { get; set; }
 
     /// <summary>
     /// 获得/设置 是否选中

--- a/test/UnitTest/Components/CheckboxListGenericTest.cs
+++ b/test/UnitTest/Components/CheckboxListGenericTest.cs
@@ -78,12 +78,12 @@ public class CheckboxListGenericTest : BootstrapBlazorTestBase
     [Fact]
     public async Task NullItem_Ok()
     {
-        var items = new List<SelectedItem<Foo>>()
+        var items = new List<SelectedItem<Foo?>>()
         {
             new(null, "Select ..."),
             new(new Foo() { Id = 2, Name = "Test2" }, "Test 2")
         };
-        var cut = Context.RenderComponent<CheckboxListGeneric<Foo>>(pb =>
+        var cut = Context.RenderComponent<CheckboxListGeneric<Foo?>>(pb =>
         {
             pb.Add(a => a.Items, items);
         });


### PR DESCRIPTION
# add theme color for safari on mac 

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #4910 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a theme color for Safari on macOS.

Enhancements:
- Set the theme color to #712cf9.

Documentation:
- Document the theme color for Safari on macOS.