### PR TITLE
feat(ButtonUpload): add FileCount parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Upload/ButtonUploadBase.cs
+++ b/src/BootstrapBlazor/Components/Upload/ButtonUploadBase.cs
@@ -180,6 +180,7 @@ public abstract class ButtonUploadBase<TValue> : SingleUploadBase<TValue>
                 OriginFileName = f.Name,
                 Size = f.Size,
                 File = f,
+                FileCount = args.FileCount,
                 Uploaded = OnChange == null,
                 UpdateCallback = Update
             }).ToList();

--- a/src/BootstrapBlazor/Components/Upload/UploadBase.cs
+++ b/src/BootstrapBlazor/Components/Upload/UploadBase.cs
@@ -21,7 +21,7 @@ public abstract class UploadBase<TValue> : ValidateBase<TValue>, IUpload
         .Build();
 
     /// <summary>
-    /// 
+    /// 获得/设置 当前上传文件
     /// </summary>
     protected UploadFile? CurrentFile { get; set; }
 

--- a/src/BootstrapBlazor/Components/Upload/UploadFile.cs
+++ b/src/BootstrapBlazor/Components/Upload/UploadFile.cs
@@ -48,6 +48,11 @@ public class UploadFile
     public IBrowserFile? File { get; set; }
 
     /// <summary>
+    /// 获得/设置 上传文件数量
+    /// </summary>
+    public int FileCount { get; init; } = 1;
+
+    /// <summary>
     /// 获得/设置 更新进度回调委托
     /// </summary>
     internal Action<UploadFile>? UpdateCallback { get; set; }

--- a/test/UnitTest/Components/UploadTest.cs
+++ b/test/UnitTest/Components/UploadTest.cs
@@ -606,6 +606,7 @@ public class UploadTest : BootstrapBlazorTestBase
     [Fact]
     public async Task ButtonUpload_IsDirectory_Ok()
     {
+        var fileCount = 0;
         var fileNames = new List<string>();
         List<UploadFile> fileList = [];
         var cut = Context.RenderComponent<ButtonUpload<string>>(pb =>
@@ -613,6 +614,7 @@ public class UploadTest : BootstrapBlazorTestBase
             pb.Add(a => a.IsDirectory, true);
             pb.Add(a => a.OnChange, file =>
             {
+                fileCount = file.FileCount;
                 fileNames.Add(file.OriginFileName!);
                 return Task.CompletedTask;
             });
@@ -628,6 +630,7 @@ public class UploadTest : BootstrapBlazorTestBase
             new(),
             new("UploadTestFile2")
         })));
+        Assert.Equal(2, fileCount);
         Assert.Equal(2, fileNames.Count);
         Assert.Equal(2, fileList.Count);
     }


### PR DESCRIPTION
# add FileCount parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5329 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add `FileCount` parameter to `UploadFile` class and update `ButtonUpload` component to use it.

New Features:
- Add a `FileCount` parameter to the `UploadFile` class to track the number of uploaded files. 

Bug Fixes:
- Resolve issue #5329

Tests:
- Add a test case for the `ButtonUpload` component to verify the `FileCount` parameter.