### PR TITLE
feat(IDynamicObject): disable support complex object

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.3.1-beta02</Version>
+    <Version>9.3.1-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/EditorForm/EditorItem.cs
+++ b/src/BootstrapBlazor/Components/EditorForm/EditorItem.cs
@@ -12,11 +12,7 @@ namespace BootstrapBlazor.Components;
 /// EditorItem 组件
 /// </summary>
 /// <remarks>用于 EditorForm 的 FieldItems 模板内</remarks>
-#if NET6_0_OR_GREATER
 public class EditorItem<TModel, TValue> : ComponentBase, IEditorItem
-#else
-public class EditorItem<TValue> : ComponentBase, IEditorItem
-#endif
 {
     /// <summary>
     /// 获得/设置 绑定字段值
@@ -108,9 +104,6 @@ public class EditorItem<TValue> : ComponentBase, IEditorItem
     /// 获得/设置 编辑模板
     /// </summary>
     [Parameter]
-#if NET5_0
-    public RenderFragment<object>? EditTemplate { get; set; }
-#elif NET6_0_OR_GREATER
     public RenderFragment<TModel>? EditTemplate { get; set; }
 
     RenderFragment<object>? IEditorItem.EditTemplate
@@ -126,7 +119,6 @@ public class EditorItem<TValue> : ComponentBase, IEditorItem
         {
         }
     }
-#endif
 
     /// <summary>
     /// 获得/设置 组件类型 默认为 null

--- a/src/BootstrapBlazor/Components/Table/TableColumn.cs
+++ b/src/BootstrapBlazor/Components/Table/TableColumn.cs
@@ -291,27 +291,6 @@ public class TableColumn<TItem, TType> : BootstrapComponentBase, ITableColumn
     /// 获得/设置 显示模板
     /// </summary>
     [Parameter]
-#if NET5_0
-    public RenderFragment<TableColumnContext<object, TType>>? Template { get; set; }
-
-    /// <summary>
-    /// 内部使用负责把 object 类型的绑定数据值转化为泛型数据传递给前端
-    /// </summary>
-    RenderFragment<object>? ITableColumn.Template
-    {
-        get => Template == null ? null : new RenderFragment<object>(context => builder =>
-        {
-            // 此处 context 为行数据
-            var fieldName = GetFieldName();
-            var value = Utility.GetPropertyValue<object, TType>(context, fieldName);
-            builder.AddContent(0, Template.Invoke(new TableColumnContext<object, TType>(context, value)));
-        });
-        set
-        {
-
-        }
-    }
-#elif NET6_0_OR_GREATER
     public RenderFragment<TableColumnContext<TItem, TType?>>? Template { get; set; }
 
     /// <summary>
@@ -338,15 +317,11 @@ public class TableColumn<TItem, TType> : BootstrapComponentBase, ITableColumn
 
         }
     }
-#endif
 
     /// <summary>
     /// 获得/设置 编辑模板
     /// </summary>
     [Parameter]
-#if NET5_0
-    public RenderFragment<object>? EditTemplate { get; set; }
-#elif NET6_0_OR_GREATER
     public RenderFragment<TItem>? EditTemplate { get; set; }
 
     RenderFragment<object>? IEditorItem.EditTemplate
@@ -362,16 +337,12 @@ public class TableColumn<TItem, TType> : BootstrapComponentBase, ITableColumn
         {
         }
     }
-#endif
 
     /// <summary>
     /// 获得/设置 搜索模板
     /// </summary>
     /// <value></value>
     [Parameter]
-#if NET5_0
-    public RenderFragment<object>? SearchTemplate { get; set; }
-#elif NET6_0_OR_GREATER
     public RenderFragment<TItem>? SearchTemplate { get; set; }
 
     RenderFragment<object>? ITableColumn.SearchTemplate
@@ -387,7 +358,6 @@ public class TableColumn<TItem, TType> : BootstrapComponentBase, ITableColumn
         {
         }
     }
-#endif
 
     /// <summary>
     /// 获得/设置 过滤模板

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
@@ -123,7 +123,7 @@ public class DataTableDynamicContext : DynamicObjectContext
                     {
                         if (!row.IsNull(col))
                         {
-                            Utility.SetPropertyValue<object, object?>(d, col.ColumnName, row[col]);
+                            Utility.SetPropertyValue<object, object?>(d, col.ColumnName, row[col], false);
                         }
                     }
 
