### PR TITLE
feat(DataTableDynamicContext): add UseCache parameter

### DIFF
--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
@@ -109,11 +109,14 @@ public class DataTableDynamicContext : DynamicObjectContext
     /// <returns></returns>
     public override IEnumerable<IDynamicObject> GetItems()
     {
-        if (!UseCache)
+        if (UseCache)
         {
-            Items = null;
+            Items ??= BuildItems();
         }
-        Items ??= BuildItems();
+        else
+        {
+            Items = BuildItems();
+        }
         return Items;
     }
 

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
@@ -109,6 +109,10 @@ public class DataTableDynamicContext : DynamicObjectContext
     /// <returns></returns>
     public override IEnumerable<IDynamicObject> GetItems()
     {
+        if (!UseCache)
+        {
+            Items = null;
+        }
         Items ??= BuildItems();
         return Items;
     }

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
@@ -29,6 +29,11 @@ public class DataTableDynamicContext : DynamicObjectContext
     private Action<DataTableDynamicContext, ITableColumn>? AddAttributesCallback { get; set; }
 
     /// <summary>
+    /// 获得/设置 是否启用内部缓存 默认 true 启用
+    /// </summary>
+    public bool UseCache { get; set; } = true;
+
+    /// <summary>
     /// 负责将 DataRow 与 Items 关联起来方便查找提高效率
     /// </summary>
     private ConcurrentDictionary<Guid, (IDynamicObject DynamicObject, DataRow Row)> Caches { get; } = new();

--- a/test/UnitTest/Components/DataTableDynamicContextTest.cs
+++ b/test/UnitTest/Components/DataTableDynamicContextTest.cs
@@ -1,0 +1,38 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using System.Data;
+
+namespace UnitTest.Components;
+
+public class DataTableDynamicContextTest : BootstrapBlazorTestBase
+{
+    [Fact]
+    public void UseCache_Ok()
+    {
+        var table = new DataTable();
+        table.Columns.Add("Id", typeof(int));
+        table.Rows.Add(1);
+        table.AcceptChanges();
+
+        var context = new DataTableDynamicContext(table);
+        Assert.True(context.UseCache);
+
+        var data = context.GetItems();
+        Assert.Single(data);
+        Assert.Equal(1, data.First().GetValue("Id"));
+
+        // 增加数据
+        table.Rows.Add(2);
+        var data2 = context.GetItems();
+        Assert.Equal(data, data2);
+
+        // 关闭缓存
+        context.UseCache = false;
+        table.Rows.Add(3);
+        data2 = context.GetItems();
+        Assert.Equal(3, data2.Count());
+    }
+}


### PR DESCRIPTION
# add UseCache parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5384 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduced a `UseCache` parameter to the `DataTableDynamicContext` to allow developers to control whether the internal cache is used when retrieving items, providing more flexibility in data handling.

New Features:
- Added a `UseCache` parameter to the `DataTableDynamicContext` class to control whether the internal cache is used when retrieving items.

Enhancements:
- The `GetItems` method now checks the `UseCache` property to determine whether to use the cached items or rebuild them.