### PR TITLE
feat(MultiSelect):  add IsEditable parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/MultiSelects.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/MultiSelects.razor
@@ -5,6 +5,17 @@
 
 <h4>@Localizer["MultiSelectsDescription"]</h4>
 
+<DemoBlock Title="@Localizer["MultiSelectIsEditableTitle"]" Introduction="@Localizer["MultiSelectIsEditableIntro"]" Name="IsEditable">
+    <section ignore>
+        @((MarkupString)Localizer["MultiSelectIsEditableDescription"].Value)
+    </section>
+    <div class="row g-3">
+        <div class="col-12">
+            <MultiSelect TValue="string" Items="@EditableItems" IsEditable="true" EditSubmitKey="EditSubmitKey.Space" />
+        </div>
+    </div>
+</DemoBlock>
+
 <DemoBlock Title="@Localizer["MultiSelectColorTitle"]" Introduction="@Localizer["MultiSelectColorIntro"]" Name="Color">
     <div class="row g-3">
         <div class="col-12 col-sm-6">

--- a/src/BootstrapBlazor.Server/Components/Samples/MultiSelects.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/MultiSelects.razor
@@ -5,17 +5,6 @@
 
 <h4>@Localizer["MultiSelectsDescription"]</h4>
 
-<DemoBlock Title="@Localizer["MultiSelectIsEditableTitle"]" Introduction="@Localizer["MultiSelectIsEditableIntro"]" Name="IsEditable">
-    <section ignore>
-        @((MarkupString)Localizer["MultiSelectIsEditableDescription"].Value)
-    </section>
-    <div class="row g-3">
-        <div class="col-12">
-            <MultiSelect TValue="string" Items="@EditableItems" IsEditable="true" EditSubmitKey="EditSubmitKey.Space" />
-        </div>
-    </div>
-</DemoBlock>
-
 <DemoBlock Title="@Localizer["MultiSelectColorTitle"]" Introduction="@Localizer["MultiSelectColorIntro"]" Name="Color">
     <div class="row g-3">
         <div class="col-12 col-sm-6">
@@ -249,6 +238,17 @@
     <div class="row">
         <div class="col-12 col-sm-6 overflow-hidden">
             <MultiSelect TValue="string" Items="@Items" IsPopover="true" ShowSearch="true" ShowToolbar />
+        </div>
+    </div>
+</DemoBlock>
+
+<DemoBlock Title="@Localizer["MultiSelectIsEditableTitle"]" Introduction="@Localizer["MultiSelectIsEditableIntro"]" Name="IsEditable">
+    <section ignore>
+        @((MarkupString)Localizer["MultiSelectIsEditableDescription"].Value)
+    </section>
+    <div class="row g-3">
+        <div class="col-12">
+            <MultiSelect TValue="string" Items="@EditableItems" IsEditable="true" Max="2" EditSubmitKey="EditSubmitKey.Space" />
         </div>
     </div>
 </DemoBlock>

--- a/src/BootstrapBlazor.Server/Components/Samples/MultiSelects.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/MultiSelects.razor.cs
@@ -20,6 +20,9 @@ public partial class MultiSelects
     private Foo Foo { get; set; } = new Foo();
 
     [NotNull]
+    private List<SelectedItem>? EditableItems { get; set; }
+
+    [NotNull]
     private List<SelectedItem>? Items1 { get; set; }
 
     [NotNull]
@@ -129,6 +132,7 @@ public partial class MultiSelects
         Items7 = GenerateItems();
         Items8 = GenerateItems();
         TemplateItems = GenerateItems();
+        EditableItems = GenerateItems();
 
         // 初始化数据
         DataSource =

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2987,7 +2987,10 @@
     "MultiSelectMaxMinMin": "Select at least two options",
     "MultiSelectSearchLog": "Search for text",
     "MultiSelectVeryLongTextDisplayText": "Extra long text",
-    "MultiSelectOptionChangeLog": "Select the collection of items"
+    "MultiSelectOptionChangeLog": "Select the collection of items",
+    "MultiSelectIsEditableTitle": "Editable",
+    "MultiSelectIsEditableIntro": "Make the component editable by setting the <code>IsEditable</code> parameter",
+    "MultiSelectIsEditableDescription": "By setting the <code>EditSubmitKey</code> parameter, you can specify whether to submit via <kbd>Enter</kbd> or <kbd>Space</kbd>"
   },
   "BootstrapBlazor.Server.Components.Samples.Radios": {
     "RadiosTitle": "Radio",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2987,7 +2987,10 @@
     "MultiSelectMaxMinMin": "最少选择两个选项",
     "MultiSelectSearchLog": "搜索文字",
     "MultiSelectVeryLongTextDisplayText": "超长文字",
-    "MultiSelectOptionChangeLog": "选中项集合"
+    "MultiSelectOptionChangeLog": "选中项集合",
+    "MultiSelectIsEditableTitle": "可编辑",
+    "MultiSelectIsEditableIntro": "通过设置 <code>IsEditable</code> 参数，使组件可编辑",
+    "MultiSelectIsEditableDescription": "通过设置 <code>EditSubmitKey</code> 参数可以指定通过 <kbd>Enter</kbd> 还是 <kbd>Space</kbd> 进行提交"
   },
   "BootstrapBlazor.Server.Components.Samples.Radios": {
     "RadiosTitle": "Radio 单选框",

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -35,7 +35,7 @@
                     }
                 }
             }
