### PR TITLE
feat(Dropdown): add OnClick event callback

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Dropdowns.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dropdowns.razor
@@ -37,7 +37,7 @@
             <Dropdown TValue="string" Items="Items" ShowSplit="true" Color="Color.Primary"></Dropdown>
         </div>
         <div class="col-6 col-sm-4 col-md-3">
-            <Dropdown TValue="string" Items="Items" ShowSplit="false" Color="Color.Info"></Dropdown>
+            <Dropdown TValue="string" Items="Items" ShowSplit="true" Color="Color.Info"></Dropdown>
         </div>
         <div class="col-6 col-sm-4 col-md-3">
             <Dropdown TValue="string" Items="Items" ShowSplit="true" Color="Color.Warning"></Dropdown>

--- a/src/BootstrapBlazor.Server/Components/Samples/Dropdowns.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dropdowns.razor.cs
@@ -251,6 +251,18 @@ public sealed partial class Dropdowns
     /// <returns></returns>
     private EventItem[] GetEvents() =>
     [
+        new()
+        {
+            Name = "OnClick",
+            Description = Localizer["EventDesc1"],
+            Type ="EventCallback<MouseEventArgs>"
+        },
+        new()
+        {
+            Name = "OnClickWithoutRender",
+            Description = Localizer["EventDesc2"],
+            Type ="Func<Task>"
+        },
         new EventItem()
         {
             Name = "OnSelectedItemChanged",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -1793,6 +1793,8 @@
     "AttributeButtonTemplate": "The template of button",
     "AttributeItemTemplate": "The template of item",
     "AttributeItemsTemplate": "The template of items",
+    "EventDesc1": "This event is triggered when the button is clicked",
+    "EventDesc2": "This event is triggered when the button is clicked and the current component is not refreshed for performance improvement",
     "EventOnSelectedItemChanged": "Triggered when the value of the drop-down box changes",
     "FixedButtonText": "The text of fixed button",
     "Item1": "Melbourne",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -1793,6 +1793,8 @@
     "AttributeButtonTemplate": "按钮模板",
     "AttributeItemTemplate": "菜单项模板",
     "AttributeItemsTemplate": "下拉菜单模板",
+    "EventDesc1": "点击按钮时触发此事件",
+    "EventDesc2": "点击按钮时触发此事件并且不刷新当前组件，用于提高性能时使用",
     "EventOnSelectedItemChanged": "下拉框值发生改变时触发",
     "FixedButtonText": "固定按钮显示文字",
     "Item1": "北京",

--- a/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor
+++ b/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor
@@ -8,7 +8,8 @@
     <BootstrapLabel for="@Id" ShowLabelTooltip="ShowLabelTooltip" Value="@DisplayText" />
 }
 <div @attributes="@AdditionalAttributes" id="@Id" class="@DirectionClassName">
-    <button type="button" class="@ButtonClassName" data-bs-toggle="@DropdownToggle" disabled="@Disabled">
+    <DynamicElement type="button" class="@ButtonClassName" data-bs-toggle="@DropdownToggle" disabled="@Disabled"
+                    TriggerClick="ShowSplit" OnClick="OnClickButton">
         @if (ButtonTemplate == null)
         {
             @ButtonText
@@ -17,7 +18,7 @@
         {
             @ButtonTemplate(SelectedItem)
         }
-    </button>
+    </DynamicElement>
     @if (ShowSplit)
     {
         <button type="button" class="@ClassName" data-bs-toggle="@ToggleString" disabled="@Disabled" aria-haspopup="true" aria-expanded="false"></button>

--- a/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.cs
+++ b/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.cs
@@ -109,6 +109,13 @@ public partial class Dropdown<TValue>
     /// </summary>
     [Parameter]
     public EventCallback<MouseEventArgs> OnClick { get; set; }
+
+    /// <summary>
+    /// 获得/设置 OnClick 事件不刷新父组件
+    /// </summary>
+    [Parameter]
+    public Func<Task>? OnClickWithoutRender { get; set; }
+
     /// <summary>
     /// 获得/设置 获取菜单对齐方式 默认 none 未设置
     /// </summary>

--- a/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.cs
+++ b/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.cs
@@ -217,4 +217,16 @@ public partial class Dropdown<TValue>
     }
 
     private string? ButtonText => IsFixedButtonText ? FixedButtonText : SelectedItem?.Text;
+
+    private async Task OnClickButton()
+    {
+        if (OnClickWithoutRender != null)
+        {
+            await OnClickWithoutRender();
+        }
+        if (OnClick.HasDelegate)
+        {
+            await OnClick.InvokeAsync();
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.cs
+++ b/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Microsoft.AspNetCore.Components.Web;
+
 namespace BootstrapBlazor.Components;
 
 /// <summary>
@@ -102,6 +104,11 @@ public partial class Dropdown<TValue>
     [Parameter]
     public bool ShowSplit { get; set; }
 
+    /// <summary>
+    /// 获得/设置 OnClick 事件
+    /// </summary>
+    [Parameter]
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
     /// <summary>
     /// 获得/设置 获取菜单对齐方式 默认 none 未设置
     /// </summary>


### PR DESCRIPTION
# add OnClick event callback

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5303 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add `OnClick` and `OnClickWithoutRender` events to the `Dropdown` component.

New Features:
- Added an `OnClick` event callback to the `Dropdown` component to allow custom logic to be executed when the dropdown button is clicked.
- Added an `OnClickWithoutRender` event callback to the `Dropdown` component. This event is useful for scenarios where re-rendering the parent component is not desired after the click action.