@@ -200,7 +200,7 @@ public class DataTableDynamicContext : DynamicObjectContext
             {
                 if (col.DefaultValue != DBNull.Value)
                 {
-                    Utility.SetPropertyValue<object, object?>(dynamicObject, col.ColumnName, col.DefaultValue);
+                    Utility.SetPropertyValue<object, object?>(dynamicObject, col.ColumnName, col.DefaultValue, false);
                 }
             }
             dynamicObject.Row = row;

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicObject.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicObject.cs
@@ -18,7 +18,7 @@ public class DataTableDynamicObject : DynamicObject
     internal DataRow? Row { get; set; }
 
     /// <summary>
-    /// 
+    /// <inheritdoc/>
     /// </summary>
     /// <param name="propertyName"></param>
     /// <returns></returns>
@@ -42,7 +42,7 @@ public class DataTableDynamicObject : DynamicObject
     }
 
     /// <summary>
-    /// 
+    /// <inheritdoc/>
     /// </summary>
     /// <param name="propertyName"></param>
     /// <param name="value"></param>

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicObject.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicObject.cs
@@ -33,12 +33,12 @@ public class DataTableDynamicObject : DynamicObject
                 if (!Row.Table.Columns[propertyName]!.AutoIncrement)
                 {
                     // 自增长列
-                    Row[propertyName] = Utility.GetPropertyValue(this, propertyName);
+                    Row[propertyName] = Utility.GetPropertyValue(this, propertyName, false);
                 }
             }
             ret = Row[propertyName];
         }
