### PR TITLE
fix(AutoComplete): trigger onBlur when clicking outside

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.3-beta01</Version>
+    <Version>9.4.3-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -10,7 +10,7 @@
            data-bs-toggle="@ToggleString" data-bs-placement="@PlacementString"
            data-bs-offset="@OffsetString" data-bs-custom-class="@CustomClassString"
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
-           data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString"
+           data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString"
            value="@CurrentValueAsString"
            placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement"/>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -93,15 +93,10 @@ export function init(id, invoke) {
 
                             const el = a.querySelector('[data-bs-toggle="bb.dropdown"]');
                             if (el === null) {
-                                a.classList.remove('show');
                                 const id = a.getAttribute('id');
                                 const ac = Data.get(id);
                                 if (ac) {
-                                    const { invoke, input } = ac;
-                                    const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
-                                    if (triggerBlur) {
-                                        invoke.invokeMethodAsync('TriggerBlur');
-                                    }
+                                    triggerBlurEvent(ac);
                                 }
                             }
                         });
@@ -112,6 +107,15 @@ export function init(id, invoke) {
     }
 
     window.BootstrapBlazor.AutoComplete.registerCloseDropdownHandler();
+}
+
+const triggerBlurEvent = ac => {
+    const { el, invoke, input } = ac;
+    el.classList.remove('show');
+    const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
+    if (triggerBlur) {
+        invoke.invokeMethodAsync('TriggerBlur');
+    }
 }
 
 const handlerKeyup = (ac, e) => {
@@ -131,7 +135,8 @@ const handlerKeyup = (ac, e) => {
     else if (key === 'Escape') {
         const skipEsc = el.getAttribute('data-bb-skip-esc') === 'true';
         if (skipEsc === false) {
-            el.classList.remove('show');
+            input.blur();
+            triggerBlurEvent(ac);
             invoke.invokeMethodAsync('EscCallback');
         }
     }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -54,10 +54,6 @@ export function init(id, invoke) {
         }
     });
 
-    EventHandler.on(menu, 'click', e => {
-        el.classList.remove('show');
-    });
-
     EventHandler.on(input, 'change', e => {
         invoke.invokeMethodAsync('TriggerChange', e.target.value);
     });
@@ -118,6 +114,7 @@ const handlerKeyup = (ac, e) => {
             const current = menu.querySelector('.active');
             if (current !== null) {
                 current.click();
+                input.blur();
             }
             invoke.invokeMethodAsync('EnterCallback', input.value);
         }
@@ -125,8 +122,8 @@ const handlerKeyup = (ac, e) => {
     else if (key === 'Escape') {
         const skipEsc = el.getAttribute('data-bb-skip-esc') === 'true';
         if (skipEsc === false) {
-            input.blur();
             invoke.invokeMethodAsync('EscCallback');
+            input.blur();
         }
     }
     else if (key === 'ArrowUp' || key === 'ArrowDown') {
@@ -176,7 +173,6 @@ export function dispose(id) {
         }
         EventHandler.off(input, 'keyup');
         EventHandler.off(input, 'blur');
-        EventHandler.off(menu, 'click');
         Input.dispose(input);
     }
 }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -131,7 +131,7 @@ const handlerKeyup = (ac, e) => {
     else if (key === 'Escape') {
         const skipEsc = el.getAttribute('data-bb-skip-esc') === 'true';
         if (skipEsc === false) {
-            EventHandler.trigger(menu, 'click');
+            el.classList.remove('show');
             invoke.invokeMethodAsync('EscCallback');
         }
     }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -97,7 +97,11 @@ export function init(id, invoke) {
                                 const id = a.getAttribute('id');
                                 const ac = Data.get(id);
                                 if (ac) {
-                                    ac.invoke.invokeMethodAsync('TriggerBlur');
+                                    const { invoke, input } = ac;
+                                    const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
+                                    if (triggerBlur) {
+                                        invoke.invokeMethodAsync('TriggerBlur');
+                                    }
                                 }
                             }
                         });

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -37,6 +37,14 @@ export function init(id, invoke) {
         })
     }
 