-            @if (IsEditable)
+            @if (CheckCanEdit())
             {
                 <input type="text" class="multi-select-input" autocomplete="off" tabindex="0" data-bb-trigger-key="@EditSubmitKeyString" />
             }

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -35,6 +35,10 @@
                     }
                 }
             }
+            @if (IsEditable)
+            {
+                <input type="text" class="multi-select-input" autocomplete="off" tabindex="0" data-bb-trigger-key="@EditSubmitKeyString" />
+            }
         </div>
         @if (!IsSingleLine)
         {

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -9,7 +9,10 @@
 }
 <div @attributes="@AdditionalAttributes" class="@ClassString" id="@Id">
     <div class="@ToggleClassString" data-bs-toggle="@ToggleString" data-bs-placement="@PlacementString" data-bs-offset="@OffsetString" data-bs-auto-close="outside" data-bs-custom-class="@CustomClassString" tabindex="0">
-        <div class="@PlaceHolderClassString">@PlaceHolder</div>
+        @if(!CheckCanEdit())
+        {
+            <div class="@PlaceHolderClassString">@PlaceHolder</div>
+        }
         <div class="multi-select-items">
             @if (DisplayTemplate != null)
             {
@@ -37,7 +40,7 @@
             }
             @if (CheckCanEdit())
             {
-                <input type="text" class="multi-select-input" autocomplete="off" tabindex="0" data-bb-trigger-key="@EditSubmitKeyString" />
+                <input type="text" class="multi-select-input" autocomplete="off" tabindex="0" placeholder="@PlaceholderString" data-bb-trigger-key="@EditSubmitKeyString" />
             }
         </div>
         @if (!IsSingleLine)

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -193,6 +193,8 @@ public partial class MultiSelect<TValue>
 
     private string? PreviousValue { get; set; }
 
+    private string? PlaceholderString => SelectedItems.Count == 0 ? PlaceHolder : null;
+
     /// <summary>
     /// OnParametersSet 方法
     /// </summary>

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -18,6 +18,8 @@ public partial class MultiSelect<TValue>
     private static string? ClassString => CssBuilder.Default("select dropdown multi-select")
         .Build();
 
+    private string? EditSubmitKeyString => EditSubmitKey == EditSubmitKey.Space ? EditSubmitKey.ToDescriptionString() : null;
+
     private string? ToggleClassString => CssBuilder.Default("dropdown-toggle scroll")
         .AddClass($"border-{Color.ToDescriptionString()}", Color != Color.None && !IsDisabled)
         .AddClass("is-fixed", IsFixedHeight)
@@ -85,6 +87,26 @@ public partial class MultiSelect<TValue>
     /// </summary>
     [Parameter]
     public bool IsSingleLine { get; set; }
+
+    /// <summary>
+    /// 获得/设置 是否可编辑 默认 false
+    /// </summary>
+    [Parameter]
+    public bool IsEditable { get; set; }
+
+    /// <summary>
+    /// 获得/设置 编辑模式下输入选项更新后回调方法 默认 null
+    /// <para>返回 true 时输入选项生效，返回 false 时选项不生效进行舍弃操作，建议在回调方法中自行提示</para>
+    /// </summary>
+    /// <remarks>设置 <see cref="IsEditable"/> 后生效</remarks>
+    [Parameter]
+    public Func<string, Task<bool>>? OnEditCallback { get; set; }
+
+    /// <summary>
+    /// 获得/设置 编辑提交按键 默认 Enter
+    /// </summary>
+    [Parameter]
+    public EditSubmitKey EditSubmitKey { get; set; }
 
     /// <summary>
     /// 获得/设置 扩展按钮模板
@@ -254,6 +276,27 @@ public partial class MultiSelect<TValue>
             }
 
             _isToggle = true;