-        return ret ?? Utility.GetPropertyValue(this, propertyName);
+        return ret ?? Utility.GetPropertyValue(this, propertyName, false);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Dynamic/DynamicItemChangedType.cs
+++ b/src/BootstrapBlazor/Dynamic/DynamicItemChangedType.cs
@@ -6,7 +6,7 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// 
+/// DynamicItemChangedType 类型
 /// </summary>
 public enum DynamicItemChangedType
 {

--- a/src/BootstrapBlazor/Dynamic/DynamicObject.cs
+++ b/src/BootstrapBlazor/Dynamic/DynamicObject.cs
@@ -11,20 +11,20 @@ namespace BootstrapBlazor.Components;
 public class DynamicObject : IDynamicObject
 {
     /// <summary>
-    /// 
+    /// <inheritdoc/>
     /// </summary>
     [AutoGenerateColumn(Ignore = true)]
     public Guid DynamicObjectPrimaryKey { get; set; }
 
     /// <summary>
-    /// 
+    /// 获得指定属性值方法
     /// </summary>
     /// <param name="propertyName"></param>
     /// <returns></returns>
     public virtual object? GetValue(string propertyName) => Utility.GetPropertyValue(this, propertyName);
 
     /// <summary>
-    /// 
+    /// 给指定属性设置值方法
     /// </summary>
     /// <param name="propertyName"></param>
     /// <param name="value"></param>

--- a/src/BootstrapBlazor/Dynamic/DynamicObject.cs
+++ b/src/BootstrapBlazor/Dynamic/DynamicObject.cs
@@ -21,12 +21,12 @@ public class DynamicObject : IDynamicObject
     /// </summary>
     /// <param name="propertyName"></param>
     /// <returns></returns>
-    public virtual object? GetValue(string propertyName) => Utility.GetPropertyValue(this, propertyName);
+    public virtual object? GetValue(string propertyName) => Utility.GetPropertyValue(this, propertyName, false);
 
     /// <summary>
     /// 给指定属性设置值方法
     /// </summary>
     /// <param name="propertyName"></param>
     /// <param name="value"></param>
-    public virtual void SetValue(string propertyName, object? value) => Utility.SetPropertyValue<object, object?>(this, propertyName, value);
+    public virtual void SetValue(string propertyName, object? value) => Utility.SetPropertyValue<object, object?>(this, propertyName, value, false);
 }

--- a/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
@@ -620,8 +620,9 @@ public static class LambdaExtensions
     /// <typeparam name="TResult"></typeparam>
     /// <param name="model"></param>
     /// <param name="propertyName"></param>
+    /// <param name="supportComplexProperty"></param>
     /// <returns></returns>
-    public static Expression<Func<TModel, TResult>> GetPropertyValueLambda<TModel, TResult>(TModel model, string propertyName)
+    public static Expression<Func<TModel, TResult>> GetPropertyValueLambda<TModel, TResult>(TModel model, string propertyName, bool supportComplexProperty = true)
     {
         if (model == null)
         {
@@ -629,7 +630,10 @@ public static class LambdaExtensions
         }
         var type = model.GetType();
         var parameter = Expression.Parameter(typeof(TModel));
-        return propertyName.Contains('.') ? GetComplexPropertyExpression() : GetSimplePropertyExpression();
+
+        return supportComplexProperty && propertyName.Contains('.')
+            ? GetComplexPropertyExpression()
+            : GetSimplePropertyExpression();
 
         Expression<Func<TModel, TResult>> GetSimplePropertyExpression()
         {
@@ -684,8 +688,9 @@ public static class LambdaExtensions
     /// <typeparam name="TValue"></typeparam>
     /// <param name="model"></param>
     /// <param name="propertyName"></param>
+    /// <param name="supportComplexProperty"></param>
     /// <returns></returns>
-    public static Expression<Action<TModel, TValue>> SetPropertyValueLambda<TModel, TValue>(TModel model, string propertyName)
+    public static Expression<Action<TModel, TValue>> SetPropertyValueLambda<TModel, TValue>(TModel model, string propertyName, bool supportComplexProperty = true)
     {
         if (model == null)
         {
@@ -695,7 +700,9 @@ public static class LambdaExtensions
         var type = model.GetType();
         var parameter1 = Expression.Parameter(typeof(TModel));
         var parameter2 = Expression.Parameter(typeof(TValue));
-        return propertyName.Contains('.') ? SetComplexPropertyExpression() : SetSimplePropertyExpression();
+        return (supportComplexProperty && propertyName.Contains('.'))
+            ? SetComplexPropertyExpression()
+            : SetSimplePropertyExpression();
 
         Expression<Action<TModel, TValue>> SetSimplePropertyExpression()
         {

--- a/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
@@ -274,12 +274,12 @@ public static class LambdaExtensions
     /// <returns></returns>
     public static Expression<Func<IEnumerable<TItem>, List<string>, IEnumerable<TItem>>> GetSortListLambda<TItem>()
     {
-        var exp_p1 = Expression.Parameter(typeof(IEnumerable<TItem>));
-        var exp_p2 = Expression.Parameter(typeof(List<string>));
+        var parameter1 = Expression.Parameter(typeof(IEnumerable<TItem>));
+        var parameter2 = Expression.Parameter(typeof(List<string>));
 
         var mi = typeof(LambdaExtensions).GetMethods().First(m => m.Name == nameof(Sort) && m.ReturnType.Name == typeof(IEnumerable<>).Name && m.GetParameters().Any(p => p.Name == "sortList")).MakeGenericMethod(typeof(TItem));
-        var body = Expression.Call(mi, exp_p1, exp_p2);
-        return Expression.Lambda<Func<IEnumerable<TItem>, List<string>, IEnumerable<TItem>>>(body, exp_p1, exp_p2);
+        var body = Expression.Call(mi, parameter1, parameter2);
+        return Expression.Lambda<Func<IEnumerable<TItem>, List<string>, IEnumerable<TItem>>>(body, parameter1, parameter2);
     }
 
     /// <summary>
@@ -305,16 +305,10 @@ public static class LambdaExtensions
                     sortOrder = SortOrder.Desc;
                 }
             }
-            if (index == 0)
-            {
-                // OrderBy
-                items = EnumerableOrderBy(items, sortName, sortOrder);
-            }
-            else
-            {
-                // ThenBy
-                items = EnumerableThenBy(items, sortName, sortOrder);
-            }
+
+            items = index == 0
+                ? EnumerableOrderBy(items, sortName, sortOrder)
+                : EnumerableThenBy(items, sortName, sortOrder);
         }
         return items;
     }
@@ -342,16 +336,7 @@ public static class LambdaExtensions
                     sortOrder = SortOrder.Desc;
                 }
             }
-            if (index == 0)
-            {
-                // OrderBy
-                items = QueryableOrderBy(items, sortName, sortOrder);
-            }
-            else
-            {
-                // ThenBy
-                items = QueryableThenBy(items, sortName, sortOrder);
-            }
+            items = index == 0 ? QueryableOrderBy(items, sortName, sortOrder) : QueryableThenBy(items, sortName, sortOrder);
         }
         return items;
     }
