### PR TITLE
refactor(ScrollIntoView): use nearest value instead of center

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesSelection.razor.js
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesSelection.razor.js
@@ -1,12 +1,9 @@
 ﻿export function scroll(id) {
     const element = document.getElementById(id);
     if (element) {
-        const selectedRow = element.querySelector('.form-check.is-checked');
+        const selectedRow = element.querySelector('tr.active');
         if (selectedRow) {
-            const row = selectedRow.closest('tr');
-            if (row) {
-                row.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            }
+            selectedRow.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
     }
 }

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.2.5-beta01</Version>
+    <Version>9.2.5-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -26,7 +26,6 @@ export function init(id, invoke) {
     if (duration > 0) {
         ac.debounce = true
         EventHandler.on(input, 'keyup', debounce(e => {
-            e.preventDefault();
             handlerKeyup(ac, e);
         }, duration, e => {
             return ['ArrowUp', 'ArrowDown', 'Escape', 'Enter', 'NumpadEnter'].indexOf(e.key) > -1
@@ -34,8 +33,6 @@ export function init(id, invoke) {
     }
     else {
         EventHandler.on(input, 'keyup', e => {
-            e.stopPropagation();
-            e.preventDefault();
             handlerKeyup(ac, e);
         })
     }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -26,6 +26,7 @@ export function init(id, invoke) {
     if (duration > 0) {
         ac.debounce = true
         EventHandler.on(input, 'keyup', debounce(e => {
+            e.preventDefault();
             handlerKeyup(ac, e);
         }, duration, e => {
             return ['ArrowUp', 'ArrowDown', 'Escape', 'Enter', 'NumpadEnter'].indexOf(e.key) > -1
@@ -33,6 +34,8 @@ export function init(id, invoke) {
     }
     else {
         EventHandler.on(input, 'keyup', e => {
+            e.stopPropagation();
+            e.preventDefault();
             handlerKeyup(ac, e);
         })
     }
@@ -127,24 +130,10 @@ const handlerKeyup = (ac, e) => {
         else if (index > items.length - 1) {
             index = 0;
         }
-        items[index].classList.add('active');
-        const top = getTop(menu, index);
-        const hehavior = el.getAttribute('data-bb-scroll-behavior') ?? 'smooth';
-        menu.scrollTo({ top: top, left: 0, behavior: hehavior });
+        current = items[index];
+        current.classList.add('active');
+        scrollIntoView(el, current);
     }
-}
-
-const getTop = (menu, index) => {
-    const styles = getComputedStyle(menu)
-    const maxHeight = parseInt(styles.maxHeight) / 2
-    const itemHeight = getHeight(menu.querySelector('.dropdown-item'))
-    const height = itemHeight * index
-    const count = Math.floor(maxHeight / itemHeight);
-    let top = 0;
-    if (height > maxHeight) {
-        top = itemHeight * (index > count ? index - count : index)
-    }
-    return top;
 }
 
 export function showList(id) {
@@ -175,6 +164,11 @@ export function dispose(id) {
         EventHandler.off(menu, 'click');
         Input.dispose(input);
     }
+}
+
+const scrollIntoView = (el, item) => {
+    const behavior = el.getAttribute('data-bb-scroll-behavior') ?? 'smooth';
+    item.scrollIntoView({ behavior: behavior, block: "nearest", inline: "start" });
 }
 
 export { handleKeyUp, select, selectAllByFocus, selectAllByEnter }

--- a/src/BootstrapBlazor/Components/Select/Select.razor.js
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.js
@@ -141,5 +141,5 @@ function indexOf(el, element) {
 
 const scrollIntoView = (el, item) => {
     const behavior = el.getAttribute('data-bb-scroll-behavior') ?? 'smooth';
-    item.scrollIntoView({ behavior: behavior, block: "center", inline: "nearest" });
+    item.scrollIntoView({ behavior: behavior, block: "nearest", inline: "start" });
 }

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -258,7 +258,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     public bool EnableKeyboard { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否键盘上下键操作当前选中节点与视窗关系配置 默认 null 使用 { behavior: "smooth", block: "center", inline: "nearest" }
+    /// 获得/设置 是否键盘上下键操作当前选中节点与视窗关系配置 默认 null 使用 { behavior: "smooth", block: "nearest", inline: "nearest" }
     /// </summary>
     [Parameter]
     public ScrollIntoViewOptions? ScrollIntoViewOptions { get; set; }

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -258,7 +258,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     public bool EnableKeyboard { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否键盘上下键操作当前选中节点与视窗关系配置 默认 null 使用 { behavior: "smooth", block: "nearest", inline: "nearest" }
+    /// 获得/设置 是否键盘上下键操作当前选中节点与视窗关系配置 默认 null 使用 { behavior: "smooth", block: "nearest", inline: "start" }
     /// </summary>
     [Parameter]
     public ScrollIntoViewOptions? ScrollIntoViewOptions { get; set; }

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.js
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.js
@@ -32,7 +32,7 @@ export function scroll(id, options) {
     const el = document.getElementById(id);
     const item = el.querySelector(".tree-content.active");
     if (item) {
-        item.scrollIntoView(options ?? { behavior: 'smooth', block: 'start', inline: 'nearest' });
+        item.scrollIntoView(options ?? { behavior: 'smooth', block: 'nearest', inline: 'start' });
     }
 }
 


### PR DESCRIPTION
# use nearest value instead of center

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5048 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Improve the scrolling behavior in several components, including AutoComplete, Table, Select, and TreeView, by using "nearest" instead of "center" for vertical alignment.