### PR TITLE
feat(SelectTable): add EmptyTemplate parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor
@@ -46,7 +46,8 @@
                    SearchModel="SearchModel" SearchTemplate="SearchTemplate" CollapsedTopSearch="CollapsedTopSearch"
                    CustomerSearchModel="CustomerSearchModel" CustomerSearchTemplate="CustomerSearchTemplate"
                    IsPagination="IsPagination" PageItemsSource="PageItemsSource" ShowGotoNavigator="false" MaxPageLinkCount="3"
-                   OnClickRowCallback="OnClickRowCallback" OnQueryAsync="OnQueryAsync"></Table>
+                   OnClickRowCallback="OnClickRowCallback" OnQueryAsync="OnQueryAsync"
+                   ShowEmpty="ShowEmpty" EmptyTemplate="EmptyTemplate"></Table>
         </div>
     </RenderTemplate>
 </div>

--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor.cs
@@ -68,6 +68,18 @@ public partial class SelectTable<TItem> : IColumnCollection where TItem : class,
     public bool IsClearable { get; set; }
 
     /// <summary>
+    /// 获得/设置 是否显示无数据空记录 默认 false 不显示
+    /// </summary>
+    [Parameter]
+    public bool ShowEmpty { get; set; }
+
+    /// <summary>
+    /// 获得/设置 无数据时显示模板 默认 null
+    /// </summary>
+    [Parameter]
+    public RenderFragment? EmptyTemplate { get; set; }
+
+    /// <summary>
     /// 获得/设置 IIconTheme 服务实例
     /// </summary>
     [Inject]

--- a/test/UnitTest/Components/SelectTableTest.cs
+++ b/test/UnitTest/Components/SelectTableTest.cs
@@ -543,6 +543,44 @@ public class SelectTableTest : BootstrapBlazorTestBase
         Assert.Equal(2, labels.Count);
     }
 
+    [Fact]
+    public void EmptyTemplate_OK()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer);
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<SelectTable<Foo>>(pb =>
+            {
+                pb.Add(a => a.OnQueryAsync, options =>
+                {
+                    return Task.FromResult(new QueryData<Foo>()
+                    {
+                        Items = [],
+                        IsAdvanceSearch = true,
+                        IsFiltered = true,
+                        IsSearch = true,
+                        IsSorted = true
+                    });
+                });
+                pb.Add(a => a.ShowEmpty, true);
+                pb.Add(a => a.EmptyTemplate, builder => builder.AddContent(0, "empty-template"));
+                pb.Add(a => a.Value, items[0]);
+                pb.Add(a => a.GetTextCallback, foo => foo.Name);
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.AddAttribute(3, "Searchable", true);
+                    builder.CloseComponent();
+                });
+            });
+        });
+
+        cut.Contains("<div class=\"empty\"><div class=\"empty-telemplate\">empty-template</div></div>");
+    }
+
     private static Task<QueryData<Foo>> OnFilterQueryAsync(QueryPageOptions options, IEnumerable<Foo> _filterItems)
     {
         _filterItems = _filterItems.Where(options.ToFilterFunc<Foo>());


### PR DESCRIPTION
# add EmptyTemplate parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5212 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add an `EmptyTemplate` parameter to the `SelectTable` component to allow custom content to be displayed when no data is available.

New Features:
- Added an `EmptyTemplate` parameter to the `SelectTable` component. This parameter allows developers to customize the content displayed when the table is empty.

Tests:
- Added unit tests for the `EmptyTemplate` functionality.