### PR TITLE
doc(WebSite): update gear button document

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Components/ThemeMode.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/ThemeMode.razor
@@ -1,7 +1,7 @@
 ﻿@inherits WebSiteModuleComponentBase
 @attribute [JSModuleAutoLoader("Components/ThemeMode.razor.js")]
 
-<div id="@Id" class="btn btn-circle btn-fade btn-theme-mode icon-theme d-flex">
+<div id="@Id" class="btn btn-circle btn-fade btn-theme-mode icon-theme d-flex" @onclick:stopPropagation>
     <i class="@GetLightIconClassString"></i>
     <i class="@GetDarkIconClassString"></i>
 </div>

--- a/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor
@@ -18,7 +18,7 @@
         @Body
     </section>
 
-    <DialButton DialMode="DialMode.Radial" Icon="fa-solid fa-gear" Radius="100" Placement="Placement.BottomEnd" IsAutoClose="false">
+    <DialButton DialMode="DialMode.Radial" Icon="fa-solid fa-gear" Radius="100" Placement="Placement.BottomEnd">
         <ButtonTemplate>
             <div class="btn-circle btn-fade dial-button-gear">
                 <img src="./images/logo.png" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Modals.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modals.razor
@@ -89,9 +89,9 @@
             </Modal>
         </div>
         <div class="col-12 col-sm-4 col-lg-auto">
-            <Button OnClick="() => ExtraLargeModal.Toggle()">@Localizer["ModalsOversizedPopup"]</Button>
+            <Button OnClick="() => ExtraLargeModal.Toggle()">@Localizer["ModalsOverSizedPopup"]</Button>
             <Modal @ref="ExtraLargeModal">
-                <ModalDialog Size="Size.ExtraLarge" Title="@Localizer["ModalsOversizedPopup"]">
+                <ModalDialog Size="Size.ExtraLarge" Title="@Localizer["ModalsOverSizedPopup"]">
                     <BodyTemplate>
                         <div>@Localizer["ModalsTitlePopupWindowText"]</div>
                     </BodyTemplate>

--- a/src/BootstrapBlazor.Server/Data/WebsiteOptions.cs
+++ b/src/BootstrapBlazor.Server/Data/WebsiteOptions.cs
@@ -60,7 +60,7 @@ public class WebsiteOptions
     /// <summary>
     /// 
     /// </summary>
-    public string WikiUrl { get; set; } = "https://gitee.com/LongbowEnterprise/BootstrapBlazor/wikis/%E6%9B%B4%E6%96%B0%E6%97%A5%E5%BF%97?sort_id=4062034";
+    public string WikiUrl { get; set; } = "https://github.com/dotnetcore/BootstrapBlazor/releases?wt.mc_id=DT-MVP-5004174";
 
     /// <summary>
     /// 获得 QQ 1 群链接地址

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -389,7 +389,7 @@
     "ModalsDialogResizeIntro": "Resize the modal box by setting the <code>ShowResize</code> property",
     "ModalsSmallPopup": "small popup",
     "ModalsBigPopup": "big popup",
-    "ModalsOversizedPopup": "Oversized pop-up window",
+    "ModalsOverSizedPopup": "OverSized pop-up window",
     "ModalsSuperLargePopup": "super large pop-up window",
     "ModalsFullScreenSizeTitle": "Full screen popup",
     "ModalsFullScreenSizeIntro": "Just set the property <code>FullScreenSize</code>",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -389,7 +389,7 @@
     "ModalsDialogResizeIntro": "通过设置 <code>ShowResize=\"true\"</code> 可以通过鼠标拉动弹窗右下角进行窗口大小调整",
     "ModalsSmallPopup": "小弹窗",
     "ModalsBigPopup": "大弹窗",
