### PR TITLE
fix(CacheManager): GetJsonStringByTypeName prevent throw ArgumentNull exception

### DIFF
--- a/src/BootstrapBlazor/Localization/Json/JsonLocalizationOptions.cs
+++ b/src/BootstrapBlazor/Localization/Json/JsonLocalizationOptions.cs
@@ -44,6 +44,11 @@ public class JsonLocalizationOptions : LocalizationOptions
     public bool IgnoreLocalizerMissing { get; set; }
 
     /// <summary>
+    /// 获得/设置 如果 Value 值为 null 时使用 Key 代替 默认 false 触发异常
+    /// </summary>
+    public bool UseKeyWhenValueIsNull { get; set; }
+
+    /// <summary>
     /// 获得/设置 资源文件是否热加载 默认 false
     /// </summary>
     public bool ReloadOnChange { get; set; }

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -234,9 +234,9 @@ internal class CacheManager : ICacheManager
             Instance.Cache.Remove(key);
             Instance.Cache.Remove(typeKey);
         }
-        return Instance.GetOrCreate(typeKey, entry =>
+        return Instance.GetOrCreate(typeKey, _ =>
         {
-            var sections = Instance.GetOrCreate(key, entry => option.GetJsonStringFromAssembly(assembly, cultureName));
+            var sections = Instance.GetOrCreate(key, _ => option.GetJsonStringFromAssembly(assembly, cultureName));
             var items = sections.FirstOrDefault(kv => typeName.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))?
                 .GetChildren()
                 .SelectMany(kv => new[] { new LocalizedString(kv.Key, kv.Value?? kv.Key, false, typeName) });

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -152,10 +152,7 @@ internal class CacheManager : ICacheManager
                 entry.SetDynamicAssemblyPolicy(type);
                 return LambdaExtensions.CountLambda(type).Compile();
             });
-            if (invoker != null)
-            {
-                ret = invoker(value);
-            }
+            ret = invoker(value);
         }
         return ret;
     }

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -246,7 +246,7 @@ internal class CacheManager : ICacheManager
                     {
                         value = kv.Key;
                     }
-                    return new LocalizedString(kv.Key, value!, false, typeName);
+                    return new LocalizedString(kv.Key, value ?? "", false, typeName);
                 });
 #if NET8_0_OR_GREATER
             return items?.ToFrozenSet();

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -242,7 +242,7 @@ internal class CacheManager : ICacheManager
             var sections = Instance.GetOrCreate(key, entry => option.GetJsonStringFromAssembly(assembly, cultureName));
             var items = sections.FirstOrDefault(kv => typeName.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))?
                 .GetChildren()
-                .SelectMany(kv => new[] { new LocalizedString(kv.Key, kv.Value!, false, typeName) });
+                .SelectMany(kv => new[] { new LocalizedString(kv.Key, kv.Value?? kv.Key, false, typeName) });
 #if NET8_0_OR_GREATER
             return items?.ToFrozenSet();
 #else

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -239,7 +239,15 @@ internal class CacheManager : ICacheManager
             var sections = Instance.GetOrCreate(key, _ => option.GetJsonStringFromAssembly(assembly, cultureName));
             var items = sections.FirstOrDefault(kv => typeName.Equals(kv.Key, StringComparison.OrdinalIgnoreCase))?
                 .GetChildren()
-                .SelectMany(kv => new[] { new LocalizedString(kv.Key, kv.Value?? kv.Key, false, typeName) });
+                .Select(kv =>
+                {
+                    var value = kv.Value;
+                    if (value == null && option.UseKeyWhenValueIsNull == true)
+                    {
+                        value = kv.Key;
+                    }
+                    return new LocalizedString(kv.Key, value!, false, typeName);
+                });
 #if NET8_0_OR_GREATER
             return items?.ToFrozenSet();
 #else

--- a/test/UnitTest/Locales/en-US.json
+++ b/test/UnitTest/Locales/en-US.json
@@ -25,5 +25,9 @@
     "PlaceHolder": "Click to select ...",
     "Primary": "Primary",
     "Middle": "Middle"
+  },
+  "UnitTest.Utils.UtilityTest": {
+    "Test-Null": null,
+    "Test-Key:": ""
   }
 }

--- a/test/UnitTest/Utils/UtilityTest.cs
+++ b/test/UnitTest/Utils/UtilityTest.cs
@@ -379,6 +379,23 @@ public class UtilityTest : BootstrapBlazorTestBase
         Utility.GetJsonStringByTypeName(option, dynamicType!.Assembly, "Test");
     }
 
+    [Fact]
+    public void GetJsonStringByTypeName_Exception()
+    {
+        // improve code coverage
+        var option = Context.Services.GetRequiredService<IOptions<JsonLocalizationOptions>>().Value;
+        option.UseKeyWhenValueIsNull = true;
+        var items = Utility.GetJsonStringByTypeName(option, this.GetType().Assembly, "UnitTest.Utils.UtilityTest", "en-US", true);
+
+        var test1 = items.FirstOrDefault(i => i.Name == "Test-Null");
+        Assert.NotNull(test1);
+        Assert.Equal("", test1.Value);
+
+        var test2 = items.FirstOrDefault(i => i.Name == "Test-Key");
+        Assert.NotNull(test2);
+        Assert.Equal("Test-Key", test2.Value);
+    }
+
     private class MockDynamicObject : IDynamicObject
     {
         public Guid DynamicObjectPrimaryKey { get; set; }

--- a/test/UnitTest/Utils/UtilityTest.cs
+++ b/test/UnitTest/Utils/UtilityTest.cs
@@ -380,7 +380,7 @@ public class UtilityTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void GetJsonStringByTypeName_Exception()
+    public void GetJsonStringByTypeName_UseKeyWhenValueIsNull()
     {
         // improve code coverage
         var option = Context.Services.GetRequiredService<IOptions<JsonLocalizationOptions>>().Value;
@@ -394,6 +394,17 @@ public class UtilityTest : BootstrapBlazorTestBase
         var test2 = items.FirstOrDefault(i => i.Name == "Test-Key");
         Assert.NotNull(test2);
         Assert.Equal("Test-Key", test2.Value);
+
+        option.UseKeyWhenValueIsNull = false;
+        items = Utility.GetJsonStringByTypeName(option, this.GetType().Assembly, "UnitTest.Utils.UtilityTest", "en-US", true);
+
+        test1 = items.FirstOrDefault(i => i.Name == "Test-Null");
+        Assert.NotNull(test1);
+        Assert.Equal("", test1.Value);
+
+        test2 = items.FirstOrDefault(i => i.Name == "Test-Key");
+        Assert.NotNull(test2);
+        Assert.Equal("", test2.Value);
     }
 
     private class MockDynamicObject : IDynamicObject


### PR DESCRIPTION
# CacheManager GetLocalizedString Key.Value Null

CacheManager GetLocalizedString Key.Value Null

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5103

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix a bug where `CacheManager.GetLocalizedString` returned null values when the resource value was not found.