### PR TITLE
feat(Tab): add BeforeNavigatorTemplate/AfterNavigatorTemplate parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.3.1-beta19</Version>
+    <Version>9.3.1-beta21</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor
@@ -11,6 +11,10 @@ else
     <div @attributes="@AdditionalAttributes" id="@Id" class="@ClassString" style="@StyleString">
         <div class="tabs-header">
             <div class="@WrapClassString">
+                @if (BeforeNavigatorTemplate != null)
+                {
+                    @BeforeNavigatorTemplate
+                }
                 @if (ShowNavigatorButtons)
                 {
                     <div class="nav-link-bar left" @onclick="@ClickPrevTab"><i class="@PreviousIcon"></i></div>
@@ -105,6 +109,10 @@ else
                         <div class="dropdown-item" @onclick="@OnClickCloseOtherTabs"><span>@CloseOtherTabsText</span></div>
                         <div class="dropdown-item" @onclick="@OnClickCloseAllTabs"><span>@CloseAllTabsText</span></div>
                     </div>
+                }
+                @if (AfterNavigatorTemplate != null)
+                {
+                    @AfterNavigatorTemplate
                 }
             </div>
         </div>

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -227,6 +227,20 @@ public partial class Tab : IHandlerException
     public RenderFragment? ButtonTemplate { get; set; }
 
     /// <summary>
+    /// 获得/设置 标签页前置模板 默认 null
+    /// <para>在向前移动标签页按钮前</para>
+    /// </summary>
+    [Parameter]
+    public RenderFragment? BeforeNavigatorTemplate { get; set; }
+
+    /// <summary>
+    /// 获得/设置 标签页后置模板 默认 null
+    /// <para>在向后移动标签页按钮前</para>
+    /// </summary>
+    [Parameter]
+    public RenderFragment? AfterNavigatorTemplate { get; set; }
+
+    /// <summary>
     /// 获得/设置 上一个标签图标
     /// </summary>
     [Parameter]

--- a/test/UnitTest/Components/TabTest.cs
+++ b/test/UnitTest/Components/TabTest.cs
@@ -877,6 +877,27 @@ public class TabTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => button.Click());
     }
 
+    [Fact]
+    public void BeforeNavigatorTemplate_Ok()
+    {
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Tab>(pb =>
+            {
+                pb.Add(a => a.BeforeNavigatorTemplate, builder => builder.AddContent(0, "before-navigator-template"));
+                pb.Add(a => a.AfterNavigatorTemplate, builder => builder.AddContent(0, "after-navigator-template"));
+                pb.AddChildContent<TabItem>(pb =>
+                {
+                    pb.Add(a => a.ShowFullScreen, true);
+                    pb.Add(a => a.Text, "Text1");
+                    pb.Add(a => a.ChildContent, builder => builder.AddContent(0, "Test1"));
+                });
+            });
+        });
+        cut.Contains("before-navigator-template");
+        cut.Contains("after-navigator-template");
+    }
+
     class DisableTabItemButton : ComponentBase
     {
         [CascadingParameter, NotNull]


### PR DESCRIPTION
# add BeforeNavigatorTemplate/AfterNavigatorTemplate parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5393 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

This pull request introduces `BeforeNavigatorTemplate` and `AfterNavigatorTemplate` parameters to the Tab component, providing more flexibility in customizing the tab navigator area.

New Features:
- Added `BeforeNavigatorTemplate` and `AfterNavigatorTemplate` parameters to the Tab component, allowing developers to inject custom content before and after the tab navigator buttons.

Tests:
- Added a unit test to verify the rendering of the `BeforeNavigatorTemplate` and `AfterNavigatorTemplate` parameters in the Tab component.