### PR TITLE
refactor(ValidateForm): use style instead of cascade parameter

### DIFF
--- a/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
+++ b/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
@@ -234,9 +234,6 @@ public partial class EditorForm<TModel> : IShowLabel
 
         // 为空时使用级联参数 ValidateForm 的 ShowLabel
         ShowLabel ??= ValidateForm?.ShowLabel;
-
-        // 为空时使用级联参数 ValidateForm 的 LabelWidth
-        LabelWidth ??= ValidateForm?.LabelWidth;
         _itemsCache = null;
     }
 

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor
@@ -5,7 +5,10 @@
 @if (Model != null)
 {
     <CascadingValue Value="this" IsFixed="true">
-        <EditForm Model="@Model" @attributes="@AdditionalAttributes" id="@Id" data-bb-dissubmit="@DisableAutoSubmitString" data-bb-invalid-result="@ShowAllInvalidResultString" OnValidSubmit="@OnValidSubmitForm" OnInvalidSubmit="@OnInvalidSubmitForm">
+        <EditForm @attributes="@AdditionalAttributes" id="@Id" Model="@Model" 
+                    data-bb-dissubmit="@DisableAutoSubmitString" data-bb-invalid-result="@ShowAllInvalidResultString"
+                    style="@StyleString"
+                    OnValidSubmit="@OnValidSubmitForm" OnInvalidSubmit="@OnInvalidSubmitForm">
             <BootstrapBlazorDataAnnotationsValidator @ref="Validator" />
             @ChildContent
         </EditForm>

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -130,6 +130,10 @@ public partial class ValidateForm
 
     private string? ShowAllInvalidResultString => ShowAllInvalidResult ? "true" : null;
 
+    private string? StyleString => CssBuilder.Default()
+        .AddClass($"--bb-row-label-width: {LabelWidth}px;", LabelWidth.HasValue)
+        .Build();
+
     /// <summary>
     /// OnParametersSet 方法
     /// </summary>

--- a/test/UnitTest/Components/EditorFormTest.cs
+++ b/test/UnitTest/Components/EditorFormTest.cs
@@ -276,32 +276,6 @@ public class EditorFormTest : BootstrapBlazorTestBase
         });
     }
 
-    [Fact]
-    public void LabelWidth_Ok()
-    {
-        var foo = new Foo();
-        var cut = Context.RenderComponent<ValidateForm>(pb =>
-        {
-            pb.Add(a => a.Model, foo);
-            pb.Add(a => a.LabelWidth, 120);
-            pb.AddChildContent<EditorForm<Foo>>(pb =>
-            {
-                pb.Add(a => a.AutoGenerateAllItem, false);
-                pb.Add(a => a.FieldItems, f => builder =>
-                {
-                    var index = 0;
-                    builder.OpenComponent<EditorItem<Foo, string>>(index++);
-                    builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.Field), f.Name);
-                    builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.FieldExpression), Utility.GenerateValueExpression(foo, nameof(Foo.Name), typeof(string)));
-                    builder.CloseComponent();
-                });
-            });
-        });
-
-        // EditorForm 使用 ValidatForm 级联参数值
-        cut.Contains("class=\"row g-3\" style=\"--bb-row-label-width: 120px;\"");
-    }
-
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -163,6 +163,25 @@ public class ValidateFormTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void LabelWidth_Ok()
+    {
+        var foo = new Foo();
+        var cut = Context.RenderComponent<ValidateForm>(pb =>
+        {
+            pb.Add(a => a.Model, foo);
+            pb.Add(a => a.LabelWidth, 120);
+            pb.AddChildContent<BootstrapInput<string>>(pb =>
+            {
+                pb.Add(a => a.Value, foo.Name);
+                pb.Add(a => a.ValueChanged, EventCallback.Factory.Create<string?>(this, v => foo.Name = v));
+                pb.Add(a => a.ValueExpression, foo.GenerateValueExpression());
+            });
+        });
+
+        cut.Contains("style=\"--bb-row-label-width: 120px;\"");
+    }
+
+    [Fact]
     public async Task SetError_Ok()
     {
         var foo = new Foo();


### PR DESCRIPTION
# use style instead of cascade parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5268 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix an issue where the `EditorForm` component was not correctly inheriting the label width from the `ValidateForm` component.