+            // 更新选中值
+            await SetValue();
+        }
+    }
+
+    /// <summary>
+    /// 客户端编辑提交数据回调方法
+    /// </summary>
+    /// <param name="val"></param>
+    /// <returns></returns>
+    [JSInvokable]
+    public async Task TriggerEditTag(string val)
+    {
+        var ret = true;
+        if (OnEditCallback != null)
+        {
+            ret = await OnEditCallback.Invoke(val);
+        }
+
+        if (ret)
+        {
             // 更新选中值
             await SetValue();
         }

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -298,14 +298,15 @@ public partial class MultiSelect<TValue>
         else if (!string.IsNullOrEmpty(val))
         {
             ret = GetData().Find(i => i.Text.Equals(val, StringComparison.OrdinalIgnoreCase)) ?? new SelectedItem(val, val);
+        }
+        if (ret != null)
+        {
             if (SelectedItems.Find(i => i.Text.Equals(val, StringComparison.OrdinalIgnoreCase)) == null)
             {
                 SelectedItems.Add(ret);
             }
-        }
-        if (ret != null)
-        {
             // 更新选中值
+            _isToggle = true;
             await SetValue();
         }
         return ret != null;
@@ -440,6 +441,21 @@ public partial class MultiSelect<TValue>
             ret = CheckCanTrigger(item);
         }
         return !ret;
+    }
+
+    private bool CheckCanEdit()
+    {
+        var ret = IsEditable;
+        if (ret == false)
+        {
+            return false;
+        }
+
+        if (Max > 0)
+        {
+            ret = SelectedItems.Count < Max;
+        }
+        return ret;
     }
 
     private List<SelectedItem> GetData()

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.js
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.js
@@ -23,10 +23,6 @@ export function init(id, invoke, method) {
         popover
     }
 
