### PR TITLE
feat(ICacheEntry): add GetLastAccessed extension method

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
@@ -36,8 +36,6 @@ public partial class CacaheExpiration
         ExpirationTime = "loading ...";
         await Task.Yield();
 
-        ExpirationTime = Context is ICacheEntry entry
-            ? entry.GetExpiration()
-            : "-";
+        ExpirationTime = Context is ICacheEntry entry ? entry.GetExpiration() : "-";
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
@@ -19,7 +19,7 @@ public partial class CacaheExpiration
     /// 获得/设置 <see cref="TableColumnContext{TItem, TValue}"/> 实例
     /// </summary>
     [Parameter, NotNull]
-    public object? Key { get; set; }
+    public TableColumnContext<object, object>? TableColumnContext { get; set; }
 
     private string? ExpirationTime { get; set; }
 
@@ -39,32 +39,9 @@ public partial class CacaheExpiration
         ExpirationTime = "loading ...";
         await Task.Yield();
 
-        if (CacheManager.TryGetCacheEntry(Key, out ICacheEntry? entry))
-        {
-            if (entry.Priority == CacheItemPriority.NeverRemove)
-            {
-                ExpirationTime = "Never Remove";
-            }
-            else if (entry.SlidingExpiration.HasValue)
-            {
-                ExpirationTime = $"Sliding: {entry.SlidingExpiration.Value}";
-            }
-            else if (entry.AbsoluteExpiration.HasValue)
-            {
-                ExpirationTime = $"Absolute: {entry.AbsoluteExpiration.Value}";
-            }
-            else if (entry.ExpirationTokens.Count != 0)
-            {
-                ExpirationTime = $"Token: {entry.ExpirationTokens.Count}";
-            }
-            else
-            {
-                ExpirationTime = "Not Set";
-            }
-        }
-        else
-        {
-            ExpirationTime = "Not Found";
-        }
+        var key = TableColumnContext.Row;
+        ExpirationTime = CacheManager.TryGetCacheEntry(key, out ICacheEntry? entry)
+            ? entry.GetExpiration()
+            : "Not Found";
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
@@ -12,14 +12,11 @@ namespace BootstrapBlazor.Server.Components.Pages;
 /// </summary>
 public partial class CacaheExpiration
 {
-    [Inject, NotNull]
-    private ICacheManager? CacheManager { get; set; }
-
     /// <summary>
-    /// 获得/设置 <see cref="TableColumnContext{TItem, TValue}"/> 实例
+    /// 获得/设置 <see cref="ICacheEntry"/> 实例
     /// </summary>
     [Parameter, NotNull]
-    public TableColumnContext<object, object>? TableColumnContext { get; set; }
+    public object? Context { get; set; }
 
     private string? ExpirationTime { get; set; }
 
@@ -39,9 +36,8 @@ public partial class CacaheExpiration
         ExpirationTime = "loading ...";
         await Task.Yield();
 
-        var key = TableColumnContext.Row;
-        ExpirationTime = CacheManager.TryGetCacheEntry(key, out ICacheEntry? entry)
+        ExpirationTime = Context is ICacheEntry entry
             ? entry.GetExpiration()
-            : "Not Found";
+            : "-";
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Pages/CacaheExpiration.razor.cs
@@ -57,6 +57,14 @@ public partial class CacaheExpiration
             {
                 ExpirationTime = $"Token: {entry.ExpirationTokens.Count}";
             }
+            else
+            {
+                ExpirationTime = "Not Set";
+            }
+        }
+        else
+        {
+            ExpirationTime = "Not Found";
         }
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Pages/CacheList.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/CacheList.razor
@@ -18,9 +18,9 @@
                     @GetValue(v.Row)
                 </Template>
             </TableTemplateColumn>
-            <TableTemplateColumn Text="@Localizer["CacheListExpiration"]" Width="160">
+            <TableTemplateColumn Text="@Localizer["CacheListExpiration"]" Width="180">
                 <Template Context="v">
-                    <CacaheExpiration Key="v.Row"></CacaheExpiration>
+                    <CacaheExpiration TableColumnContext="v"></CacaheExpiration>
                 </Template>
             </TableTemplateColumn>
             <TableTemplateColumn Text="@Localizer["CacheListAction"]" Width="80">

--- a/src/BootstrapBlazor.Server/Components/Pages/CacheList.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/CacheList.razor
@@ -10,7 +10,7 @@
         <TableColumns>
             <TableTemplateColumn Text="@Localizer["CacheListKey"]" TextWrap="true">
                 <Template Context="v">
-                    @v.Row.ToString()
+                    @GetKey(v.Row)
                 </Template>
             </TableTemplateColumn>
             <TableTemplateColumn Text="@Localizer["CacheListValue"]" TextWrap="true" Width="220">
