### PR TITLE
refactor(Typed): override Equals method

### DIFF
--- a/src/BootstrapBlazor/Components/Typed/Typed.razor.cs
+++ b/src/BootstrapBlazor/Components/Typed/Typed.razor.cs
@@ -28,9 +28,9 @@ public partial class Typed
     [Parameter]
     public Func<Task>? OnCompleteAsync { get; set; }
 
-    private string? _lastOptions;
-
     private string? _text;
+
+    private TypedOptions? _options;
 
     /// <summary>
     /// <inheritdoc/>
@@ -43,8 +43,8 @@ public partial class Typed
 
         if (firstRender)
         {
-            _lastOptions = Options?.ToString();
             _text = Text;
+            _options = Options;
         }
         else if (UpdateParameters())
         {
@@ -82,24 +82,12 @@ public partial class Typed
             return true;
         }
 
-        var optionString = GetOptionsString();
-        if (string.Equals(optionString, _lastOptions, StringComparison.Ordinal))
+        if (Options?.Equals(_options) ?? false)
         {
-            return false;
+            return true;
         }
 
-        _lastOptions = optionString;
-        return true;
-    }
-
-    private string? GetOptionsString()
-    {
-        if (Options == null)
-        {
-            return null;
-        }
-
-        var textString = Options.Text == null ? "" : string.Join(",", Options.Text);
-        return $"{Options} {textString}";
+        _options = Options;
+        return false;
     }
 }

--- a/src/BootstrapBlazor/Components/Typed/TypedOptions.cs
+++ b/src/BootstrapBlazor/Components/Typed/TypedOptions.cs
@@ -10,14 +10,14 @@ namespace BootstrapBlazor.Components;
 /// <summary>
 /// TypedJs 组件配置类
 /// </summary>
-public record TypedOptions
+public class TypedOptions : IEquatable<TypedOptions>
 {
     /// <summary>
     /// 获得/设置 要打字的字符串数组
     /// </summary>
     [JsonPropertyName("strings")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-    public List<string?>? Text { get; set; }
+    public List<string>? Text { get; set; }
 
     /// <summary>
     /// 获得/设置 打字速度 默认 null 未设置 单位毫秒
@@ -88,4 +88,46 @@ public record TypedOptions
     [JsonPropertyName("contentType")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? ContentType { get; set; }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="option"></param>
+    /// <returns></returns>
+    public bool Equals(TypedOptions? option)
+    {
+        if (option == null)
+        {
+            return false;
+        }
+
+        return EqualText(option.Text) &&
+               TypeSpeed == option.TypeSpeed &&
+               BackSpeed == option.BackSpeed &&
+               SmartBackspace == option.SmartBackspace &&
+               Shuffle == option.Shuffle &&
+               BackDelay == option.BackDelay &&
+               Loop == option.Loop &&
+               LoopCount == option.LoopCount &&
+               ShowCursor == option.ShowCursor &&
+               CursorChar == option.CursorChar &&
+               ContentType == option.ContentType;
+    }
+
+    private bool EqualText(List<string>? text)
+    {
+        if (Text == null && text == null)
+        {
+            return true;
+        }
+        if (Text == null || text == null)
+        {
+            return false;
+        }
+        if (Text.Count != text.Count)
+        {
+            return false;
+        }
+        return Text.SequenceEqual(text);
+    }
 }

--- a/src/BootstrapBlazor/Components/Typed/TypedOptions.cs
+++ b/src/BootstrapBlazor/Components/Typed/TypedOptions.cs
@@ -130,4 +130,25 @@ public class TypedOptions : IEquatable<TypedOptions>
         }
         return Text.SequenceEqual(text);
     }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="obj"></param>
+    /// <returns></returns>
+    public override bool Equals(object? obj)
+    {
+        if (obj is TypedOptions option)
+        {
+            return Equals(option);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    public override int GetHashCode() => base.GetHashCode();
 }

--- a/test/UnitTest/Components/TypedTest.cs
+++ b/test/UnitTest/Components/TypedTest.cs
@@ -106,4 +106,21 @@ public class TypedTest : BootstrapBlazorTestBase
         Assert.Equal("|", options.CursorChar);
         Assert.Equal("html", options.ContentType);
     }
+
+    [Fact]
+    public void Equal_Ok()
+    {
+        var options = new TypedOptions() { Text = ["test1", "test2"], TypeSpeed = 70 };
+        Assert.False(options.Equals(null));
+
+        var options2 = new TypedOptions() { Text = ["test1", "test2", "test3"], TypeSpeed = 70 };
+        Assert.False(options.Equals(options2));
+
+        var options3 = new TypedOptions() { Text = ["test1", "test2"], TypeSpeed = 70 };
+        Assert.True(options.Equals(options3));
+
+        Assert.True(options.Equals((object)options3));
+        Assert.False(options.Equals(new object()));
+        Assert.True(options.GetHashCode() > 0);
+    }
 }


### PR DESCRIPTION
# override Equals method

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5292 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Override the Equals method for the TypedOptions class.

Bug Fixes:
- Fix comparison of TypedOptions objects.

Tests:
- Add unit tests for the Equals method of the TypedOptions class.