### PR TITLE
feat(BootstrapInputNumber): support NumberDecimalSeparator setting

### DIFF
--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -50,6 +50,12 @@ public static class ObjectExtensions
     /// <returns></returns>
     public static bool IsNumber(this Type t)
     {
+        var separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+        if (separator != ".")
+        {
+            return false;
+        }
+
         var targetType = Nullable.GetUnderlyingType(t) ?? t;
         return targetType == typeof(int) || targetType == typeof(long) || targetType == typeof(short) ||
             targetType == typeof(float) || targetType == typeof(double) || targetType == typeof(decimal);

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.Localization;
 using System.ComponentModel;
 using System.Data;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -100,6 +101,11 @@ public static class Utility
     /// <param name="fieldName"></param>
     /// <returns></returns>
     public static TResult GetPropertyValue<TModel, TResult>(TModel model, string fieldName) => CacheManager.GetPropertyValue<TModel, TResult>(model, fieldName);
+
+    /// <summary>
+    /// 获得 当前输入语言小数点分隔符
+    /// </summary>
+    private static string NumberDecimalSeparator => CultureInfo.CurrentCulture?.NumberFormat?.NumberDecimalSeparator ?? ".";
 
     /// <summary>
     /// 获取 指定对象的属性值
@@ -429,12 +435,10 @@ public static class Utility
             builder.OpenComponent(0, typeof(Display<>).MakeGenericType(fieldType));
             builder.AddAttribute(10, nameof(Display<string>.DisplayText), displayName);
             builder.AddAttribute(20, nameof(Display<string>.Value), fieldValue);
-            builder.AddAttribute(30, nameof(Display<string>.Lookup), item.Lookup);
-            builder.AddAttribute(30, nameof(Display<string>.LookupService), item.LookupService);
-            builder.AddAttribute(40, nameof(Display<string>.LookupServiceKey), item.LookupServiceKey);
-            builder.AddAttribute(50, nameof(Display<string>.LookupServiceData), item.LookupServiceData);
-            builder.AddAttribute(60, nameof(Display<string>.LookupStringComparison), item.LookupStringComparison);
-            builder.AddAttribute(65, nameof(Display<string>.ShowLabelTooltip), item.ShowLabelTooltip);
+            builder.AddAttribute(30, nameof(Display<string>.LookupServiceKey), item.LookupServiceKey);
+            builder.AddAttribute(40, nameof(Display<string>.LookupServiceData), item.LookupServiceData);
+            builder.AddAttribute(50, nameof(Display<string>.Lookup), item.Lookup);
+            builder.AddAttribute(60, nameof(Display<string>.ShowLabelTooltip), item.ShowLabelTooltip);
             if (item is ITableColumn col)
             {
                 if (col.Formatter != null)
@@ -524,7 +528,6 @@ public static class Utility
         if (item.IsLookup() && item.Items == null)
         {
             builder.AddAttribute(110, nameof(Select<SelectedItem>.ShowSearch), item.ShowSearchWhenSelect);
-            builder.AddAttribute(115, nameof(Select<SelectedItem>.Items), item.Lookup);
             builder.AddAttribute(120, nameof(Select<SelectedItem>.LookupService), lookupService);
             builder.AddAttribute(121, nameof(Select<SelectedItem>.LookupServiceKey), item.LookupServiceKey);
             builder.AddAttribute(122, nameof(Select<SelectedItem>.LookupServiceData), item.LookupServiceData);
@@ -638,7 +641,7 @@ public static class Utility
         {
             ret = typeof(NullSwitch);
         }
-        else if (fieldType.IsNumber())
+        else if (fieldType.IsNumber() && NumberDecimalSeparator == ".")
         {
             ret = typeof(BootstrapInputNumber<>).MakeGenericType(fieldType);
         }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.Localization;
 using System.ComponentModel;
 using System.Data;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -191,6 +192,11 @@ public static class Utility
     public static string? GetPlaceHolder(Type modelType, string fieldName) => modelType.Assembly.IsDynamic
         ? null
         : CacheManager.GetPlaceholder(modelType, fieldName);
+
+    /// <summary>
+    /// 获得 当前输入语言小数点分隔符
+    /// </summary>
+    private static string NumberDecimalSeparator => CultureInfo.CurrentCulture?.NumberFormat?.NumberDecimalSeparator ?? ".";
 
     /// <summary>
     /// 通过 数据类型与字段名称获取 PropertyInfo 实例方法
@@ -638,7 +644,7 @@ public static class Utility
         {
             ret = typeof(NullSwitch);
         }
-        else if (fieldType.IsNumber())
+        else if (fieldType.IsNumber() && NumberDecimalSeparator == ".")
         {
             ret = typeof(BootstrapInputNumber<>).MakeGenericType(fieldType);
         }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.Localization;
 using System.ComponentModel;
 using System.Data;
-using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -101,11 +100,6 @@ public static class Utility
     /// <param name="fieldName"></param>
     /// <returns></returns>
     public static TResult GetPropertyValue<TModel, TResult>(TModel model, string fieldName) => CacheManager.GetPropertyValue<TModel, TResult>(model, fieldName);
-
-    /// <summary>
-    /// 获得 当前输入语言小数点分隔符
-    /// </summary>
-    private static string NumberDecimalSeparator => CultureInfo.CurrentCulture?.NumberFormat?.NumberDecimalSeparator ?? ".";
 
     /// <summary>
     /// 获取 指定对象的属性值
@@ -435,10 +429,12 @@ public static class Utility
             builder.OpenComponent(0, typeof(Display<>).MakeGenericType(fieldType));
             builder.AddAttribute(10, nameof(Display<string>.DisplayText), displayName);
             builder.AddAttribute(20, nameof(Display<string>.Value), fieldValue);
-            builder.AddAttribute(30, nameof(Display<string>.LookupServiceKey), item.LookupServiceKey);
-            builder.AddAttribute(40, nameof(Display<string>.LookupServiceData), item.LookupServiceData);
-            builder.AddAttribute(50, nameof(Display<string>.Lookup), item.Lookup);
-            builder.AddAttribute(60, nameof(Display<string>.ShowLabelTooltip), item.ShowLabelTooltip);
+            builder.AddAttribute(30, nameof(Display<string>.Lookup), item.Lookup);
+            builder.AddAttribute(30, nameof(Display<string>.LookupService), item.LookupService);
+            builder.AddAttribute(40, nameof(Display<string>.LookupServiceKey), item.LookupServiceKey);
+            builder.AddAttribute(50, nameof(Display<string>.LookupServiceData), item.LookupServiceData);
+            builder.AddAttribute(60, nameof(Display<string>.LookupStringComparison), item.LookupStringComparison);
+            builder.AddAttribute(65, nameof(Display<string>.ShowLabelTooltip), item.ShowLabelTooltip);
             if (item is ITableColumn col)
             {
                 if (col.Formatter != null)
@@ -528,6 +524,7 @@ public static class Utility
         if (item.IsLookup() && item.Items == null)
         {
             builder.AddAttribute(110, nameof(Select<SelectedItem>.ShowSearch), item.ShowSearchWhenSelect);
+            builder.AddAttribute(115, nameof(Select<SelectedItem>.Items), item.Lookup);
             builder.AddAttribute(120, nameof(Select<SelectedItem>.LookupService), lookupService);
             builder.AddAttribute(121, nameof(Select<SelectedItem>.LookupServiceKey), item.LookupServiceKey);
             builder.AddAttribute(122, nameof(Select<SelectedItem>.LookupServiceData), item.LookupServiceData);
@@ -641,7 +638,7 @@ public static class Utility
         {
             ret = typeof(NullSwitch);
         }
-        else if (fieldType.IsNumber() && NumberDecimalSeparator == ".")
+        else if (fieldType.IsNumber())
         {
             ret = typeof(BootstrapInputNumber<>).MakeGenericType(fieldType);
         }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.Localization;
 using System.ComponentModel;
 using System.Data;
-using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 
@@ -192,11 +191,6 @@ public static class Utility
     public static string? GetPlaceHolder(Type modelType, string fieldName) => modelType.Assembly.IsDynamic
         ? null
         : CacheManager.GetPlaceholder(modelType, fieldName);
-
-    /// <summary>
-    /// 获得 当前输入语言小数点分隔符
-    /// </summary>
-    private static string NumberDecimalSeparator => CultureInfo.CurrentCulture?.NumberFormat?.NumberDecimalSeparator ?? ".";
 
     /// <summary>
     /// 通过 数据类型与字段名称获取 PropertyInfo 实例方法
@@ -644,7 +638,7 @@ public static class Utility
         {
             ret = typeof(NullSwitch);
         }
-        else if (fieldType.IsNumber() && NumberDecimalSeparator == ".")
+        else if (fieldType.IsNumber())
         {
             ret = typeof(BootstrapInputNumber<>).MakeGenericType(fieldType);
         }

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -44,6 +44,18 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
         Assert.Equal(expect, actual);
     }
 
+    [Fact]
+    public void IsNumber_Culture()
+    {
+        var culture = new CultureInfo("es-ES");
+        CultureInfo.CurrentCulture = culture;
+        Assert.False(typeof(long).IsNumber());
+
+        culture = new CultureInfo("en-US");
+        CultureInfo.CurrentCulture = culture;
+        Assert.True(typeof(long).IsNumber());
+    }
+
     [Theory]
     [InlineData(typeof(DateTime?), true)]
     [InlineData(typeof(DateTime), true)]


### PR DESCRIPTION
# 按当前输入语言小数点分隔符格式自动渲染组件类型

多语言: 数字类型字段在编辑对话框渲染为数字输入框格式问题
一个自动的机制, 非点号(.) 数字格式区域, 数字类型编辑自动渲染为文本框, 而不是数字框

close #4987
  
## Regression?

- [x] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [x] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

New Features:
- Automatically render numeric type fields as text input boxes in locales with non-period decimal separators.