@@ -363,13 +348,13 @@ public static class LambdaExtensions
     /// <returns></returns>
     public static Expression<Func<IEnumerable<TItem>, string, SortOrder, IEnumerable<TItem>>> GetSortLambda<TItem>()
     {
-        var exp_p1 = Expression.Parameter(typeof(IEnumerable<TItem>));
-        var exp_p2 = Expression.Parameter(typeof(string));
-        var exp_p3 = Expression.Parameter(typeof(SortOrder));
+        var parameter1 = Expression.Parameter(typeof(IEnumerable<TItem>));
+        var parameter2 = Expression.Parameter(typeof(string));
+        var parameter3 = Expression.Parameter(typeof(SortOrder));
 
         var mi = typeof(LambdaExtensions).GetMethods().First(m => m.Name == nameof(Sort) && m.ReturnType.Name == typeof(IEnumerable<>).Name && m.GetParameters().Any(p => p.Name == "sortName")).MakeGenericMethod(typeof(TItem));
-        var body = Expression.Call(mi, exp_p1, exp_p2, exp_p3);
-        return Expression.Lambda<Func<IEnumerable<TItem>, string, SortOrder, IEnumerable<TItem>>>(body, exp_p1, exp_p2, exp_p3);
+        var body = Expression.Call(mi, parameter1, parameter2, parameter3);
+        return Expression.Lambda<Func<IEnumerable<TItem>, string, SortOrder, IEnumerable<TItem>>>(body, parameter1, parameter2, parameter3);
     }
 
     /// <summary>
@@ -416,15 +401,9 @@ public static class LambdaExtensions
 
     private static PropertyInfo? GetPropertyInfoByName<TItem>(this PropertyInfo? pi, string propertyName)
     {
-        if (pi == null)
-        {
-            pi = typeof(TItem).GetPropertyByName(propertyName);
-        }
-        else
-        {
-            pi = pi.PropertyType.GetPropertyByName(propertyName);
-        }
-        return pi;
+        return pi == null
+            ? typeof(TItem).GetPropertyByName(propertyName)
+            : pi.PropertyType.GetPropertyByName(propertyName);
     }
 
     private static IEnumerable<TItem> EnumerableOrderBy<TItem>(IEnumerable<TItem> query, string propertyName, SortOrder sortOrder)
@@ -608,13 +587,13 @@ public static class LambdaExtensions
 
     private static Expression<Func<TItem, TKey>> GetPropertyLambda<TItem, TKey>(PropertyInfo pi)
     {
-        var exp_p1 = Expression.Parameter(typeof(TItem));
-        return Expression.Lambda<Func<TItem, TKey>>(Expression.Property(exp_p1, pi), exp_p1);
+        var parameter1 = Expression.Parameter(typeof(TItem));
+        return Expression.Lambda<Func<TItem, TKey>>(Expression.Property(parameter1, pi), parameter1);
     }
 
     private static Expression<Func<TItem, TKey>> GetPropertyLambdaByName<TItem, TKey>(string propertyName)
     {
-        var exp_p1 = Expression.Parameter(typeof(TItem));
+        var parameter1 = Expression.Parameter(typeof(TItem));
         PropertyInfo? pi = null;
         Expression? expression = null;
         foreach (var name in propertyName.Split('.'))
@@ -622,7 +601,7 @@ public static class LambdaExtensions
             if (pi == null)
             {
                 pi = typeof(TItem).GetPropertyByName(name);
-                expression = Expression.PropertyOrField(exp_p1, name);
+                expression = Expression.PropertyOrField(parameter1, name);
             }
             else
             {
@@ -630,7 +609,7 @@ public static class LambdaExtensions
                 expression = Expression.PropertyOrField(expression!, name);
             }
         }
-        return Expression.Lambda<Func<TItem, TKey>>(expression!, exp_p1);
+        return Expression.Lambda<Func<TItem, TKey>>(expression!, parameter1);
     }
     #endregion
 

--- a/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
@@ -22,7 +22,7 @@ public static class LambdaExtensions
     private class ComboExpressionVisitor(ParameterExpression parameter) : ExpressionVisitor
     {
         /// <summary>
-        /// 
+        /// <inheritdoc/>
         /// </summary>
         /// <param name="p"></param>
         /// <returns></returns>

--- a/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
@@ -320,7 +320,7 @@ public static class LambdaExtensions
     }
 
     /// <summary>
