### PR TITLE
feat(MaskService): add Selector parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Mask/Mask.razor.cs
+++ b/src/BootstrapBlazor/Components/Mask/Mask.razor.cs
@@ -43,7 +43,12 @@ public partial class Mask
 
         if (!firstRender)
         {
-            await InvokeVoidAsync("update", Id, new { Show = _options != null, _options?.ContainerId });
+            await InvokeVoidAsync("update", Id, new
+            {
+                Show = _options != null,
+                _options?.ContainerId,
+                _options?.Selector
+            });
         }
     }
 

--- a/src/BootstrapBlazor/Components/Mask/Mask.razor.js
+++ b/src/BootstrapBlazor/Components/Mask/Mask.razor.js
@@ -1,20 +1,17 @@
 ﻿export function update(id, options) {
     const mask = document.getElementById(id);
     if (mask) {
-        const { show, containerId } = options;
+        const { show } = options;
         const el = document.querySelector(`[data-bb-mask="${id}"]`);
-        if (containerId) {
-            const container = document.getElementById(containerId);
-            if (container) {
-                const position = container.style.getPropertyValue('position');
-                if (position === '' || position === 'static') {
-                    container.style.setProperty('position', 'relative');
-                }
-
-                if (show) {
-                    el.style.setProperty('--bb-mask-position', 'absolute');
-                    container.appendChild(el);
-                }
+        const container = getContainerBySelector(options);
+        if (container) {
+            const position = container.style.getPropertyValue('position');
+            if (position === '' || position === 'static') {
+                container.style.setProperty('position', 'relative');
+            }
+            if (show) {
+                el.style.setProperty('--bb-mask-position', 'absolute');
+                container.appendChild(el);
             }
         }
         else {
@@ -31,3 +28,10 @@
         }
     }
 }
+
+const getContainerBySelector = options => {
+    const selector = getContainerById(options.containerId) ?? options.selector;
+    return selector ? document.querySelector(selector) : null;
+}
+
+const getContainerById = id => id ? `#${id}` : null;

--- a/src/BootstrapBlazor/Components/Mask/MaskOption.cs
+++ b/src/BootstrapBlazor/Components/Mask/MaskOption.cs
@@ -34,4 +34,9 @@ public class MaskOption
     /// 获得/设置 遮罩父容器 id 默认 null 未设置
     /// </summary>
     public string? ContainerId { get; set; }
+
+    /// <summary>
+    /// 获得/设置 遮罩父容器选择器 Selector 默认 null 未设置
+    /// </summary>
+    public string? Selector { get; set; }
 }

--- a/test/UnitTest/Services/MaskServiceTest.cs
+++ b/test/UnitTest/Services/MaskServiceTest.cs
@@ -66,7 +66,8 @@ public class MaskServiceTest : TestBase
                         Opacity = 0.5f,
                         ZIndex = 1050,
                         ChildContent = builder => builder.AddContent(0, "test-mask-content"),
-                        ContainerId = "test-9527"
+                        ContainerId = "test-9527",
+                        Selector = "test-mask-selector"
                     });
                 });
             });


### PR DESCRIPTION
# add Selector parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5358 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for CSS selectors when configuring the mask container. This allows for more dynamic and flexible placement of the mask element. Resolve an issue where the mask was not displaying correctly within its container.

New Features:
- Add a `Selector` parameter to the `MaskOption` class to provide more flexibility in specifying the mask's container element using a CSS selector.

Bug Fixes:
- Fix mask display issue within a container element. Add `Selector` parameter to allow specifying a CSS selector for the mask's container element, fixing issue #5358