### PR TITLE
bug(EnableIpLocator): WebClientOptions parameter EnableIpLocator not work

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.3.1-beta22</Version>
+    <Version>9.3.1-beta23</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/ConnectionHub/ConnectionHub.cs
+++ b/src/BootstrapBlazor/Components/ConnectionHub/ConnectionHub.cs
@@ -51,7 +51,8 @@ public class ConnectionHub : BootstrapModuleComponentBase
                 Method = nameof(Callback),
                 ConnectionId = Guid.NewGuid(),
                 Interval = options.BeatInterval.TotalMilliseconds,
-                Url = "ip.axd"
+                Url = "ip.axd",
+                BootstrapBlazorOptions.Value.WebClientOptions.EnableIpLocator
             });
         }
     }

--- a/src/BootstrapBlazor/Services/WebClientService.cs
+++ b/src/BootstrapBlazor/Services/WebClientService.cs
@@ -44,7 +44,10 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
         {
             _jsModule ??= await runtime.LoadModuleByName("client");
             _interop ??= DotNetObjectReference.Create(this);
-            await _jsModule.InvokeVoidAsync("ping", "ip.axd", _interop, nameof(SetData));
+            await _jsModule.InvokeVoidAsync("ping", "ip.axd", _interop, nameof(SetData), new
+            {
+                options.CurrentValue.WebClientOptions.EnableIpLocator
+            });
 
             // 等待 SetData 方法执行完毕
             await _taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(3));

--- a/src/BootstrapBlazor/wwwroot/modules/client.js
+++ b/src/BootstrapBlazor/wwwroot/modules/client.js
@@ -1,12 +1,12 @@
 ﻿import "./browser.js"
 import { execute } from "./ajax.js"
 
-export async function ping(url, invoke, method) {
-    const data = await getClientInfo(url);
+export async function ping(url, invoke, method, options) {
+    const data = await getClientInfo(url, options);
     await invoke.invokeMethodAsync(method, data)
 }
 
-export async function getClientInfo(url) {
+export async function getClientInfo(url, options) {
     const info = browser()
     let data = {
         browser: info.browser + ' ' + info.version,
@@ -17,12 +17,14 @@ export async function getClientInfo(url) {
         os: info.system + ' ' + info.systemVersion
     }
 
-    const result = await execute({
-        method: 'GET',
-        url
-    });
-    if (result) {
-        data.ip = result.Ip;
+    if (options.enableIpLocator === true) {
+        const result = await execute({
+            method: 'GET',
+            url
+        });
+        if (result) {
+            data.ip = result.Ip;
+        }
     }
     data.id = localStorage.getItem('bb_hub_connection_id') ?? result.Id;
     return data;

--- a/src/BootstrapBlazor/wwwroot/modules/hub.js
+++ b/src/BootstrapBlazor/wwwroot/modules/hub.js
@@ -3,7 +3,7 @@ import Data from "./data.js"
 import EventHandler from "./event-handler.js";
 
 export async function init(id, options) {
-    const { invoke, method, interval = 3000, url, connectionId } = options;
+    const { invoke, method, interval = 3000, url, connectionId, enableIpLocator } = options;
     const elKey = 'bb_hub_el_id';
     if (localStorage.getItem(elKey) === null) {
         localStorage.setItem(elKey, id);
@@ -34,7 +34,7 @@ export async function init(id, options) {
         }
     });
 
-    const info = await getClientInfo(url);
+    const info = await getClientInfo(url, { enableIpLocator: enableIpLocator });
     info.id = clientId;
 
     const callback = async () => {


### PR DESCRIPTION
# WebClientOptions parameter EnableIpLocator not work

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5399 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fixes a bug where the `EnableIpLocator` option was not working as expected. The fix ensures that the `EnableIpLocator` option is correctly passed to the client-side JavaScript, enabling or disabling IP address resolution as intended.

Bug Fixes:
- Fixes an issue where the `EnableIpLocator` option in `WebClientOptions` was not being correctly passed to the client-side JavaScript, preventing the IP address from being resolved.

Enhancements:
- Passes the `EnableIpLocator` option to the client-side JavaScript to control IP address resolution.