### PR TITLE
perf(LocalizerString): use FrozenSet improve performance

### DIFF
--- a/src/BootstrapBlazor.Server/Extensions/CacheManagerExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/CacheManagerExtensions.cs
@@ -21,7 +21,7 @@ internal static class CacheManagerExtensions
     /// <param name="typeName"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public static FrozenSet<LocalizedString> GetLocalizedStrings(this ICacheManager cache, string typeName, JsonLocalizationOptions options)
+    public static IEnumerable<LocalizedString> GetLocalizedStrings(this ICacheManager cache, string typeName, JsonLocalizationOptions options)
     {
         var key = $"Snippet-{CultureInfo.CurrentUICulture.Name}-{nameof(GetLocalizedStrings)}-{typeName}";
         return cache.GetOrCreate(key, entry =>

--- a/src/BootstrapBlazor.Server/Extensions/CacheManagerExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/CacheManagerExtensions.cs
@@ -4,7 +4,6 @@
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
 using Microsoft.Extensions.Caching.Memory;
-using System.Collections.Frozen;
 using System.Globalization;
 
 namespace BootstrapBlazor.Server.Extensions;

--- a/src/BootstrapBlazor.Server/Extensions/CacheManagerExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/CacheManagerExtensions.cs
@@ -4,6 +4,7 @@
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
 using Microsoft.Extensions.Caching.Memory;
+using System.Collections.Frozen;
 using System.Globalization;
 
 namespace BootstrapBlazor.Server.Extensions;
@@ -20,7 +21,7 @@ internal static class CacheManagerExtensions
     /// <param name="typeName"></param>
     /// <param name="options"></param>
     /// <returns></returns>
-    public static IEnumerable<LocalizedString> GetLocalizedStrings(this ICacheManager cache, string typeName, JsonLocalizationOptions options)
+    public static FrozenSet<LocalizedString> GetLocalizedStrings(this ICacheManager cache, string typeName, JsonLocalizationOptions options)
     {
         var key = $"Snippet-{CultureInfo.CurrentUICulture.Name}-{nameof(GetLocalizedStrings)}-{typeName}";
         return cache.GetOrCreate(key, entry =>

--- a/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
@@ -42,7 +42,7 @@ internal static class LocalizationOptionsExtensions
             assemblies.AddRange(option.AdditionalJsonAssemblies);
         }
 
-        var streams = assemblies.SelectMany(i => option.GetResourceStream(i, cultureName));
+        var streams = assemblies.SelectMany(i => option.GetResourceStream(i, cultureName)).ToList();
 
         // 添加 Json 文件流到配置
         foreach (var s in streams)

--- a/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LocalizationOptionsExtensions.cs
@@ -27,16 +27,14 @@ internal static class LocalizationOptionsExtensions
         var builder = new ConfigurationBuilder();
 
         // 获取程序集中的资源文件
-        var assemblies = new List<Assembly>()
-        {
-            assembly
-        };
+        var assemblies = new List<Assembly>() { assembly };
 
         var entryAssembly = GetAssembly();
         if (assembly != entryAssembly)
         {
             assemblies.Add(entryAssembly);
         }
+
         if (option.AdditionalJsonAssemblies != null)
         {
             assemblies.AddRange(option.AdditionalJsonAssemblies);
@@ -120,16 +118,17 @@ internal static class LocalizationOptionsExtensions
 
         // 开启回落机制并且当前文化信息与回落语言相同
         bool EqualFallbackCulture(string name) => option.EnableFallbackCulture && option.FallbackCulture == name;
+    }
 
-        StringSegment GetParentCultureName(StringSegment cultureInfoName)
+    static StringSegment GetParentCultureName(StringSegment cultureInfoName)
+    {
+        var ret = new StringSegment();
+        var index = cultureInfoName.IndexOf('-');
+        if (index > 0)
         {
-            var ret = new StringSegment();
-            var index = cultureInfoName.IndexOf('-');
-            if (index > 0)
-            {
-                ret = cultureInfoName.Subsegment(0, index);
-            }
-            return ret;
+            ret = cultureInfoName.Subsegment(0, index);
         }
+
+        return ret;
     }
 }

--- a/src/BootstrapBlazor/Localization/Json/JsonStringLocalizer.cs
+++ b/src/BootstrapBlazor/Localization/Json/JsonStringLocalizer.cs
@@ -9,10 +9,6 @@ using System.Globalization;
 using System.Reflection;
 using System.Resources;
 
-#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#endif
-
 namespace BootstrapBlazor.Components;
 
 /// <summary>
@@ -101,11 +97,7 @@ internal class JsonStringLocalizer(Assembly assembly, string typeName, string ba
         }
     }
 
-#if NET8_0_OR_GREATER
-    private string? GetValueFromCache(FrozenSet<LocalizedString>? localizerStrings, string name)
-#else
-    private string? GetValueFromCache(HashSet<LocalizedString>? localizerStrings, string name)
-#endif
+    private string? GetValueFromCache(IEnumerable<LocalizedString>? localizerStrings, string name)
     {
         string? ret = null;
         var cultureName = CultureInfo.CurrentUICulture.Name;

--- a/src/BootstrapBlazor/Localization/Json/JsonStringLocalizer.cs
+++ b/src/BootstrapBlazor/Localization/Json/JsonStringLocalizer.cs
@@ -5,7 +5,6 @@
 
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Logging;
-using System.Collections.Concurrent;
 using System.Globalization;
 using System.Reflection;
 using System.Resources;
@@ -28,8 +27,6 @@ internal class JsonStringLocalizer(Assembly assembly, string typeName, string ba
 
     private ILogger Logger { get; } = logger;
 
-    private readonly ConcurrentDictionary<string, LocalizedString> _cache = [];
-
     /// <summary>
     /// 通过指定键值获取多语言值信息索引
     /// </summary>
@@ -39,13 +36,8 @@ internal class JsonStringLocalizer(Assembly assembly, string typeName, string ba
     {
         get
         {
-            if (_cache.TryGetValue(name, out var result) == false)
-            {
-                var value = GetStringSafely(name);
-                result = new LocalizedString(name, value ?? name, resourceNotFound: value == null, searchedLocation: typeName);
-                _cache.TryAdd(name, result);
-            }
-            return result;
+            var value = GetStringSafely(name);
+            return new LocalizedString(name, value ?? name, resourceNotFound: value == null, searchedLocation: typeName);
         }
     }
 
@@ -59,22 +51,23 @@ internal class JsonStringLocalizer(Assembly assembly, string typeName, string ba
     {
         get
         {
-            if (_cache.TryGetValue(name, out var result) == false)
+            var value = SafeFormat();
+            return new LocalizedString(name, value ?? name, resourceNotFound: value == null, searchedLocation: typeName);
+
+            string? SafeFormat()
             {
-                string? value = null;
+                string? ret = null;
                 try
                 {
                     var format = GetStringSafely(name);
-                    value = string.Format(CultureInfo.CurrentCulture, format ?? name, arguments);
+                    ret = string.Format(CultureInfo.CurrentCulture, format ?? name, arguments);
                 }
                 catch (Exception ex)
                 {
                     Logger.LogError(ex, "{JsonStringLocalizerName} searched for '{Name}' in '{typeName}' with culture '{CultureName}' throw exception.", nameof(JsonStringLocalizer), name, typeName, CultureInfo.CurrentUICulture.Name);
                 }
-                result = new LocalizedString(name, value ?? name, resourceNotFound: value == null, searchedLocation: typeName);
-                _cache.TryAdd(name, result);
+                return ret;
             }
-            return result;
         }
     }
 
@@ -107,11 +100,11 @@ internal class JsonStringLocalizer(Assembly assembly, string typeName, string ba
     private string? GetValueFromCache(IEnumerable<LocalizedString>? localizerStrings, string name)
     {
         string? ret = null;
-        var cacheKey = $"{nameof(GetValueFromCache)}&name={name}&{Assembly.GetUniqueName()}&type={typeName}&culture={CultureInfo.CurrentUICulture.Name}";
+        var cultureName = CultureInfo.CurrentUICulture.Name;
+        var cacheKey = $"{nameof(GetValueFromCache)}&name={name}&{Assembly.GetUniqueName()}&type={typeName}&culture={cultureName}";
         if (!CacheManager.GetMissingLocalizerByKey(cacheKey))
         {
-            var l = localizerStrings?.FirstOrDefault(i => i.Name == name)
-                ?? CacheManager.GetAllStringsFromResolve().FirstOrDefault(i => i.Name == name);
+            var l = GetLocalizedString();
             if (l is { ResourceNotFound: false })
             {
                 ret = l.Value;
@@ -123,12 +116,23 @@ internal class JsonStringLocalizer(Assembly assembly, string typeName, string ba
             }
         }
         return ret;
+
+        LocalizedString? GetLocalizedString()
+        {
+            LocalizedString? localizer = null;
+            if (localizerStrings != null)
+            {
+                localizer = localizerStrings.FirstOrDefault(i => i.Name == name);
+            }
+            return localizer ?? CacheManager.GetAllStringsFromResolve().FirstOrDefault(i => i.Name == name);
+        }
     }
 
     private string? GetLocalizerValueFromCache(IStringLocalizer localizer, string name)
     {
         string? ret = null;
-        var cacheKey = $"{nameof(GetLocalizerValueFromCache)}&name={name}&{Assembly.GetUniqueName()}&type={typeName}&culture={CultureInfo.CurrentUICulture.Name}";
+        var cultureName = CultureInfo.CurrentUICulture.Name;
+        var cacheKey = $"{nameof(GetLocalizerValueFromCache)}&name={name}&{Assembly.GetUniqueName()}&type={typeName}&culture={cultureName}";
         if (!CacheManager.GetMissingLocalizerByKey(cacheKey))
         {
             var l = localizer[name];

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -193,7 +193,7 @@ internal class CacheManager : ICacheManager
     {
         IStringLocalizer? ret = null;
         var factories = Instance.Provider.GetServices<IStringLocalizerFactory>();
-        var factory = factories?.LastOrDefault(a => a is not JsonStringLocalizerFactory);
+        var factory = factories.LastOrDefault(a => a is not JsonStringLocalizerFactory);
         if (factory != null)
         {
             var type = assembly.GetType(typeName);

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -223,26 +223,26 @@ internal class CacheManager : ICacheManager
     /// <returns></returns>
     public static IEnumerable<LocalizedString>? GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false)
     {
-        return assembly.IsDynamic ? null : GetJsonStringByTypeName();
-
-        IEnumerable<LocalizedString>? GetJsonStringByTypeName()
+        if (assembly.IsDynamic)
         {
-            cultureName ??= CultureInfo.CurrentUICulture.Name;
-            var key = $"{nameof(GetJsonStringByTypeName)}-{assembly.GetUniqueName()}-{cultureName}";
-            var typeKey = $"{key}-{typeName}";
-            if (forceLoad)
-            {
-                Instance.Cache.Remove(key);
-                Instance.Cache.Remove(typeKey);
-            }
-            return Instance.GetOrCreate(typeKey, entry =>
-            {
-                var sections = Instance.GetOrCreate(key, entry => option.GetJsonStringFromAssembly(assembly, cultureName));
-                return sections.FirstOrDefault(kv => typeName.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))?
-                    .GetChildren()
-                    .SelectMany(kv => new[] { new LocalizedString(kv.Key, kv.Value!, false, typeName) });
-            });
+            return null;
         }
+
+        cultureName ??= CultureInfo.CurrentUICulture.Name;
+        var key = $"{nameof(GetJsonStringByTypeName)}-{assembly.GetUniqueName()}-{cultureName}";
+        var typeKey = $"{key}-{typeName}";
+        if (forceLoad)
+        {
+            Instance.Cache.Remove(key);
+            Instance.Cache.Remove(typeKey);
+        }
+        return Instance.GetOrCreate(typeKey, entry =>
+        {
+            var sections = Instance.GetOrCreate(key, entry => option.GetJsonStringFromAssembly(assembly, cultureName));
+            return sections.FirstOrDefault(kv => typeName.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))?
+                .GetChildren()
+                .SelectMany(kv => new[] { new LocalizedString(kv.Key, kv.Value!, false, typeName) });
+        });
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -210,11 +210,7 @@ internal class CacheManager : ICacheManager
     /// </summary>
     /// <param name="assembly"></param>
     /// <param name="typeName"></param>
-#if NET8_0_OR_GREATER
-    public static FrozenSet<LocalizedString>? GetAllStringsByTypeName(Assembly assembly, string typeName)
-#else
-    public static HashSet<LocalizedString>? GetAllStringsByTypeName(Assembly assembly, string typeName)
-#endif
+    public static IEnumerable<LocalizedString>? GetAllStringsByTypeName(Assembly assembly, string typeName)
         => GetJsonStringByTypeName(GetJsonLocalizationOption(), assembly, typeName, CultureInfo.CurrentUICulture.Name);
 
     /// <summary>
@@ -226,11 +222,7 @@ internal class CacheManager : ICacheManager
     /// <param name="cultureName">cultureName 未空时使用 CultureInfo.CurrentUICulture.Name</param>
     /// <param name="forceLoad">默认 false 使用缓存值 设置 true 时内部强制重新加载</param>
     /// <returns></returns>
-#if NET8_0_OR_GREATER
-    public static FrozenSet<LocalizedString>? GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false)
-#else
-    public static HashSet<LocalizedString>? GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false)
-#endif
+    public static IEnumerable<LocalizedString>? GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false)
     {
         if (assembly.IsDynamic)
         {

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -10,10 +10,6 @@ using System.Data;
 using System.Linq.Expressions;
 using System.Reflection;
 
-#if NET8_0_OR_GREATER
-using System.Collections.Frozen;
-#endif
-
 namespace BootstrapBlazor.Components;
 
 /// <summary>
@@ -160,11 +156,7 @@ public static class Utility
     /// <param name="typeName">类名称</param>
     /// <param name="cultureName">cultureName 未空时使用 CultureInfo.CurrentUICulture.Name</param>
     /// <param name="forceLoad">默认 false 使用缓存值 设置 true 时内部强制重新加载</param>
-#if NET8_0_OR_GREATER
-    public static FrozenSet<LocalizedString> GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false) => CacheManager.GetJsonStringByTypeName(option, assembly, typeName, cultureName, forceLoad) ?? FrozenSet<LocalizedString>.Empty;
-#else
-    public static HashSet<LocalizedString> GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false) => CacheManager.GetJsonStringByTypeName(option, assembly, typeName, cultureName, forceLoad) ?? new HashSet<LocalizedString>();
-#endif
+    public static IEnumerable<LocalizedString> GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false) => CacheManager.GetJsonStringByTypeName(option, assembly, typeName, cultureName, forceLoad) ?? [];
 
     /// <summary>
     /// 通过指定程序集与类型获得 IStringLocalizer 实例

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -10,6 +10,10 @@ using System.Data;
 using System.Linq.Expressions;
 using System.Reflection;
 
+#if NET8_0_OR_GREATER
+using System.Collections.Frozen;
+#endif
+
 namespace BootstrapBlazor.Components;
 
 /// <summary>
@@ -156,8 +160,11 @@ public static class Utility
     /// <param name="typeName">类名称</param>
     /// <param name="cultureName">cultureName 未空时使用 CultureInfo.CurrentUICulture.Name</param>
     /// <param name="forceLoad">默认 false 使用缓存值 设置 true 时内部强制重新加载</param>
-    /// <returns></returns>
-    public static IEnumerable<LocalizedString> GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false) => CacheManager.GetJsonStringByTypeName(option, assembly, typeName, cultureName, forceLoad) ?? [];
+#if NET8_0_OR_GREATER
+    public static FrozenSet<LocalizedString> GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false) => CacheManager.GetJsonStringByTypeName(option, assembly, typeName, cultureName, forceLoad) ?? FrozenSet<LocalizedString>.Empty;
+#else
+    public static HashSet<LocalizedString> GetJsonStringByTypeName(JsonLocalizationOptions option, Assembly assembly, string typeName, string? cultureName = null, bool forceLoad = false) => CacheManager.GetJsonStringByTypeName(option, assembly, typeName, cultureName, forceLoad) ?? new HashSet<LocalizedString>();
+#endif
 
     /// <summary>
     /// 通过指定程序集与类型获得 IStringLocalizer 实例
@@ -367,7 +374,7 @@ public static class Utility
         return defaultOrderCallback?.Invoke(cols) ?? cols;
     }
 
-    internal static IEnumerable<ITableColumn> OrderFunc(this IEnumerable<ITableColumn> cols) => cols
+    internal static IEnumerable<ITableColumn> OrderFunc(this List<ITableColumn> cols) => cols
         .Where(a => a.Order > 0).OrderBy(a => a.Order)
         .Concat(cols.Where(a => a.Order == 0))
         .Concat(cols.Where(a => a.Order < 0).OrderBy(a => a.Order));
@@ -404,7 +411,6 @@ public static class Utility
                 builder.AddAttribute(50, "class", col.CssClass);
             }
             builder.AddMultipleAttributes(60, item.ComponentParameters);
-            builder.CloseComponent();
         }
         else if (item.ComponentType == typeof(Textarea) || item.Rows > 0)
         {
@@ -422,7 +428,6 @@ public static class Utility
                 builder.AddAttribute(60, "class", col.CssClass);
             }
             builder.AddMultipleAttributes(70, item.ComponentParameters);
