### PR TITLE
bug(Cascader): should display Empty after click Clearable button

### DIFF
--- a/src/BootstrapBlazor/Components/Cascader/Cascader.razor.cs
+++ b/src/BootstrapBlazor/Components/Cascader/Cascader.razor.cs
@@ -170,7 +170,7 @@ public partial class Cascader<TValue>
         }
         else
         {
-            CurrentValueAsString = Items.FirstOrDefault()?.Value ?? string.Empty;
+            CurrentValueAsString = string.Empty;
         }
         RefreshDisplayText();
     }

--- a/test/UnitTest/Components/CascaderTest.cs
+++ b/test/UnitTest/Components/CascaderTest.cs
@@ -159,7 +159,7 @@ public class CascaderTest : BootstrapBlazorTestBase
             pb.Add(a => a.Items, items);
             pb.Add(a => a.Value, "Test");
         });
-        Assert.Equal("1", cut.Instance.Value);
+        Assert.Equal("", cut.Instance.Value);
 
         cut.SetParametersAndRender(pb =>
         {


### PR DESCRIPTION
# should display Empty after click Clearable button

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5127 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix an issue where the cascader component would not display "Empty" after clicking the clear button.