@@ -20,7 +20,7 @@
             </TableTemplateColumn>
             <TableTemplateColumn Text="@Localizer["CacheListExpiration"]" Width="180">
                 <Template Context="v">
-                    <CacaheExpiration TableColumnContext="v"></CacaheExpiration>
+                    <CacaheExpiration Context="v.Row"></CacaheExpiration>
                 </Template>
             </TableTemplateColumn>
             <TableTemplateColumn Text="@Localizer["CacheListAction"]" Width="80">

--- a/src/BootstrapBlazor.Server/Components/Samples/AutoFills.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/AutoFills.razor.cs
@@ -18,7 +18,7 @@ partial class AutoFills
     [NotNull]
     private Foo Model3 { get; set; } = new();
 
-    private static string OnGetDisplayText(Foo foo) => foo.Name ?? "";
+    private static string? OnGetDisplayText(Foo? foo) => foo?.Name;
 
     [NotNull]
     private IEnumerable<Foo>? Items1 { get; set; }

--- a/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor
@@ -88,7 +88,7 @@
         <div class="col-12 col-sm-6">
             <BootstrapInputGroup>
                 <BootstrapInputGroupLabel DisplayText="AutoFill" />
-                <AutoFill Items="AufoFillItems" IsLikeMatch="true" OnGetDisplayText="@(foo => foo.Name)">
+                <AutoFill Items="AufoFillItems" IsLikeMatch="true" OnGetDisplayText="@(foo => foo?.Name)">
                     <ItemTemplate>
                         <div class="d-flex">
                             <div>

--- a/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor.cs
@@ -54,9 +54,9 @@ public partial class InputGroups
 
     private readonly IEnumerable<SelectedItem> Items = new SelectedItem[]
     {
-        new SelectedItem("", "请选择 ..."),
-        new SelectedItem("Beijing", "北京"),
-        new SelectedItem("Shanghai", "上海")
+        new("", "请选择 ..."),
+        new("Beijing", "北京"),
+        new("Shanghai", "上海")
     };
     private string? GroupFormClassString => CssBuilder.Default("row g-3").AddClass("form-inline", FormRowType == RowType.Inline).Build();
 

--- a/src/BootstrapBlazor.Server/Extensions/ICacheEntryExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/ICacheEntryExtensions.cs
@@ -46,12 +46,7 @@ public static class ICacheEntryExtensions
 
     private static TimeSpan GetSlidingLeftTime(this ICacheEntry entry)
     {
-        var ret = TimeSpan.Zero;
         var lastAccessed = entry.GetLastAccessed();
-        if (lastAccessed != null)
-        {
-            ret = entry.SlidingExpiration!.Value - (DateTime.UtcNow - lastAccessed.Value);
-        }
-        return ret;
+        return lastAccessed == null ? TimeSpan.Zero : entry.SlidingExpiration!.Value - (DateTime.UtcNow - lastAccessed.Value);
     }
 }

--- a/src/BootstrapBlazor.Server/Extensions/ICacheEntryExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/ICacheEntryExtensions.cs
@@ -1,0 +1,57 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using Microsoft.Extensions.Caching.Memory;
+using System.Reflection;
+
+namespace BootstrapBlazor.Server.Extensions;
+
+/// <summary>
+/// <see cref="ICacheEntry"/> 扩展方法
+/// </summary>
+public static class ICacheEntryExtensions
+{
+    /// <summary>
+    /// 获取缓存项过期时间
+    /// </summary>
+    /// <param name="entry"></param>
+    /// <returns></returns>
+    public static string GetExpiration(this ICacheEntry entry)
+    {
+        string? ret;
+        if (entry.Priority == CacheItemPriority.NeverRemove)
+        {
+            ret = "Never Remove";
+        }
+        else if (entry.SlidingExpiration.HasValue)
+        {
+            ret = $"Sliding: {entry.GetSlidingLeftTime().TotalSeconds:###}/{entry.SlidingExpiration.Value.TotalSeconds}";
+        }
+        else if (entry.AbsoluteExpiration.HasValue)
+        {
+            ret = $"Absolute: {entry.AbsoluteExpiration.Value}";
+        }
+        else if (entry.ExpirationTokens.Count != 0)
+        {
+            ret = $"Token: {entry.ExpirationTokens.Count}";
+        }
+        else
+        {
+            ret = "Not Set";
+        }
+        return ret;
+    }
+
+    private static TimeSpan GetSlidingLeftTime(this ICacheEntry entry)
+    {
+        var ret = TimeSpan.Zero;
+        var lastAccessed = entry.GetLastAccessed();
+        if (lastAccessed != null)
+        {
+            ret = entry.SlidingExpiration!.Value - (DateTime.UtcNow - lastAccessed.Value);
+        }
+        return ret;
+    }
+}

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -58,7 +58,7 @@ public partial class AutoFill<TValue>
     /// </summary>
     [Parameter]
     [NotNull]
