### PR TITLE
feat(QueryPageOptions): add TriggerByPagination parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.2.9-beta03</Version>
+    <Version>9.2.9-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -392,7 +392,7 @@ public partial class Table<TItem>
         StateHasChanged();
     }
 
-    private async Task QueryAsync(bool shouldRender, int? pageIndex = null)
+    private async Task QueryAsync(bool shouldRender, int? pageIndex = null, bool triggerByPagination = false)
     {
         if (ScrollMode == ScrollMode.Virtual && VirtualizeElement != null)
         {
@@ -405,7 +405,7 @@ public partial class Table<TItem>
             {
                 PageIndex = pageIndex.Value;
             }
-            await QueryData();
+            await QueryData(triggerByPagination);
             await InternalToggleLoading(false);
         }
 
@@ -451,12 +451,14 @@ public partial class Table<TItem>
     /// <summary>
     /// 调用 OnQuery 回调方法获得数据源
     /// </summary>
-    protected async Task QueryData()
+    protected async Task QueryData(bool triggerByPagination = false)
     {
         // 目前设计使用 Items 参数后不回调 OnQueryAsync 方法
         if (Items == null)
         {
             var queryOption = BuildQueryPageOptions();
+            // 是否为分页查询
+            queryOption.TriggerByPagination = triggerByPagination;
             // 设置是否为首次查询
             queryOption.IsFirstQuery = _firstQuery;
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Pagination.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Pagination.cs
@@ -165,7 +165,7 @@ public partial class Table<TItem>
             }
 
             // 无刷新查询数据
-            await QueryAsync(false);
+            await QueryAsync(false, triggerByPagination: true);
 
             // 通知 SelectedRow 双向绑定集合改变
             await OnSelectedRowsChanged();

--- a/src/BootstrapBlazor/Options/QueryPageOptions.cs
+++ b/src/BootstrapBlazor/Options/QueryPageOptions.cs
@@ -124,4 +124,9 @@ public class QueryPageOptions
     /// </summary>
     /// <remarks><see cref="Table{TItem}"/> 组件首次查询数据时为 true</remarks>
     public bool IsFirstQuery { get; set; }
+
+    /// <summary>
+    /// 获得 是否为刷新分页查询 默认 false 
+    /// </summary>
+    public bool TriggerByPagination { get; set; }
 }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -1070,6 +1070,7 @@ public class TableTest : BootstrapBlazorTestBase
     {
         var isFirstQuery = true;
         var isQuery = false;
+        var triggerByPagination = true;
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
@@ -1082,6 +1083,7 @@ public class TableTest : BootstrapBlazorTestBase
                 {
                     isQuery = true;
                     isFirstQuery = option.IsFirstQuery;
+                    triggerByPagination = option.TriggerByPagination;
                     return Task.FromResult(new QueryData<Foo>()
                     {
                         Items = Array.Empty<Foo>(),
@@ -1105,6 +1107,7 @@ public class TableTest : BootstrapBlazorTestBase
         // 首次加载为 true
         Assert.True(isFirstQuery);
         Assert.False(isQuery);
+        Assert.True(triggerByPagination);
 
         // 二次查询
         var table = cut.FindComponent<Table<Foo>>();
@@ -1112,6 +1115,7 @@ public class TableTest : BootstrapBlazorTestBase
 
         Assert.False(isFirstQuery);
         Assert.True(isQuery);
+        Assert.False(triggerByPagination);
     }
 
     [Fact]


### PR DESCRIPTION
# add TriggerByPagination parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5192 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a `TriggerByPagination` parameter to `QueryPageOptions` to indicate whether a query was triggered by pagination. Update the `QueryAsync` method in `Table.razor.Edit.cs` to accept this parameter and pass it to the `QueryData` method. Update the `OnPageLinkClick` method in `Table.razor.Pagination.cs` to pass `triggerByPagination: true` when calling `QueryAsync`. Add tests to verify the behavior of the `IsAutoQueryFirstQuery` method.

New Features:
- Added a `TriggerByPagination` parameter to `QueryPageOptions` to indicate whether a query was triggered by pagination.

Tests:
- Added tests to verify the behavior of the `IsAutoQueryFirstQuery` method.