### PR TITLE
feat(Input): use IsClearable instead of Clearable

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Inputs.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Inputs.razor
@@ -227,24 +227,24 @@
            Name="OnInput">
     <div class="row g-3">
         <div class="col-12 col-sm-6">
-            <BootstrapInput Value="Model.Name" Clearable="true" ShowLabel="true" DisplayText="Clearable" />
+            <BootstrapInput Value="Model.Name" IsClearable="true" ShowLabel="true" DisplayText="Clearable" />
         </div>
     </div>
     <div class="row form-inline g-3 mt-0">
         <div class="col-12 col-sm-6">
-            <BootstrapInput Value="Model.Name" Clearable="true" ShowLabel="true" DisplayText="Clearable" />
+            <BootstrapInput Value="Model.Name" IsClearable="true" ShowLabel="true" DisplayText="Clearable" />
         </div>
     </div>
     <div class="row g-3 mt-0">
         <div class="col-12 col-sm-6">
             <BootstrapInputGroup>
                 <BootstrapInputGroupLabel ShowRequiredMark DisplayText="Clearable"></BootstrapInputGroupLabel>
-                <BootstrapInput Value="@Model.Name" Clearable="true" />
+                <BootstrapInput Value="@Model.Name" IsClearable="true" />
             </BootstrapInputGroup>
         </div>
         <div class="col-12 col-sm-6">
             <BootstrapInputGroup>
-                <BootstrapInput Value="@Model.Name" Clearable="true" />
+                <BootstrapInput Value="@Model.Name" IsClearable="true" />
                 <BootstrapInputGroupLabel ShowRequiredMark DisplayText="Clearable"></BootstrapInputGroupLabel>
             </BootstrapInputGroup>
         </div>

--- a/src/BootstrapBlazor/Components/Input/BootstrapInput.razor
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInput.razor
@@ -7,7 +7,7 @@
     <BootstrapLabel required="@Required" for="@Id" ShowLabelTooltip="ShowLabelTooltip" Value="@DisplayText" />
 }
 
-@if (Clearable)
+@if (IsClearable)
 {
     <div class="bb-clearable-input">
         @RenderInput

--- a/src/BootstrapBlazor/Components/Input/BootstrapInput.razor.cs
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInput.razor.cs
@@ -26,7 +26,14 @@ public partial class BootstrapInput<TValue>
     /// 获得/设置 是否显示清空小按钮 默认 false
     /// </summary>
     [Parameter]
-    public bool Clearable { get; set; }
+    [Obsolete("已弃用，请使用 IsClearable 参数；Deprecated use the IsClearable parameter")]
+    public bool Clearable { get => IsClearable; set => IsClearable = value; }
+
+    /// <summary>
+    /// 获得/设置 是否显示清空小按钮 默认 false
+    /// </summary>
+    [Parameter]
+    public bool IsClearable { get; set; }
 
     /// <summary>
     /// 获得/设置 清空文本框时回调方法 默认 null
@@ -38,7 +45,14 @@ public partial class BootstrapInput<TValue>
     /// 获得/设置 清空小按钮图标 默认 null
     /// </summary>
     [Parameter]
-    public string? ClearableIcon { get; set; }
+    [Obsolete("已弃用，请使用 ClearIcon 参数；Deprecated use the ClearIcon parameter")]
+    public string? ClearableIcon { get => ClearIcon; set => ClearIcon = value; }
+
+    /// <summary>
+    /// 获得/设置 清空小按钮图标 默认 null
+    /// </summary>
+    [Parameter]
+    public string? ClearIcon { get; set; }
 
     /// <summary>
     /// 图标主题服务
@@ -50,7 +64,7 @@ public partial class BootstrapInput<TValue>
     private string? ReadonlyString => Readonly ? "true" : null;
 
     private string? ClearableIconString => CssBuilder.Default("form-control-clear-icon")
-        .AddClass(ClearableIcon)
+        .AddClass(ClearIcon)
         .Build();
 
     /// <summary>
@@ -60,7 +74,7 @@ public partial class BootstrapInput<TValue>
     {
         base.OnParametersSet();
 
-        ClearableIcon ??= IconTheme.GetIconByKey(ComponentIcons.InputClearIcon);
+        ClearIcon ??= IconTheme.GetIconByKey(ComponentIcons.InputClearIcon);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Input/BootstrapInput.razor.cs
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInput.razor.cs
@@ -27,6 +27,7 @@ public partial class BootstrapInput<TValue>
     /// </summary>
     [Parameter]
     [Obsolete("已弃用，请使用 IsClearable 参数；Deprecated use the IsClearable parameter")]
+    [ExcludeFromCodeCoverage]
     public bool Clearable { get => IsClearable; set => IsClearable = value; }
 
     /// <summary>
@@ -46,6 +47,7 @@ public partial class BootstrapInput<TValue>
     /// </summary>
     [Parameter]
     [Obsolete("已弃用，请使用 ClearIcon 参数；Deprecated use the ClearIcon parameter")]
+    [ExcludeFromCodeCoverage]
     public string? ClearableIcon { get => ClearIcon; set => ClearIcon = value; }
 
     /// <summary>

--- a/test/UnitTest/Components/InputTest.cs
+++ b/test/UnitTest/Components/InputTest.cs
@@ -72,10 +72,10 @@ public class InputTest : BootstrapBlazorTestBase
     [Fact]
     public void Clearable_Ok()
     {
-        var cut = Context.RenderComponent<BootstrapInput<string>>(builder => builder.Add(a => a.Clearable, false));
+        var cut = Context.RenderComponent<BootstrapInput<string>>(builder => builder.Add(a => a.IsClearable, false));
         cut.DoesNotContain("bb-clearable-input");
 
-        cut.SetParametersAndRender(pb => pb.Add(a => a.Clearable, true));
+        cut.SetParametersAndRender(pb => pb.Add(a => a.IsClearable, true));
         cut.Contains("bb-clearable-input");
         cut.Contains("form-control-clear-icon");
 
@@ -93,7 +93,7 @@ public class InputTest : BootstrapBlazorTestBase
         var clicked = false;
         var cut = Context.RenderComponent<BootstrapInput<string>>(builder =>
         {
-            builder.Add(a => a.Clearable, true);
+            builder.Add(a => a.IsClearable, true);
             builder.Add(a => a.OnClear, v =>
             {
                 clicked = true;


### PR DESCRIPTION
# use IsClearable instead of Clearable

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5107 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Replace the 'Clearable' parameter with 'IsClearable' in input components, marking the former as obsolete while maintaining backward compatibility.

New Features:
- Introduce the 'IsClearable' parameter to replace the deprecated 'Clearable' parameter for input components.

Enhancements:
- Mark the 'Clearable' and 'ClearableIcon' parameters as obsolete and provide backward compatibility by mapping them to 'IsClearable' and 'ClearIcon' respectively.