### PR TITLE
feat(Drawer): add ZIndex parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.3.1-beta21</Version>
+    <Version>9.3.1-beta22</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Drawer/Drawer.razor.cs
+++ b/src/BootstrapBlazor/Components/Drawer/Drawer.razor.cs
@@ -20,6 +20,7 @@ public partial class Drawer
 
     private string? StyleString => CssBuilder.Default()
         .AddStyle("--bb-drawer-position", Position)
+        .AddClass($"--bb-drawer-zindex: {ZIndex};", ZIndex.HasValue)
         .AddStyleFromAttributes(AdditionalAttributes)
         .Build();
 
@@ -108,6 +109,12 @@ public partial class Drawer
     public bool AllowResize { get; set; }
 
     /// <summary>
+    /// 获得/设置 z-index 参数值 默认 null 未设置
+    /// </summary>
+    [Parameter]
+    public int? ZIndex { get; set; }
+
+    /// <summary>
     /// 获得/设置 关闭抽屉回调委托 默认 null
     /// </summary>
     [Parameter]
@@ -133,7 +140,7 @@ public partial class Drawer
 
     private string? KeyboardString => IsKeyboard ? "true" : null;
 
-    private string? BodyScrollString => BodyScroll ? "true" : null;   
+    private string? BodyScrollString => BodyScroll ? "true" : null;
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/Drawer/DrawerContainer.cs
+++ b/src/BootstrapBlazor/Components/Drawer/DrawerContainer.cs
@@ -81,6 +81,10 @@ public class DrawerContainer : ComponentBase, IDisposable
         {
             parameters.Add(nameof(Drawer.Height), option.Height);
         }
+        if (option.ZIndex.HasValue)
+        {
+            parameters.Add(nameof(Drawer.ZIndex), option.ZIndex);
+        }
         var content = option.GetContent();
         if (content != null)
         {

--- a/src/BootstrapBlazor/Components/Drawer/DrawerOption.cs
+++ b/src/BootstrapBlazor/Components/Drawer/DrawerOption.cs
@@ -79,4 +79,9 @@ public class DrawerOption
     /// 获得/设置 相关连数据，多用于传值使用
     /// </summary>
     public object? BodyContext { get; set; }
+
+    /// <summary>
+    /// 获得/设置 z-index 参数值 默认 null 未设置
+    /// </summary>
+    public int? ZIndex { get; set; }
 }

--- a/test/UnitTest/Components/DrawerTest.cs
+++ b/test/UnitTest/Components/DrawerTest.cs
@@ -162,6 +162,16 @@ public class DrawerTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void ZIndex_Ok()
+    {
+        var cut = Context.RenderComponent<Drawer>(builder =>
+        {
+            builder.Add(a => a.ZIndex, 1055);
+        });
+        cut.Contains("--bb-drawer-zindex: 1055;");
+    }
+
+    [Fact]
     public void IsKeyboard_Ok()
     {
         var cut = Context.RenderComponent<Drawer>(builder =>

--- a/test/UnitTest/Services/DrawerServiceTest.cs
+++ b/test/UnitTest/Services/DrawerServiceTest.cs
@@ -25,12 +25,14 @@ public class DrawerServiceTest : BootstrapBlazorTestBase
             ShowBackdrop = true,
             BodyContext = "test-body-context",
             IsKeyboard = true,
-            BodyScroll = true
+            BodyScroll = true,
+            ZIndex = 1066
         };
         var service = Context.Services.GetRequiredService<DrawerService>();
         var cut = Context.RenderComponent<BootstrapBlazorRoot>();
         await service.Show(option);
         cut.Contains("data-bb-keyboard=\"true\"");
+        cut.Contains("--bb-drawer-zindex: 1066;");
         var button = cut.Find("button");
         await cut.InvokeAsync(() => button.Click());
 


### PR DESCRIPTION
# add ZIndex parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5395 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

This pull request introduces a `ZIndex` parameter to the `Drawer` component, allowing developers to control the stacking order of drawers. It also adds a corresponding property to the `DrawerOption` class for use with the `DrawerContainer` and includes a unit test for the new parameter.

New Features:
- Added a `ZIndex` parameter to the `Drawer` component to allow users to control the stacking order of the drawer.

Enhancements:
- The `DrawerOption` class now includes a `ZIndex` property to allow setting the z-index of the drawer when using the `DrawerContainer`.

Tests:
- Added a unit test to verify the `ZIndex` parameter of the `Drawer` component.