-    /// IQueryable 排序扩展方法 
+    /// IQueryable 排序扩展方法
     /// </summary>
     /// <typeparam name="TItem"></typeparam>
     /// <param name="items"></param>
@@ -386,7 +386,7 @@ public static class LambdaExtensions
     }
 
     /// <summary>
-    /// IQueryable 排序扩展方法 
+    /// IQueryable 排序扩展方法
     /// </summary>
     /// <typeparam name="TItem"></typeparam>
     /// <param name="items"></param>

--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -513,56 +513,53 @@ internal class CacheManager : ICacheManager
         return propertyInfo != null;
     }
 
-    public static TResult GetPropertyValue<TModel, TResult>(TModel model, string fieldName)
+    public static TResult GetPropertyValue<TModel, TResult>(TModel model, string fieldName, bool supportComplexProperty) => (model is IDynamicColumnsObject d)
+        ? (TResult)d.GetValue(fieldName)!
+        : GetValue<TModel, TResult>(model, fieldName, supportComplexProperty);
+
+    private static TResult GetValue<TModel, TResult>(TModel model, string fieldName, bool supportComplexProperty)
     {
         if (model == null)
         {
             throw new ArgumentNullException(nameof(model));
         }
 
-        return (model is IDynamicColumnsObject d)
-            ? (TResult)d.GetValue(fieldName)!
-            : GetValue();
-
-        TResult GetValue()
+        var type = model.GetType();
+        var cacheKey = $"{CacheKeyPrefix}-Lambda-Get-{type.GetUniqueTypeName()}-{typeof(TModel)}-{fieldName}-{typeof(TResult)}-{supportComplexProperty}";
+        var invoker = Instance.GetOrCreate(cacheKey, entry =>
         {
-            var type = model.GetType();
-            var cacheKey = $"{CacheKeyPrefix}-Lambda-Get-{type.GetUniqueTypeName()}-{typeof(TModel)}-{fieldName}-{typeof(TResult)}";
-            var invoker = Instance.GetOrCreate(cacheKey, entry =>
+            if (type.Assembly.IsDynamic)
             {
-                if (type.Assembly.IsDynamic)
-                {
-                    entry.SetAbsoluteExpiration(TimeSpan.FromSeconds(10));
-                }
+                entry.SetAbsoluteExpiration(TimeSpan.FromSeconds(10));
+            }
 
-                return LambdaExtensions.GetPropertyValueLambda<TModel, TResult>(model, fieldName).Compile();
-            });
-            return invoker(model);
-        }
+            return LambdaExtensions.GetPropertyValueLambda<TModel, TResult>(model, fieldName, supportComplexProperty).Compile();
+        });
+        return invoker(model);
     }
 
