### PR TITLE
fix(Modal): use `TrySetResult` prevent throw exception

### DIFF
--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -385,7 +385,7 @@ public partial class ModalDialog : IHandlerException
                 }
             }
         }
-        ResultTask?.SetResult(_result);
+        ResultTask?.TrySetResult(_result);
         await Modal.Close();
     }
 


### PR DESCRIPTION
# use `TrySetResult` prevent throw exception

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5221 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixed an exception being thrown when closing a modal.