-    "ModalsOversizedPopup": "超大弹窗",
+    "ModalsOverSizedPopup": "超大弹窗",
     "ModalsSuperLargePopup": "超超大弹窗",
     "ModalsFullScreenSizeTitle": "全屏弹窗",
     "ModalsFullScreenSizeIntro": "设置属性 <code>FullScreenSize</code> 即可",

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor
@@ -76,7 +76,9 @@
                     }
                     @if (ShowResize)
                     {
-                        <svg class="modal-resizer" viewBox="0 0 1024 1024" version="1.1" xmlns="http://www.w3.org/2000/svg" width="200" height="200"><path d="M319.20128 974.56128L348.16 1003.52l655.36-655.36-28.95872-28.95872-655.36 655.36zM675.84 1003.52l327.68-327.68-28.95872-28.95872-327.68 327.68L675.84 1003.52z"></path></svg>
+                        <svg class="modal-resizer" viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg" width="200" height="200">
+                            <path d="M319.20128 974.56128L348.16 1003.52l655.36-655.36-28.95872-28.95872-655.36 655.36zM675.84 1003.52l327.68-327.68-28.95872-28.95872-327.68 327.68L675.84 1003.52z"></path>
+                        </svg>
                     }
                 </CascadingValue>
             </CascadingValue>

--- a/src/BootstrapBlazor/Components/Responsive/Responsive.cs
+++ b/src/BootstrapBlazor/Components/Responsive/Responsive.cs
@@ -36,7 +36,6 @@ public class Responsive : BootstrapModuleComponentBase
         if (OnBreakPointChanged != null && breakPoint != _breakPoint)
         {
             _breakPoint = breakPoint;
-
             await OnBreakPointChanged(breakPoint);
         }
     }


### PR DESCRIPTION
# update gear button document

Summary of the changes (Less than 80 chars)

简单描述你更改了什么, 不超过80个字符；如果有关联 Issue 请在下方填写相关编号

## Description

fixes #5468 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Details
### Bug Fixes and Improvements:

* [`src/BootstrapBlazor.Server/Components/Components/ThemeMode.razor`](diffhunk://#diff-c2d68b52c0377c0a73193b37468d52aaad40a141ceb8afe257f7800e1b3aa2a8L4-R4): Added `@onclick:stopPropagation` to the `div` element to prevent event propagation.
* [`src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor`](diffhunk://#diff-8b1b061268a838352d0caa2ce8bcfeda94327779577ad41e15e6070d994b2d9aL21-R21): Removed the `IsAutoClose` attribute from the `DialButton` component.

### Localization Updates:

* [`src/BootstrapBlazor.Server/Components/Samples/Modals.razor`](diffhunk://#diff-6e0025d58d2531af006d590e46830757552ba73b5fff366b8969dc0802c95c4eL92-R94): Corrected the localization key from "ModalsOversizedPopup" to "ModalsOverSizedPopup".
* [`src/BootstrapBlazor.Server/Locales/en-US.json`](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L392-R392): Updated the localization value for "ModalsOversizedPopup" to "ModalsOverSizedPopup".
* [`src/BootstrapBlazor.Server/Locales/zh-CN.json`](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL392-R392): Updated the localization value for "ModalsOversizedPopup" to "ModalsOverSizedPopup".

### Code Cleanup:

* [`src/BootstrapBlazor/Components/Modal/ModalDialog.razor`](diffhunk://#diff-aa52233fa1f02b573379f39dafd43b7549c740dacc25e1a36404d152de08c530L79-R81): Formatted the SVG element for better readability.
* [`src/BootstrapBlazor/Components/Responsive/Responsive.cs`](diffhunk://#diff-c8093288694133a8a510fe5862ebfd9d9ed07c01c962a7cdfdba94d5a2a96b52L39): Removed an unnecessary blank line in the `OnResize` method.

### Configuration Update:

* [`src/BootstrapBlazor.Server/Data/WebsiteOptions.cs`](diffhunk://#diff-c43eea96170e161d49095fdfff069690f87e66010c0c0d8e582cadb97a1c622dL63-R63): Updated the `WikiUrl` property to point to the GitHub releases page.

## Summary by Sourcery

Fixes a bug related to event propagation in the theme mode component, corrects a localization key, updates the Wiki URL, and cleans up code formatting.

Bug Fixes:
- Prevents event propagation in the theme mode component by adding `@onclick:stopPropagation` to the div element.
- Corrects the localization key from "ModalsOversizedPopup" to "ModalsOverSizedPopup" in the code and localization files.
- Removes the `IsAutoClose` attribute from the `DialButton` component in MainLayout.razor

Enhancements:
- Updates the `WikiUrl` property to point to the GitHub releases page.
- Formats the SVG element in ModalDialog.razor for better readability.
- Removes an unnecessary blank line in the `OnResize` method in Responsive.cs