+    EventHandler.on(input, 'blur', e => {
+        el.classList.remove('show');
+        const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
+        if (triggerBlur) {
+            invoke.invokeMethodAsync('TriggerBlur');
+        }
+    });
+
     EventHandler.on(input, 'focus', e => {
         const showDropdownOnFocus = input.getAttribute('data-bb-auto-dropdown-focus') === 'true';
         if (showDropdownOnFocus) {
@@ -48,10 +56,6 @@ export function init(id, invoke) {
 
     EventHandler.on(menu, 'click', e => {
         el.classList.remove('show');
-        if (el.triggerEnter !== true) {
-            invoke.invokeMethodAsync('TriggerBlur');
-        }
-        delete el.triggerEnter;
     });
 
     EventHandler.on(input, 'change', e => {
@@ -93,11 +97,7 @@ export function init(id, invoke) {
 
                             const el = a.querySelector('[data-bs-toggle="bb.dropdown"]');
                             if (el === null) {
-                                const id = a.getAttribute('id');
-                                const ac = Data.get(id);
-                                if (ac) {
-                                    triggerBlurEvent(ac);
-                                }
+                                a.classList.remove('show');
                             }
                         });
                     });
@@ -109,15 +109,6 @@ export function init(id, invoke) {
     window.BootstrapBlazor.AutoComplete.registerCloseDropdownHandler();
 }
 
-const triggerBlurEvent = ac => {
-    const { el, invoke, input } = ac;
-    el.classList.remove('show');
-    const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
-    if (triggerBlur) {
-        invoke.invokeMethodAsync('TriggerBlur');
-    }
-}
-
 const handlerKeyup = (ac, e) => {
     const key = e.key;
     const { el, input, invoke, menu } = ac;
@@ -126,7 +117,6 @@ const handlerKeyup = (ac, e) => {
         if (!skipEnter) {
             const current = menu.querySelector('.active');
             if (current !== null) {
-                el.triggerEnter = true;
                 current.click();
             }
             invoke.invokeMethodAsync('EnterCallback', input.value);
@@ -136,7 +126,6 @@ const handlerKeyup = (ac, e) => {
         const skipEsc = el.getAttribute('data-bb-skip-esc') === 'true';
         if (skipEsc === false) {
             input.blur();
-            triggerBlurEvent(ac);
             invoke.invokeMethodAsync('EscCallback');
         }
     }
@@ -186,6 +175,7 @@ export function dispose(id) {
             }
         }
         EventHandler.off(input, 'keyup');
+        EventHandler.off(input, 'blur');
         EventHandler.off(menu, 'click');
         Input.dispose(input);
     }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -94,6 +94,11 @@ export function init(id, invoke) {
                             const el = a.querySelector('[data-bs-toggle="bb.dropdown"]');
                             if (el === null) {
                                 a.classList.remove('show');
+                                const id = a.getAttribute('id');
+                                const ac = Data.get(id);
+                                if (ac) {
+                                    ac.invoke.invokeMethodAsync('TriggerBlur');
+                                }
                             }
                         });
                     });

--- a/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
@@ -102,6 +102,11 @@ public abstract class PopoverCompleteBase<TValue> : BootstrapInputBase<TValue>, 
     protected string? SkipEnterString => SkipEnter ? "true" : null;
 
     /// <summary>
+    /// 获得 是否跳过 Blur 处理字符串
+    /// </summary>
+    protected string? TriggerBlurString => OnBlurAsync != null ? "true" : null;
+
+    /// <summary>
     /// 获得 滚动行为字符串
     /// </summary>
     protected string? ScrollIntoViewBehaviorString => ScrollIntoViewBehavior == ScrollIntoViewBehavior.Smooth ? null : ScrollIntoViewBehavior.ToDescriptionString();

--- a/src/BootstrapBlazor/Components/Search/Search.razor
+++ b/src/BootstrapBlazor/Components/Search/Search.razor
@@ -26,7 +26,7 @@
                    data-bs-toggle="@ToggleString" data-bs-placement="@PlacementString"
                    data-bs-offset="@OffsetString" data-bs-custom-class="@CustomClassString"
                    data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
-                   data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString"
+                   data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
                    data-bb-scroll-behavior="@ScrollIntoViewBehaviorString"
                    data-bb-input="@UseInputString"
                    value="@_displayText"


### PR DESCRIPTION
## Link issues

fixes #5475 

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary of the changes

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the AutoComplete component does not trigger the onBlur event when clicking outside of the component.

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the AutoComplete component does not trigger the onBlur event when clicking outside of the component.