### PR TITLE
bug(BootstrapInputGroupLabel): should show DisplayText when bind-Value in ValidateForm

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor
@@ -113,14 +113,14 @@
     <ValidateForm Model="@Model">
         <div class="@GroupFormClassString">
             <div class="col-12 col-sm-6">
-                <BootstrapInputGroupLabel @bind-Value="@Model.Name" required="true" />
+                <BootstrapInputGroupLabel @bind-Value="@Model.Name" ShowRequiredMark="true" />
                 <BootstrapInputGroup>
                     <Display @bind-Value="@Model.Name"></Display>
                     <BootstrapInputGroupLabel @bind-Value="@Model.Name" />
                 </BootstrapInputGroup>
             </div>
             <div class="col-12 col-sm-6">
-                <BootstrapInputGroupLabel @bind-Value="@Model.Address" required="true" />
+                <BootstrapInputGroupLabel @bind-Value="@Model.Address" ShowRequiredMark="true" />
                 <BootstrapInputGroup>
                     <Display @bind-Value="@Model.Address"></Display>
                     <BootstrapInputGroupLabel @bind-Value="@Model.Address" />

--- a/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs
@@ -19,9 +19,9 @@ public partial class BootstrapInputGroupLabel
         .Build();
 
     private string? StyleString => CssBuilder.Default()
-    .AddClass($"--bb-input-group-label-width: {Width}px;", Width.HasValue)
-    .AddClassFromAttributes(AdditionalAttributes)
-    .Build();
+        .AddClass($"--bb-input-group-label-width: {Width}px;", Width.HasValue)
+        .AddClassFromAttributes(AdditionalAttributes)
+        .Build();
 
     private bool IsInnerLabel { get; set; }
 

--- a/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs
@@ -53,5 +53,10 @@ public partial class BootstrapInputGroupLabel
         base.OnParametersSet();
 
         IsInnerLabel = InputGroup != null;
+
+        if (IsInnerLabel)
+        {
+            DisplayText ??= FieldIdentifier?.GetDisplayName();
+        }
     }
 }

--- a/test/UnitTest/Components/DisplayTest.cs
+++ b/test/UnitTest/Components/DisplayTest.cs
@@ -191,7 +191,7 @@ public class DisplayTest : BootstrapBlazorTestBase
     [Fact]
     public void Bind_Ok()
     {
-        var foo = new Foo();
+        var foo = new Foo() { Name = "test-name" };
         var cut = Context.RenderComponent<ValidateForm>(pb =>
         {
             pb.Add(a => a.Model, foo);
@@ -201,21 +201,21 @@ public class DisplayTest : BootstrapBlazorTestBase
                 {
                     builder.OpenComponent<Display<string>>(0);
                     builder.AddAttribute(1, "Value", foo.Name);
-                    builder.AddAttribute(2, "ValueExpression",
-                        Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.AddAttribute(2, "ValueExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
                     builder.CloseComponent();
 
                     builder.OpenComponent<BootstrapInputGroupLabel>(3);
                     builder.AddAttribute(4, "Value", "Name");
-                    builder.AddAttribute(5, "ValueExpression",
-                        Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.AddAttribute(5, "ValueExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<BootstrapInputGroupLabel>(3);
+                    builder.AddAttribute(6, "Value", "Name");
                     builder.CloseComponent();
                 });
             });
         });
-        Assert.Contains("is-display", cut.Markup);
-        Assert.Contains("input-group-text", cut.Markup);
-        Assert.DoesNotContain("<span>姓名</span>", cut.Markup);
+        Assert.Contains("<div class=\"input-group\"><div class=\"form-control is-display\">test-name</div><div class=\"input-group-text\"><span>姓名</span></div><div class=\"input-group-text\"><span></span></div></div>", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
# should show DisplayText when bind-Value in ValidateForm

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5166 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix the display of the bound value in a ValidateForm within a BootstrapInputGroupLabel component.

Bug Fixes:
- Fixed an issue where the display text was not shown when a value was bound in a ValidateForm.

Enhancements:
- Improved the BootstrapInputGroupLabel component to automatically display the bound value when used inside a ValidateForm.