-    EventHandler.on(itemsElement, 'change', '.multi-select-input', e => {
-        invoke.invokeMethodAsync('TriggerEditTag', e.target.value)
-    });
-
     EventHandler.on(itemsElement, 'click', '.multi-select-input', e => {
         const handler = setTimeout(() => {
             clearTimeout(handler);
@@ -34,10 +30,21 @@ export function init(id, invoke, method) {
         }, 50);
     });
 
-    EventHandler.on(itemsElement, 'keyup', '.multi-select-input', e => {
-        const key = e.target.getAttribute('data-bb-trigger-key');
-        if (key === 'space') {
-            invoke.invokeMethodAsync('TriggerEditTag', e.target.value)
+    EventHandler.on(itemsElement, 'keyup', '.multi-select-input', async e => {
+        const triggerSpace = e.target.getAttribute('data-bb-trigger-key') === 'space';
+        let submit = false;
+        if (triggerSpace && e.code === 'Space') {
+            submit = true;
+        }
+        else if (e.code === 'Enter' || e.code === 'NumPadEnter') {
+            submit = true;
+        }
+
+        if (submit) {
+            const ret = await invoke.invokeMethodAsync('TriggerEditTag', e.target.value);
+            if (ret) {
+                e.target.value = '';
+            }
         }
     });
 

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.js
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.js
@@ -33,8 +33,10 @@ export function init(id, invoke, method) {
     EventHandler.on(itemsElement, 'keyup', '.multi-select-input', async e => {
         const triggerSpace = e.target.getAttribute('data-bb-trigger-key') === 'space';
         let submit = false;
-        if (triggerSpace && e.code === 'Space') {
-            submit = true;
+        if (triggerSpace) {
+            if (e.code === 'Space') {
+                submit = true;
+            }
         }
         else if (e.code === 'Enter' || e.code === 'NumPadEnter') {
             submit = true;

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.js
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.js
@@ -10,20 +10,39 @@ export function init(id, invoke, method) {
         return
     }
 
+    const itemsElement = el.querySelector('.multi-select-items');
     const popover = Popover.init(el, {
-        itemsElement: el.querySelector('.multi-select-items'),
+        itemsElement,
         closeButtonSelector: '.multi-select-close'
     })
 
     const ms = {
         el, invoke, method,
-        itemsElement: el.querySelector('.multi-select-items'),
+        itemsElement,
         closeButtonSelector: '.multi-select-close',
         popover
     }
 
+    EventHandler.on(itemsElement, 'change', '.multi-select-input', e => {
+        invoke.invokeMethodAsync('TriggerEditTag', e.target.value)
+    });
+
+    EventHandler.on(itemsElement, 'click', '.multi-select-input', e => {
+        const handler = setTimeout(() => {
+            clearTimeout(handler);
+            e.target.focus();
+        }, 50);
+    });
+
+    EventHandler.on(itemsElement, 'keyup', '.multi-select-input', e => {
+        const key = e.target.getAttribute('data-bb-trigger-key');
+        if (key === 'space') {
+            invoke.invokeMethodAsync('TriggerEditTag', e.target.value)
+        }
+    });
+
     if (!ms.popover.isPopover) {
-        EventHandler.on(ms.itemsElement, 'click', ms.closeButtonSelector, () => {
+        EventHandler.on(itemsElement, 'click', ms.closeButtonSelector, () => {
             const dropdown = bootstrap.Dropdown.getInstance(popover.toggleElement)
             if (dropdown && dropdown._isShown()) {
                 dropdown.hide()

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.scss
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.scss
@@ -101,6 +101,18 @@
         line-height: var(--bb-height);
         position: absolute;
     }
+
+    .multi-select-input {
+        border: none;
+        outline: none;
+        appearance: none;
+        padding: 0;
+        background-color: transparent;
+        flex: 1;
+        width: 1%;
+        min-width: 1rem;
+        margin-block-end: var(--bb-multi-select-item-margin-y);
+    }
 }
 
 .dropdown-menu .toolbar {

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.scss
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.scss
@@ -5,8 +5,8 @@
     --bb-multi-select-button-hover-bg-color: rgba(var(--bs-body-color-rgb), .3);
     --bb-multi-select-item-margin-x: 3px;
     --bb-multi-select-item-margin-y: 3px;
-    --bb-multi-select-item-padding: 2px 6px;
     --bb-multi-select-item-max-width: 130px;
+    --bb-multi-select-item-padding: 2px 6px;
     width: 100%;
     position: relative;
 
@@ -81,6 +81,10 @@
         .multi-select-item-group {
             display: inline-flex;
             position: relative;
+
+            + .multi-select-input {
+                padding: 3px 6px;
+            }
         }
 
         .multi-select-close {
@@ -106,7 +110,7 @@
         border: none;
         outline: none;
         appearance: none;
-        padding: 0;
+        padding: 3px 12px;
         background-color: transparent;
         flex: 1;
         width: 1%;

--- a/src/BootstrapBlazor/Enums/EditSubmitKey.cs
+++ b/src/BootstrapBlazor/Enums/EditSubmitKey.cs
@@ -1,0 +1,26 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using System.ComponentModel;
+
+namespace BootstrapBlazor.Components;
+
+/// <summary>
+/// EditSubmitKeys 枚举
+/// </summary>
+public enum EditSubmitKey
+{
+    /// <summary>
+    /// Enter 键
+    /// </summary>
+    [Description("enter")]
+    Enter,
+
+    /// <summary>
+    /// Space 键
+    /// </summary>
+    [Description("space")]
+    Space
+}

--- a/test/UnitTest/Components/MultiSelectTest.cs
+++ b/test/UnitTest/Components/MultiSelectTest.cs
@@ -34,6 +34,54 @@ public class MultiSelectTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task IsEditable_Ok()
+    {
+        var cut = Context.RenderComponent<MultiSelect<string>>(pb =>
+        {
+            pb.Add(a => a.Max, 2);
+            pb.Add(a => a.Items, new List<SelectedItem>
+            {
+                new("1", "Test 1"),
+                new("2", "Test 2"),
+                new("3", "Test 3"),
+                new("4", "Test 4"),
+            });
+        });
+        Assert.DoesNotContain("class=\"multi-select-input\"", cut.Markup);
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.IsEditable, true);
+        });
+        Assert.Contains("class=\"multi-select-input\"", cut.Markup);
+        Assert.DoesNotContain("data-bb-trigger-key", cut.Markup);
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.EditSubmitKey, EditSubmitKey.Space);
+        });
+        Assert.Contains("data-bb-trigger-key=\"space\"", cut.Markup);
+
+        await cut.InvokeAsync(() => cut.Instance.TriggerEditTag("123"));
+        Assert.Equal("123", cut.Instance.Value);
+
+        await cut.InvokeAsync(() => cut.Instance.TriggerEditTag("123"));
+        Assert.Equal("123", cut.Instance.Value);
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.OnEditCallback, async v =>
+            {
+                await Task.Delay(10);
+                return new SelectedItem("test", "456");
+            });
+        });
+        await cut.InvokeAsync(() => cut.Instance.TriggerEditTag("456"));
+        Assert.Equal("123,test", cut.Instance.Value);
+        Assert.DoesNotContain("class=\"multi-select-input\"", cut.Markup);
+    }
+
+    [Fact]
     public void IsFixedHeight_Ok()
     {
         var cut = Context.RenderComponent<MultiSelect<EnumEducation>>(pb =>


### PR DESCRIPTION
# add IsEditable parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5067 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add an `IsEditable` parameter to the `MultiSelect` component to allow users to input custom values.

New Features:
- Added an `IsEditable` parameter to the `MultiSelect` component. When set to `true`, it allows users to type and submit custom values, which are then added to the selected items.

Tests:
- Added unit tests for the new `IsEditable` parameter of the `MultiSelect` component.