### PR TITLE
feat(SweetAlert): support trigger OnCloseAsync when set IsAutoHide to true

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.2.4-beta01</Version>
+    <Version>9.2.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/SweetAlert/SwalOption.cs
+++ b/src/BootstrapBlazor/Components/SweetAlert/SwalOption.cs
@@ -102,7 +102,7 @@ public class SwalOption : PopupOptionBase
     public Func<Task>? OnConfirmAsync { get; set; }
 
     /// <summary>
-    /// 
+    /// 构造函数
     /// </summary>
     public SwalOption()
     {

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.cs
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.cs
@@ -93,6 +93,11 @@ public partial class SweetAlert : IAsyncDisposable
                     }
                     await Task.Delay(Delay, DelayToken.Token);
                     await ModalContainer.Close();
+
+                    if (OnCloseCallbackAsync != null)
+                    {
+                        await OnCloseCallbackAsync();
+                    }
                 }
                 catch (TaskCanceledException) { }
             }
@@ -100,6 +105,8 @@ public partial class SweetAlert : IAsyncDisposable
     }
 
     private bool AutoHideCheck() => IsAutoHide && Delay > 0;
+
+    private Func<Task>? OnCloseCallbackAsync = null;
 
     private async Task Show(SwalOption option)
     {
@@ -121,6 +128,8 @@ public partial class SweetAlert : IAsyncDisposable
             parameters.Add(nameof(ModalDialog.BodyTemplate), BootstrapDynamicComponent.CreateComponent<SweetAlertBody>(option.Parse()).Render());
 
             DialogParameter = parameters;
+
+            OnCloseCallbackAsync = AutoHideCheck() ? option.OnCloseAsync : null;
 
             // 渲染 UI 准备弹窗 Dialog
             await InvokeAsync(StateHasChanged);

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.cs
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.cs
@@ -88,6 +88,7 @@ public partial class SweetAlert : IAsyncDisposable
                 {
                     if (DelayToken.IsCancellationRequested)
                     {
+                        DelayToken.Dispose();
                         DelayToken = new();
                     }
                     await Task.Delay(Delay, DelayToken.Token);

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetContext.cs
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetContext.cs
@@ -16,9 +16,5 @@ internal class SweetContext
     /// 获得/设置 弹窗任务上下文
     /// </summary>
     [NotNull]
-#if NET7_0_OR_GREATER
-    public required TaskCompletionSource<bool>? ConfirmTask { get; init; }
-#else
-    public TaskCompletionSource<bool>? ConfirmTask { get; set; }
-#endif
+    public TaskCompletionSource<bool>? ConfirmTask { get; init; }
 }

--- a/test/UnitTest/Components/SwalTest.cs
+++ b/test/UnitTest/Components/SwalTest.cs
@@ -271,7 +271,11 @@ public class SwalTest : BootstrapBlazorTestBase
             Content = "I am auto hide",
             IsAutoHide = true,
             ForceDelay = true,
-            Delay = 500
+            Delay = 500,
+            OnCloseAsync = () =>
+            {
+                return Task.CompletedTask;
+            }
         }));
         Thread.Sleep(150);
         // 弹窗显示


### PR DESCRIPTION
# support trigger OnCloseAsync when set IsAutoHide to true

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5035 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Allow SweetAlert to trigger OnCloseAsync callback when IsAutoHide is set to true.

New Features:
- Added support for triggering the OnCloseAsync callback when the SweetAlert is configured to auto-hide.

Tests:
- Added a test case to verify the new functionality.