### PR TITLE
fix(Layout): add media query for overflow style 

### DIFF
--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
@@ -200,11 +200,6 @@
             transform: translateX(0);
         }
 
-        .layout-right {
-            overflow: hidden;
-            height: var(--bb-layout-height);
-        }
-
         .layout-footer {
             display: none;
         }
@@ -257,6 +252,13 @@
 .has-sidebar {
     flex-direction: row;
     display: flex;
+}
+
+@media (max-width: 767.99px) {
+    .layout.is-collapsed .layout-right {
+        overflow: hidden;
+        height: var(--bb-layout-height);
+    }
 }
 
 @media(min-width: 768px) {


### PR DESCRIPTION
# add media query for overflow style 

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5050 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a media query to apply overflow style to the layout right section only on smaller screens (max-width 767.99px).

Bug Fixes:
- Fixes an issue where the overflow style was not being applied correctly on smaller screens.

Enhancements:
- Improves layout responsiveness by using media queries.