-    public static void SetPropertyValue<TModel, TValue>(TModel model, string fieldName, TValue value)
+    public static void SetPropertyValue<TModel, TValue>(TModel model, string fieldName, TValue value, bool supportComplexProperty)
     {
-        if (model == null)
-        {
-            throw new ArgumentNullException(nameof(model));
-        }
-
         if (model is IDynamicColumnsObject d)
         {
             d.SetValue(fieldName, value);
         }
         else
         {
+            if (model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             var type = model.GetType();
-            var cacheKey = $"{CacheKeyPrefix}-Lambda-Set-{type.GetUniqueTypeName()}-{typeof(TModel)}-{fieldName}-{typeof(TValue)}";
+            var cacheKey = $"{CacheKeyPrefix}-Lambda-Set-{type.GetUniqueTypeName()}-{typeof(TModel)}-{fieldName}-{typeof(TValue)}-{supportComplexProperty}";
             var invoker = Instance.GetOrCreate(cacheKey, entry =>
             {
                 if (type.Assembly.IsDynamic)
                 {
                     entry.SetAbsoluteExpiration(TimeSpan.FromSeconds(10));
                 }
-                return LambdaExtensions.SetPropertyValueLambda<TModel, TValue>(model, fieldName).Compile();
+                return LambdaExtensions.SetPropertyValueLambda<TModel, TValue>(model, fieldName, supportComplexProperty).Compile();
             });
             invoker(model, value);
         }

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -108,16 +108,18 @@ public static class Utility
     /// <typeparam name="TResult"></typeparam>
     /// <param name="model"></param>
     /// <param name="fieldName"></param>
+    /// <param name="supportComplexProperty"></param>
     /// <returns></returns>
-    public static TResult GetPropertyValue<TModel, TResult>(TModel model, string fieldName) => CacheManager.GetPropertyValue<TModel, TResult>(model, fieldName);
+    public static TResult GetPropertyValue<TModel, TResult>(TModel model, string fieldName, bool supportComplexProperty = true) => CacheManager.GetPropertyValue<TModel, TResult>(model, fieldName, supportComplexProperty);
 
     /// <summary>
     /// 获取 指定对象的属性值
     /// </summary>
     /// <param name="model"></param>
     /// <param name="fieldName"></param>
+    /// <param name="supportComplexProperty"></param>
     /// <returns></returns>
-    public static object? GetPropertyValue(object model, string fieldName)
+    public static object? GetPropertyValue(object model, string fieldName, bool supportComplexProperty = true)
     {
         return model.GetType().Assembly.IsDynamic ? ReflectionInvoke() : LambdaInvoke();
 
@@ -132,7 +134,7 @@ public static class Utility
             return ret;
         }
 
-        object? LambdaInvoke() => GetPropertyValue<object, object?>(model, fieldName);
+        object? LambdaInvoke() => GetPropertyValue<object, object?>(model, fieldName, supportComplexProperty);
     }
 
     /// <summary>
@@ -143,8 +145,9 @@ public static class Utility
     /// <param name="model"></param>
     /// <param name="fieldName"></param>
     /// <param name="value"></param>
+    /// <param name="supportComplexProperty"></param>
     /// <returns></returns>
-    public static void SetPropertyValue<TModel, TValue>(TModel model, string fieldName, TValue value) => CacheManager.SetPropertyValue(model, fieldName, value);
+    public static void SetPropertyValue<TModel, TValue>(TModel model, string fieldName, TValue value, bool supportComplexProperty = true) => CacheManager.SetPropertyValue(model, fieldName, value, supportComplexProperty);
 
     /// <summary>
     /// 获得 排序方法
@@ -866,7 +869,7 @@ public static class Utility
     /// <param name="model"></param>
     /// <param name="fieldName"></param>
     /// <returns></returns>
-    public static EventCallback<TType> CreateCallback<TType>(ComponentBase component, object model, string fieldName) => EventCallback.Factory.Create<TType>(component, t => CacheManager.SetPropertyValue(model, fieldName, t));
+    public static EventCallback<TType> CreateCallback<TType>(ComponentBase component, object model, string fieldName) => EventCallback.Factory.Create<TType>(component, t => CacheManager.SetPropertyValue(model, fieldName, t, true));
 
     /// <summary>
     /// 获得指定泛型的 IEditorItem 集合

--- a/test/UnitTest/Components/InternalTableColumnTest.cs
+++ b/test/UnitTest/Components/InternalTableColumnTest.cs
@@ -5,7 +5,7 @@
 
 namespace UnitTest.Components;
 
-public class TableColumnTest
+public class InternalTableColumnTest
 {
     [Fact]
     public void InternalTableColumn_Ok()

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6206,6 +6206,22 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void TableColumn_SupportComplexProperty_Ok()
+    {
+        var data = new DataTable();
+        data.Columns.Add("Foo.Name", typeof(string));
+        data.Rows.Add("test01");
+        data.AcceptChanges();
+
+        var cut = Context.RenderComponent<Table<DynamicObject>>(pb =>
+        {
+            pb.Add(a => a.RenderMode, TableRenderMode.Table);
+            pb.Add(a => a.DynamicContext, new DataTableDynamicContext(data));
+        });
+        cut.Contains("test01");
+    }
+
+    [Fact]
     public async Task IsKeepSelectedRowAfterAdd_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();


### PR DESCRIPTION
# disable support complex object

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5249 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor the GetPropertyValueLambda and SetPropertyValueLambda methods to disable support for complex properties by default, and add a parameter to control this behavior. Update the GetPropertyValue and SetPropertyValue methods in the Utility class to pass this parameter to the corresponding lambda methods. Update the DynamicObject, DataTableDynamicObject, and DataTableDynamicContext classes to use the new parameter when setting property values. Update the CreateCallback method in the Utility class to pass true for the supportComplexProperty parameter. Add a unit test to verify that complex properties are handled correctly when the supportComplexProperty parameter is set to false.

Bug Fixes:
- Fix issue #5249

Tests:
- Add unit test for complex property handling