### PR TITLE
feat(AjaxService): add ToJson parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.3.1-beta33</Version>
+    <Version>9.3.1-beta34</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Ajax/AjaxOption.cs
+++ b/src/BootstrapBlazor/Components/Ajax/AjaxOption.cs
@@ -26,4 +26,10 @@ public class AjaxOption
     /// </summary>
     [NotNull]
     public string? Url { get; set; }
+
+    /// <summary>
+    /// 获得/设置 是否获得序列化 Json 结果 参数 默认为 true
+    /// </summary>
+    [NotNull]
+    public bool ToJson { get; set; }
 }

--- a/src/BootstrapBlazor/wwwroot/modules/ajax.js
+++ b/src/BootstrapBlazor/wwwroot/modules/ajax.js
@@ -14,8 +14,8 @@
 
     let result = null;
     try {
-        const toJson = opitons.toJson;
-        delete options.toJson;
+        const toJson = option.toJson;
+        delete option.toJson;
         result = await fetch(option.url, {
             method: option.method,
             headers: {

--- a/src/BootstrapBlazor/wwwroot/modules/ajax.js
+++ b/src/BootstrapBlazor/wwwroot/modules/ajax.js
@@ -14,14 +14,13 @@
 
     let result = null;
     try {
-        const toJson = option.toJson;
-        delete option.toJson;
-        result = await fetch(option.url, {
-            method: option.method,
+        const { toJson, url, method, data } = option;
+        result = await fetch(url, {
+            method: method,
             headers: {
                 'Content-Type': 'application/json'
             },
-            body: option.method === 'POST' ? JSON.stringify(option.data) : null
+            body: method === 'POST' ? JSON.stringify(data) : null
         });
         if (toJson === true) {
             result = await result.json()

--- a/src/BootstrapBlazor/wwwroot/modules/ajax.js
+++ b/src/BootstrapBlazor/wwwroot/modules/ajax.js
@@ -3,6 +3,7 @@
         method: 'POST',
         url: null,
         data: null,
+        toJson: true,
         ...option
     }
 
@@ -11,27 +12,25 @@
         return null
     }
 
-    const init = {
-        method: option.method,
-        headers: {
-            'Content-Type': 'application/json'
-        }
-    }
-
-    if (option.method === 'POST' && option.data) {
-        init.body = JSON.stringify(option.data)
-    }
-
-    let json = null;
+    let result = null;
     try {
-
-        const response = await fetch(option.url, init)
-        json = await response.json()
+        const toJson = opitons.toJson;
+        delete options.toJson;
+        result = await fetch(option.url, {
+            method: option.method,
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: option.method === 'POST' ? JSON.stringify(option.data) : null
+        });
+        if (toJson === true) {
+            result = await result.json()
+        }
     }
     catch (e) {
         console.info(e);
     }
-    return json
+    return result
 }
 
 export function goto(url) {

--- a/test/UnitTest/Components/AjaxTest.cs
+++ b/test/UnitTest/Components/AjaxTest.cs
@@ -19,6 +19,7 @@ public class AjaxTest : BootstrapBlazorTestBase
         };
         Assert.Equal("/api/Login", option.Url);
         Assert.Equal("POST", option.Method);
+        Assert.False(option.ToJson);
         Assert.NotNull(option.Data);
 
         var service = Context.Services.GetRequiredService<AjaxService>();

--- a/test/UnitTest/Components/AjaxTest.cs
+++ b/test/UnitTest/Components/AjaxTest.cs
@@ -14,7 +14,8 @@ public class AjaxTest : BootstrapBlazorTestBase
         {
             Url = "/api/Login",
             Method = "POST",
-            Data = new { UserName = "admin", Password = "1234567" }
+            Data = new { UserName = "admin", Password = "1234567" },
+            ToJson = false
         };
         Assert.Equal("/api/Login", option.Url);
         Assert.Equal("POST", option.Method);


### PR DESCRIPTION
# add ToJson parameter

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5440 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Added a `ToJson` parameter to the `AjaxService` to allow users to specify whether the response should be serialized as JSON.

New Features:
- Added a `ToJson` parameter to the `AjaxService` to control whether the response is serialized as JSON.

Bug Fixes:
- Fixed issue #5440 by adding the ToJson parameter.

Enhancements:
- The `AjaxService` now allows users to specify whether the response should be serialized as JSON, providing more flexibility in handling different types of responses.