### PR TITLE
fix(DateTimeRange): should be reset Value after close pop-up

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.3.1-beta25</Version>
+    <Version>9.3.1-beta26</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor
@@ -1,7 +1,7 @@
 ﻿@namespace BootstrapBlazor.Components
 @typeparam TValue
 @inherits PopoverDropdownBase<TValue>
-@attribute [BootstrapModuleAutoLoader("DateTimePicker/DateTimePicker.razor.js")]
+@attribute [BootstrapModuleAutoLoader("DateTimePicker/DateTimePicker.razor.js", JSObjectReference = true)]
 
 @if (IsShowLabel)
 {

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.cs
@@ -372,6 +372,15 @@ public partial class DateTimePicker<TValue>
         return ret;
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new
+    {
+        TriggerHideCallback = nameof(TriggerHideCallback)
+    });
+
     private bool MinValueToEmpty(DateTime val) => val == DateTime.MinValue && AllowNull && DisplayMinValueAsEmpty;
 
     private bool MinValueToToday(DateTime val) => val == DateTime.MinValue && !AllowNull && AutoToday;
@@ -453,5 +462,16 @@ public partial class DateTimePicker<TValue>
         {
             await OnBlurAsync(Value);
         }
+    }
+
+    /// <summary>
+    /// 客户端弹窗关闭后由 Javascript 调用此方法
+    /// </summary>
+    /// <returns></returns>
+    [JSInvokable]
+    public Task TriggerHideCallback()
+    {
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 }

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.js
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.js
@@ -15,8 +15,7 @@ export function init(id, invoke, options) {
             return el.classList.contains('disabled');
         },
         hideCallback: () => {
-            console.log('hideCallback');
-            invoke.invokeMethodAsync(options.triggerHideCallback);
+            invoke?.invokeMethodAsync(options.triggerHideCallback);
         }
     });
     const dateTimePicker = {

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.js
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.js
@@ -2,7 +2,7 @@
 import EventHandler from "../../modules/event-handler.js"
 import Popover from "../../modules/base-popover.js"
 
-export function init(id) {
+export function init(id, invoke, options) {
     const el = document.getElementById(id)
     if (el == null) {
         return
@@ -13,6 +13,10 @@ export function init(id) {
         dropdownSelector: el.getAttribute('data-bb-dropdown'),
         isDisabled: () => {
             return el.classList.contains('disabled');
+        },
+        hideCallback: () => {
+            console.log('hideCallback');
+            invoke.invokeMethodAsync(options.triggerHideCallback);
         }
     });
     const dateTimePicker = {

--- a/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor
+++ b/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor
@@ -1,6 +1,6 @@
 ﻿@namespace BootstrapBlazor.Components
 @inherits PopoverDropdownBase<DateTimeRangeValue>
-@attribute [BootstrapModuleAutoLoader("DateTimePicker/DateTimePicker.razor.js")]
+@attribute [BootstrapModuleAutoLoader("DateTimePicker/DateTimePicker.razor.js", JSObjectReference = true)]
 
 @if (IsShowLabel)
 {

--- a/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
@@ -311,24 +311,7 @@ public partial class DateTimeRange
             new() { Text = Localizer["LastMonth"], StartDateTime = DateTime.Today.AddDays(1- DateTime.Today.Day).AddMonths(-1), EndDateTime = DateTime.Today.AddDays(1- DateTime.Today.Day).AddSeconds(-1) },
         ];
 
-        Value ??= new DateTimeRangeValue();
-        EndValue = Value.End == DateTime.MinValue ? GetEndDateTime(DateTime.Today) : Value.End;
-
-        if (ViewMode == DatePickerViewMode.Year)
-        {
-            var d = DateTime.Today.AddYears(-1);
-            StartValue = Value.Start == DateTime.MinValue ? new DateTime(d.Year, 1, 1) : Value.Start;
-        }
-        else if (ViewMode == DatePickerViewMode.Month)
-        {
-            var d = DateTime.Today.AddMonths(-1);
-            StartValue = Value.Start == DateTime.MinValue ? new DateTime(d.Year, d.Month, 1) : Value.Start;
-        }
-        else
-        {
-            StartValue = EndValue.AddMonths(-1).Date;
-        }
-
+        ResetBodyValue();
         SelectedValue.Start = Value.Start;
         SelectedValue.End = Value.End;
 
@@ -341,6 +324,15 @@ public partial class DateTimeRange
             }
         }
     }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new
+    {
+        TriggerHideCallback = nameof(TriggerHideCallback)
+    });
 
     private async Task OnClickSidebarItem(DateTimeRangeSidebarItem item)
     {
@@ -505,4 +497,37 @@ public partial class DateTimeRange
     public override bool IsComplexValue(object? propertyValue) => false;
 
     private static DateTime GetEndDateTime(DateTime dt) => dt.Date.AddHours(23).AddMinutes(59).AddSeconds(59);
+
+    private void ResetBodyValue()
+    {
+        Value ??= new DateTimeRangeValue();
+        EndValue = Value.End == DateTime.MinValue ? GetEndDateTime(DateTime.Today) : Value.End;
+
+        if (ViewMode == DatePickerViewMode.Year)
+        {
+            var d = DateTime.Today.AddYears(-1);
+            StartValue = Value.Start == DateTime.MinValue ? new DateTime(d.Year, 1, 1) : Value.Start;
+        }
+        else if (ViewMode == DatePickerViewMode.Month)
+        {
+            var d = DateTime.Today.AddMonths(-1);
+            StartValue = Value.Start == DateTime.MinValue ? new DateTime(d.Year, d.Month, 1) : Value.Start;
+        }
+        else
+        {
+            StartValue = EndValue.AddMonths(-1).Date;
+        }
+    }
+
+    /// <summary>
+    /// 客户端弹窗关闭后由 Javascript 调用此方法
+    /// </summary>
+    /// <returns></returns>
+    [JSInvokable]
+    public Task TriggerHideCallback()
+    {
+        ResetBodyValue();
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
 }

--- a/src/BootstrapBlazor/wwwroot/modules/base-popover.js
+++ b/src/BootstrapBlazor/wwwroot/modules/base-popover.js
@@ -14,9 +14,10 @@ const Popover = {
                 isDisabled: () => {
                     return isDisabled(el) || isDisabled(el.parentNode) || isDisabled(el.querySelector('.form-control'))
                 },
-                initCallback: null
+                initCallback: null,
+                hideCallback: null
             },
-            ...config || {}
+            ...(config ?? {})
         }
         const createPopover = () => {
             if (!popover.isDisabled()) {
@@ -69,6 +70,12 @@ const Popover = {
             }
         }
 
+        popover.triggerHideCallback = () => {
+            if (popover.hideCallback) {
+                popover.hideCallback();
+            };
+        }
+
         if (popover.isPopover) {
             popover.hasDisplayNone = false;
 
@@ -112,6 +119,8 @@ const Popover = {
                 popover.popover.tip.classList.remove('show');
                 el.classList.remove('show');
                 el.append(popover.toggleMenu);
+
+                popover.triggerHideCallback();
             }
 
             const active = e => {
@@ -176,6 +185,7 @@ const Popover = {
             }
 
             EventHandler.on(el, 'show.bs.dropdown', show)
+            EventHandler.on(el, 'hide.bs.dropdown', popover.triggerHideCallback)
 
             popover.popover = bootstrap.Dropdown.getOrCreateInstance(popover.toggleElement);
         }
@@ -200,6 +210,7 @@ const Popover = {
         }
         else {
             EventHandler.off(popover.el, 'show.bs.dropdown')
+            EventHandler.off(popover.el, 'hide.bs.dropdown')
         }
     }
 }

