### PR TITLE
feat(LoadModule): preventing OperationCancelException throw

### DIFF
--- a/src/BootstrapBlazor/Extensions/JSModuleExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/JSModuleExtensions.cs
@@ -44,6 +44,7 @@ public static class JSModuleExtensions
             throw;
 #endif
         }
+        catch (OperationCanceledException) { }
         return new JSModule(jSObjectReference);
     }
 

--- a/test/UnitTest/Extensions/JSModuleExtensionsTest.cs
+++ b/test/UnitTest/Extensions/JSModuleExtensionsTest.cs
@@ -14,13 +14,10 @@ public class JSModuleExtensionsTest : BootstrapBlazorTestBase
     {
         var jsRuntime = Context.Services.GetRequiredService<IJSRuntime>();
         await jsRuntime.LoadModule("./mock.js", "test");
-    }
 
-    [Fact]
-    public async Task LoadModule_Exception()
-    {
-        var jsRuntime = new MockJSRuntime();
-        await Assert.ThrowsAsync<TaskCanceledException>(() => jsRuntime.LoadModule("./mock.js", "test"));
+        var jsRuntime1 = new MockJSRuntime();
+        var module = await jsRuntime1.LoadModule("./mock.js", "test");
+        Assert.NotNull(module);
 
         var jsRuntime2 = new JSExceptionJSRuntime();
         await Assert.ThrowsAsync<JSException>(() => jsRuntime2.LoadModule("./mock.js", "test"));


### PR DESCRIPTION
# preventing OperationCancelException throw

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5187 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Prevent OperationCanceledException from being thrown when loading a module.

Bug Fixes:
- Fixed an issue where loading a module could throw an OperationCanceledException.

Tests:
- Updated tests to reflect the changes and ensure that the module loads correctly even when an OperationCanceledException occurs.