### PR TITLE
doc(RadioList): add sample code for AutoSelectFirstWhenValueIsNull

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Radios.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Radios.razor
@@ -13,6 +13,12 @@
     <ConsoleLogger @ref="Logger" />
 </DemoBlock>
 
+<DemoBlock Title="@Localizer["RadiosAutoSelectFirstWhenValueIsNullTitle"]"
+           Introduction="@Localizer["RadiosAutoSelectFirstWhenValueIsNullIntro"]"
+           Name="AutoSelectFirstWhenValueIsNull">
+    <RadioList TValue="string" Items="@AutoSelectValues" AutoSelectFirstWhenValueIsNull="false" />
+</DemoBlock>
+
 <DemoBlock Title="@Localizer["RadiosDisableTitle"]"
            Introduction='@Localizer["RadiosDisableIntro"]'
            Name="Disable">

--- a/src/BootstrapBlazor.Server/Components/Samples/Radios.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Radios.razor.cs
@@ -17,6 +17,9 @@ public sealed partial class Radios
     private IEnumerable<SelectedItem>? DemoValues { get; set; }
 
     [NotNull]
+    private IEnumerable<SelectedItem>? AutoSelectValues { get; set; }
+
+    [NotNull]
     private IEnumerable<SelectedItem>? DisableValues { get; set; }
 
     [NotNull]
@@ -65,6 +68,12 @@ public sealed partial class Radios
         base.OnInitialized();
 
         DemoValues = new List<SelectedItem>(2)
+        {
+            new("1", Localizer["RadiosItem1"]),
+            new("2", Localizer["RadiosItem2"])
+        };
+
+        AutoSelectValues = new List<SelectedItem>(2)
         {
             new("1", Localizer["RadiosItem1"]),
             new("2", Localizer["RadiosItem2"])
@@ -177,6 +186,14 @@ public sealed partial class Radios
             Type = "IEnumerable<TItem>",
             ValueList = " — ",
             DefaultValue = "—"
+        },
+        new()
+        {
+            Name = "AutoSelectFirstWhenValueIsNull",
+            Description = Localizer["RadiosAutoSelectFirstWhenValueIsNull"],
+            Type = "bool",
+            ValueList = "true|false",
+            DefaultValue = "true"
         }
     ];
 

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3056,7 +3056,10 @@
     "RadiosAdd1": "Beijing",
     "RadiosAdd2": "Shanghai",
     "RadioListGenericTitle": "Generic List",
-    "RadioListGenericIntro": "Enable generic support by using the <code>RadioListGeneric</code> component with <code>SelectedItem&lt;TValue&gt;</code>"
+    "RadioListGenericIntro": "Enable generic support by using the <code>RadioListGeneric</code> component with <code>SelectedItem&lt;TValue&gt;</code>",
+    "RadiosAutoSelectFirstWhenValueIsNullTitle": "AutoSelectFirst",
+    "RadiosAutoSelectFirstWhenValueIsNullIntro": "The selection of <code>RadioList</code> candidates can be controlled by setting the <code>AutoSelectFirstWhenValueIsNull</code> parameter. The default value of the parameter is <b>true</b>, which means that if the current value of the component is inconsistent with the value in the candidate, the first candidate is automatically selected. If it is set to <b>false</b>, all candidates will be unselected.",
+    "RadiosAutoSelectFirstWhenValueIsNull": "Whether to select the first candidate by default when the value is not null"
   },
   "BootstrapBlazor.Server.Components.Samples.Rates": {
     "RatesTitle": "Rate",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3056,7 +3056,10 @@
     "RadiosAdd1": "北京",
     "RadiosAdd2": "上海",
     "RadioListGenericTitle": "泛型支持",
-    "RadioListGenericIntro": "通过使用 <code>RadioListGeneric</code> 组件配合 <code>SelectedItem&lt;TValue&gt;</code> 开启泛型支持"
+    "RadioListGenericIntro": "通过使用 <code>RadioListGeneric</code> 组件配合 <code>SelectedItem&lt;TValue&gt;</code> 开启泛型支持",
+    "RadiosAutoSelectFirstWhenValueIsNullTitle": "自动选择第一候选项",
+    "RadiosAutoSelectFirstWhenValueIsNullIntro": "通过设置 <code>AutoSelectFirstWhenValueIsNull</code> 参数控制 <code>RadioList</code> 候选项选中情况，参数默认值为 <b>true</b>，即如果组件当前值与候选项中值无一致值时，自动选中第一个候选项，设置为 <b>false</b> 后，候选项将全部为未选中状态。",
+    "RadiosAutoSelectFirstWhenValueIsNull": "值未 null 时是否默认选中第一个候选项"
   },
   "BootstrapBlazor.Server.Components.Samples.Rates": {
     "RatesTitle": "Rate 评分",


### PR DESCRIPTION
# add sample code for AutoSelectFirstWhenValueIsNull

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5364 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add sample code for the `AutoSelectFirstWhenValueIsNull` parameter in the `RadioList` component and fix the issue where the first item was not selected when the value was null.

Bug Fixes:
- Fix issue where RadioList component would not select the first item when the value is null and AutoSelectFirstWhenValueIsNull is set to true.

Documentation:
- Add sample code demonstrating the usage of the `AutoSelectFirstWhenValueIsNull` parameter for the `RadioList` component.