### PR TITLE
refactor(JSException): remove JSException error log

### DIFF
--- a/src/BootstrapBlazor/Extensions/JSModuleExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/JSModuleExtensions.cs
@@ -31,7 +31,17 @@ public static class JSModuleExtensions
             fileName = $"{fileName}?v={version}";
         }
 
-        var jSObjectReference = await jsRuntime.InvokeAsync<IJSObjectReference>(identifier: "import", fileName);
+        IJSObjectReference? jSObjectReference = null;
+        try
+        {
+            jSObjectReference = await jsRuntime.InvokeAsync<IJSObjectReference>(identifier: "import", fileName);
+        }
+        catch (JSException)
+        {
+#if DEBUG
+            throw;
+#endif
+        }
         return new JSModule(jSObjectReference);
     }
 

--- a/test/UnitTest/Extensions/JSModuleExtensionsTest.cs
+++ b/test/UnitTest/Extensions/JSModuleExtensionsTest.cs
@@ -21,6 +21,9 @@ public class JSModuleExtensionsTest : BootstrapBlazorTestBase
     {
         var jsRuntime = new MockJSRuntime();
         await Assert.ThrowsAsync<TaskCanceledException>(() => jsRuntime.LoadModule("./mock.js", "test"));
+
+        var jsRuntime2 = new JSExceptionJSRuntime();
+        await Assert.ThrowsAsync<JSException>(() => jsRuntime2.LoadModule("./mock.js", "test"));
     }
 
     [Fact]
@@ -104,6 +107,19 @@ public class JSModuleExtensionsTest : BootstrapBlazorTestBase
         public ValueTask<TValue> InvokeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
         {
             throw new TaskCanceledException();
+        }
+    }
+
+    class JSExceptionJSRuntime : IJSRuntime
+    {
+        public ValueTask<TValue> InvokeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(string identifier, object?[]? args)
+        {
+            throw new JSException("test-js-exception");
+        }
+
+        public ValueTask<TValue> InvokeAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors | DynamicallyAccessedMemberTypes.PublicFields | DynamicallyAccessedMemberTypes.PublicProperties)] TValue>(string identifier, CancellationToken cancellationToken, object?[]? args)
+        {
+            throw new JSException("test-js-exception");
         }
     }
 }


### PR DESCRIPTION
# remove JSException error log

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5141 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixed an issue where JSExceptions were logged unnecessarily in non-debug builds.