--- a/test/UnitTest/Components/DateTimePickerTest.cs
+++ b/test/UnitTest/Components/DateTimePickerTest.cs
@@ -483,6 +483,19 @@ public class DateTimePickerTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task TriggerHideCallback_Ok()
+    {
+        var cut = Context.RenderComponent<DateTimePicker<DateTime>>(pb =>
+        {
+            pb.Add(a => a.DayTemplate, dt => builder =>
+            {
+                builder.AddContent(0, "day-template");
+            });
+        });
+        await cut.InvokeAsync(() => cut.Instance.TriggerHideCallback());
+    }
+
+    [Fact]
     public void DayTemplate_Ok()
     {
         var cut = Context.RenderComponent<DateTimePicker<DateTime>>(pb =>

--- a/test/UnitTest/Components/DateTimeRangeTest.cs
+++ b/test/UnitTest/Components/DateTimeRangeTest.cs
@@ -666,4 +666,14 @@ public class DateTimeRangeTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cells[0].Click());
         await cut.InvokeAsync(() => cells[1].Click());
     }
+
+    [Fact]
+    public async Task TriggerHideCallback_Ok()
+    {
+        var cut = Context.RenderComponent<DateTimeRange>(pb =>
+        {
+            pb.Add(a => a.Value, new DateTimeRangeValue());
+        });
+        await cut.InvokeAsync(() => cut.Instance.TriggerHideCallback());
+    }
 }


### PR DESCRIPTION
# should be reset Value after close pop-up

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5383 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fixes an issue where the DateTimeRange component was not properly resetting its value after the popup was closed. This is achieved by adding a JavaScript callback function that is triggered when the popup is closed, and then resetting the component's value.

Bug Fixes:
- Fixes an issue where the DateTimeRange component was not properly resetting its value after the popup was closed.

Enhancements:
- Adds a JavaScript callback function to the DateTimePicker and DateTimeRange components that is triggered when the popup is closed.
- The DateTimeRange component now resets its body value when the popup is closed.

Tests:
- Adds a unit test for the TriggerHideCallback method in the DateTimePicker component.