### PR TITLE
fix(BootstrapInputNumber): throw exception when NumberDecimalSeparator is comma

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.2.3-beta01</Version>
+    <Version>9.2.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -50,15 +50,24 @@ public static class ObjectExtensions
     /// <returns></returns>
     public static bool IsNumber(this Type t)
     {
-        var separator = CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator;
+        var targetType = Nullable.GetUnderlyingType(t) ?? t;
+        return targetType == typeof(int) || targetType == typeof(long) || targetType == typeof(short) ||
+            targetType == typeof(float) || targetType == typeof(double) || targetType == typeof(decimal);
+    }
+
+    /// <summary>
+    /// 检查是否应该渲染成 <see cref="BootstrapInputNumber{TValue}"/>
+    /// </summary>
+    /// <param name="t"></param>
+    /// <returns></returns>
+    public static bool ShouldRenderInputNumber(this Type t)
+    {
+        var separator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
         if (separator != ".")
         {
             return false;
         }
-
-        var targetType = Nullable.GetUnderlyingType(t) ?? t;
-        return targetType == typeof(int) || targetType == typeof(long) || targetType == typeof(short) ||
-            targetType == typeof(float) || targetType == typeof(double) || targetType == typeof(decimal);
+        return t.IsNumber();
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -60,7 +60,7 @@ public static class ObjectExtensions
     /// </summary>
     /// <param name="t"></param>
     /// <returns></returns>
-    public static bool ShouldRenderInputNumber(this Type t)
+    public static bool IsNumberWithDotSeparator(this Type t)
     {
         var separator = CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator;
         if (separator != ".")

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -638,7 +638,7 @@ public static class Utility
         {
             ret = typeof(NullSwitch);
         }
-        else if (fieldType.ShouldRenderInputNumber())
+        else if (fieldType.IsNumberWithDotSeparator())
         {
             ret = typeof(BootstrapInputNumber<>).MakeGenericType(fieldType);
         }
@@ -704,7 +704,7 @@ public static class Utility
                 ret.Add("rows", item.Rows);
             }
         }
-        else if (type.ShouldRenderInputNumber())
+        else if (type.IsNumberWithDotSeparator())
         {
             if (!string.IsNullOrEmpty(item.Step))
             {

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -638,7 +638,7 @@ public static class Utility
         {
             ret = typeof(NullSwitch);
         }
-        else if (fieldType.IsNumber())
+        else if (fieldType.ShouldRenderInputNumber())
         {
             ret = typeof(BootstrapInputNumber<>).MakeGenericType(fieldType);
         }
@@ -704,7 +704,7 @@ public static class Utility
                 ret.Add("rows", item.Rows);
             }
         }
-        else if (type.IsNumber())
+        else if (type.ShouldRenderInputNumber())
         {
             if (!string.IsNullOrEmpty(item.Step))
             {

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -49,11 +49,13 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
     {
         var culture = new CultureInfo("es-ES");
         CultureInfo.CurrentCulture = culture;
-        Assert.False(typeof(long).IsNumber());
+        Assert.True(typeof(long).IsNumber());
+        Assert.False(typeof(long).IsNumberWithDotSeparator());
 
         culture = new CultureInfo("en-US");
         CultureInfo.CurrentCulture = culture;
         Assert.True(typeof(long).IsNumber());
+        Assert.True(typeof(long).IsNumberWithDotSeparator());
     }
 
     [Theory]

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -48,12 +48,12 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
     public void IsNumber_Culture()
     {
         var culture = new CultureInfo("es-ES");
-        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
         Assert.True(typeof(long).IsNumber());
         Assert.False(typeof(long).IsNumberWithDotSeparator());
 
         culture = new CultureInfo("en-US");
-        CultureInfo.CurrentCulture = culture;
+        CultureInfo.CurrentUICulture = culture;
         Assert.True(typeof(long).IsNumber());
         Assert.True(typeof(long).IsNumberWithDotSeparator());
     }


### PR DESCRIPTION
# throw exception when NumberDecimalSeparator is comma

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5027 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where BootstrapInputNumber would not render correctly when the NumberDecimalSeparator was set to a comma.