### PR TITLE
fix(Table): ScrollWidth parameter not work

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesFixedColumn.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesFixedColumn.razor
@@ -16,7 +16,7 @@
     <Table TItem="Foo"
            Items="@Items.Take(4)"
            RenderMode="TableRenderMode.Table" AllowResizing="true"
-           IsBordered="true"
+           IsBordered="true" ScrollWidth="7" ScrollHoverWidth="10"
            IsStriped="true">
         <TableColumns>
             <TableColumn @bind-Field="@context.Name" Width="120" Fixed="true" />
@@ -101,7 +101,7 @@
            IsBordered="true"
            IsStriped="true"
            IsMultipleSelect="true"
-           IsFixedHeader="true"
+           IsFixedHeader="true" ScrollWidth="7" ScrollHoverWidth="10"
            FixedExtendButtonsColumn="true"
            IsExtendButtonsInRowHeader="true"
            FixedMultipleColumn="true"

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -198,7 +198,7 @@
         }
 
         <RenderTemplate OnRenderAsync="OnTableRenderAsync">
-            <div class="@WrapperClassName">
+            <div class="@WrapperClassName" style="@GetScrollStyleString(!IsFixedHeader)">
                 @if (ActiveRenderMode == TableRenderMode.Table)
                 {
                     if (IsFixedHeader)
@@ -209,7 +209,7 @@
                                 @RenderHeader(true)
                             </table>
                         </div>
-                        <div class="table-fixed-body scroll" style="@ScrollStyleString">
+                        <div class="table-fixed-body scroll" style="@GetScrollStyleString(true)">
                             @RenderTable(false)
                         </div>
                     }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -186,7 +186,9 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private string ScrollWidthString => $"width: {ActualScrollWidth}px;";
 
-    private string ScrollStyleString => $"--bb-scroll-width: {ActualScrollWidth}px; --bb-scroll-hover-width: {ActualScrollHoverWidth}px;";
+    private string? GetScrollStyleString(bool condition) => condition
+        ? $"--bb-scroll-width: {ActualScrollWidth}px; --bb-scroll-hover-width: {ActualScrollHoverWidth}px;"
+        : null;
 
     private int ActualScrollWidth => ScrollWidth ?? Options.CurrentValue.ScrollOptions.ScrollWidth;
 


### PR DESCRIPTION
# ScrollWidth parameter not work

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5343 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix the issue where the `ScrollWidth` parameter was not working correctly.