-            builder.CloseComponent();
         }
         else
         {
@@ -448,8 +453,9 @@ public static class Utility
                 builder.AddAttribute(90, "class", col.CssClass);
             }
             builder.AddMultipleAttributes(100, item.ComponentParameters);
-            builder.CloseComponent();
         }
+
+        builder.CloseComponent();
     }
 
     /// <summary>

--- a/test/UnitTest/Performance/CacheTest.cs
+++ b/test/UnitTest/Performance/CacheTest.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.Extensions.Localization;
 using System.Collections.Concurrent;
+using System.Collections.Frozen;
 using System.Diagnostics;
 
 namespace UnitTest.Performance;
@@ -52,6 +53,35 @@ public class CacheTest : BootstrapBlazorTestBase
 
         IEnumerable<Foo> CacheMethod() => cache.GetOrAdd("test", key => NoCacheMethod());
     }
+
+    [Fact]
+    public void List_Perf()
+    {
+        var listItms = GetListLocalizedStrings();
+        var setItems = GetSetLocalizedStrings();
+        var frozenItems = GetFrozenLocalizedStrings();
+
+        var sw = Stopwatch.StartNew();
+        listItms.FirstOrDefault(i => i.Name == "500000");
+        sw.Stop();
+        var sp1 = sw.Elapsed;
+
+        sw.Restart();
+        setItems.FirstOrDefault(i => i.Name == "500000");
+        sw.Stop();
+        var sp2 = sw.Elapsed;
+
+        sw.Restart();
+        frozenItems.FirstOrDefault(i => i.Name == "500000");
+        sw.Stop();
+        var sp3 = sw.Elapsed;
+    }
+
+    private IEnumerable<LocalizedString> GetListLocalizedStrings() => Enumerable.Range(1, 1000000).Select(i => new LocalizedString($"{i}", $"{i}", false, nameof(CacheTest)));
+
+    private IEnumerable<LocalizedString> GetSetLocalizedStrings() => Enumerable.Range(1, 1000000).Select(i => new LocalizedString($"{i}", $"{i}", false, nameof(CacheTest))).ToHashSet();
+
+    private IEnumerable<LocalizedString> GetFrozenLocalizedStrings() => Enumerable.Range(1, 1000000).Select(i => new LocalizedString($"{i}", $"{i}", false, nameof(CacheTest))).ToFrozenSet();
 
     private IEnumerable<Foo> NoCacheMethod() => Enumerable.Range(1, 80).Select(i => new Foo()
     {


### PR DESCRIPTION
# use FrozenSet improve performance

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5033 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve the performance of LocalizerString by using FrozenSet.

New Features:
- Add a new API to get all localized strings from a service.

Enhancements:
- Use FrozenSet to improve the performance of LocalizerString.