### PR TITLE
refactor(QueryPageOptions): rename paramater IsTriggerPagination

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -458,7 +458,7 @@ public partial class Table<TItem>
         {
             var queryOption = BuildQueryPageOptions();
             // 是否为分页查询
-            queryOption.TriggerByPagination = triggerByPagination;
+            queryOption.IsTriggerByPagination = triggerByPagination;
             // 设置是否为首次查询
             queryOption.IsFirstQuery = _firstQuery;
 

--- a/src/BootstrapBlazor/Options/QueryPageOptions.cs
+++ b/src/BootstrapBlazor/Options/QueryPageOptions.cs
@@ -128,5 +128,5 @@ public class QueryPageOptions
     /// <summary>
     /// 获得 是否为刷新分页查询 默认 false 
     /// </summary>
-    public bool TriggerByPagination { get; set; }
+    public bool IsTriggerByPagination { get; set; }
 }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -1083,7 +1083,7 @@ public class TableTest : BootstrapBlazorTestBase
                 {
                     isQuery = true;
                     isFirstQuery = option.IsFirstQuery;
-                    triggerByPagination = option.TriggerByPagination;
+                    triggerByPagination = option.IsTriggerByPagination;
                     return Task.FromResult(new QueryData<Foo>()
                     {
                         Items = Array.Empty<Foo>(),


### PR DESCRIPTION
# rename paramater IsTriggerPagination

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5194 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Rename the `TriggerByPagination` parameter to `IsTriggerByPagination` in the `QueryPageOptions` class.

Enhancements:
- Standardize parameter naming by adding "Is" prefix.

Tests:
- Update tests to reflect the parameter name change.