### PR TITLE
fix(Scroll): hover scroll width variable not work

### DIFF
--- a/src/BootstrapBlazor/Components/Scroll/Scroll.razor.scss
+++ b/src/BootstrapBlazor/Components/Scroll/Scroll.razor.scss
@@ -28,7 +28,10 @@
     }
 
     &:hover {
-        --bb-scroll-width: var(--bb-scroll-hover-width, var(--bb-scroll-default-hover-width));
+        &::-webkit-scrollbar {
+            width: var(--bb-scroll-hover-width, var(--bb-scroll-default-hover-width));
+            height: var(--bb-scroll-hover-width, var(--bb-scroll-default-hover-width));
+        }
 
         &::-webkit-scrollbar-thumb {
             background-color: var(--bb-scroll-thumb-hover-bg);


### PR DESCRIPTION
# hover scroll width variable not work

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5341 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix scrollbar width not being applied on hover.