-    public Func<TValue, string?>? OnGetDisplayText { get; set; }
+    public Func<TValue?, string?>? OnGetDisplayText { get; set; }
 
     /// <summary>
     /// 图标

--- a/src/BootstrapBlazor/Extensions/ICacheEntryExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ICacheEntryExtensions.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using Microsoft.Extensions.Caching.Memory;
+using System.Reflection;
+
+namespace BootstrapBlazor.Components;
+
+/// <summary>
+/// <see cref="ICacheEntry"/> 扩展方法
+/// </summary>
+public static class ICacheEntryExtensions
+{
+    /// <summary>
+    /// 获得缓存项 <see cref="ICacheEntry"/> 最后访问时间
+    /// </summary>
+    /// <param name="entry"></param>
+    /// <returns></returns>
+    public static DateTime? GetLastAccessed(this ICacheEntry entry)
+    {
+        _lastAccessedProperty ??= entry.GetType().GetProperty("LastAccessed", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        DateTime? ret = null;
+        if (_lastAccessedProperty != null)
+        {
+            var v = _lastAccessedProperty.GetValue(entry);
+            if (v is DateTime val)
+            {
+                ret = val;
+            }
+        }
+        return ret;
+    }
+
+    private static PropertyInfo? _lastAccessedProperty = null;
+}

--- a/src/BootstrapBlazor/Extensions/ICacheEntryExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ICacheEntryExtensions.cs
@@ -17,9 +17,14 @@ public static class ICacheEntryExtensions
     /// 获得缓存项 <see cref="ICacheEntry"/> 最后访问时间
     /// </summary>
     /// <param name="entry"></param>
+    /// <param name="force"></param>
     /// <returns></returns>
-    public static DateTime? GetLastAccessed(this ICacheEntry entry)
+    public static DateTime? GetLastAccessed(this ICacheEntry entry, bool force = false)
     {
+        if (force)
+        {
+            _lastAccessedProperty = null;
+        }
         _lastAccessedProperty ??= entry.GetType().GetProperty("LastAccessed", BindingFlags.Instance | BindingFlags.NonPublic);
 
         DateTime? ret = null;

--- a/test/UnitTest/Extensions/ICacheEntryExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ICacheEntryExtensionsTest.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+
 namespace UnitTest.Extensions;
 
 public class ICacheEntryExtensionsTest : BootstrapBlazorTestBase
@@ -16,7 +19,42 @@ public class ICacheEntryExtensionsTest : BootstrapBlazorTestBase
         });
 
         Assert.True(Cache.TryGetCacheEntry("test_01", out var entry));
-        var v = entry.GetLastAccessed();
+        var v = entry.GetLastAccessed(true);
         Assert.NotNull(v);
+    }
+
+    [Fact]
+    public void GetLastAccessed_Null()
+    {
+        var mock = new MockCacheEntry();
+        var v = mock.GetLastAccessed(true);
+        Assert.Null(v);
+    }
+
+    class MockCacheEntry : ICacheEntry
+    {
+        public object Key { get; }
+        public object? Value { get; set; }
+        public DateTimeOffset? AbsoluteExpiration { get; set; }
+        public TimeSpan? AbsoluteExpirationRelativeToNow { get; set; }
+        public TimeSpan? SlidingExpiration { get; set; }
+        public IList<IChangeToken> ExpirationTokens { get; }
+        public IList<PostEvictionCallbackRegistration> PostEvictionCallbacks { get; }
+        public CacheItemPriority Priority { get; set; }
+        public long? Size { get; set; }
+
+        private int LastAccessed { get; set; }
+
+        public MockCacheEntry()
+        {
+            Key = "_test";
+            ExpirationTokens = [];
+            PostEvictionCallbacks = [];
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/test/UnitTest/Extensions/ICacheEntryExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ICacheEntryExtensionsTest.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+namespace UnitTest.Extensions;
+
+public class ICacheEntryExtensionsTest : BootstrapBlazorTestBase
+{
+    [Fact]
+    public void GetLastAccessed_Ok()
+    {
+        Cache.GetOrCreate("test_01", entry =>
+        {
+            return 1;
+        });
+
+        Assert.True(Cache.TryGetCacheEntry("test_01", out var entry));
+        var v = entry.GetLastAccessed();
+        Assert.NotNull(v);
+    }
+}


### PR DESCRIPTION
# add GetLastAccessed extension method

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5218 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add an extension method `GetLastAccessed` to `ICacheEntry` to retrieve the last accessed time of a cache entry. Update the CacheList page to display cache expiration information using the new extension method.

New Features:
- Added `GetLastAccessed` extension method to `ICacheEntry`.

Tests:
- Added unit tests for the `ICacheEntryExtensions` class.