### PR TITLE
fix(SelectTree): shoud set the default active node by Value on first render

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.2.1-beta01</Version>
+    <Version>9.2.1-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
@@ -232,6 +232,7 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
         var currentItem = GetExpandedItems().FirstOrDefault(predicate);
         if (currentItem != null)
         {
+            currentItem.IsActive = true;
             await ItemChanged(currentItem);
         }
     }

--- a/test/UnitTest/Components/SelectTreeTest.cs
+++ b/test/UnitTest/Components/SelectTreeTest.cs
@@ -190,6 +190,20 @@ public class SelectTreeTest : BootstrapBlazorTestBase
         cut.DoesNotContain("data-bs-toggle=\"dropdown\"");
     }
 
+    [Fact]
+    public void IsActive_Ok()
+    {
+        var items = TreeFoo.GetTreeItems();
+        var cut = Context.RenderComponent<SelectTree<TreeFoo>>(builder =>
+        {
+            builder.Add(p => p.Items, items);
+            builder.Add(p => p.Value, new TreeFoo() { Id = "1020", Text = "Navigation Two" });
+        });
+        var nodes = cut.FindAll(".tree-content");
+        Assert.Equal(3, nodes.Count);
+        Assert.True(nodes[1].ClassName == "tree-content active");
+    }
+
     private List<TreeViewItem<string>> BindItems { get; } =
     [
         new TreeViewItem<string>("Test1")

--- a/test/UnitTest/Components/SelectTreeTest.cs
+++ b/test/UnitTest/Components/SelectTreeTest.cs
@@ -201,7 +201,7 @@ public class SelectTreeTest : BootstrapBlazorTestBase
         });
         var nodes = cut.FindAll(".tree-content");
         Assert.Equal(3, nodes.Count);
-        Assert.True(nodes[1].ClassName == "tree-content active");
+        Assert.Contains("active", nodes[1].ClassName);
     }
 
     private List<TreeViewItem<string>> BindItems { get; } =


### PR DESCRIPTION
# shoud set the default active node by Value on first render

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5001

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where the active node in the SelectTree was not set correctly on the initial render.