### PR TITLE
fix(SelectObject): should not override IsRequired method

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.1</Version>
+    <Version>9.4.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/SelectObject.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectObject.razor.cs
@@ -180,12 +180,6 @@ public partial class SelectObject<TItem>
         ClearIcon ??= IconTheme.GetIconByKey(ComponentIcons.SelectClearIcon);
     }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <returns></returns>
-    protected override bool IsRequired() => ValidateForm != null;
-
     private bool GetClearable() => IsClearable && !IsDisabled;
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor.cs
@@ -266,12 +266,6 @@ public partial class SelectTable<TItem> : IColumnCollection where TItem : class,
     }
 
     /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <returns></returns>
-    protected override bool IsRequired() => ValidateForm != null;
-
-    /// <summary>
     /// 获得 Text 显示文字
     /// </summary>
     /// <returns></returns>


### PR DESCRIPTION
# should not override IsRequired method

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5461

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the `IsRequired` method was being overridden in `SelectObject` and `SelectTable` components, which was causing validation to not work correctly.