### PR TITLE
refactor(DialButton): use registerBootstrapBlazorModule to prevent multiple event handler registrations

### DIFF
--- a/src/BootstrapBlazor/Components/Button/DialButton.razor.js
+++ b/src/BootstrapBlazor/Components/Button/DialButton.razor.js
@@ -1,4 +1,5 @@
-﻿import Data from "../../modules/data.js"
+﻿import { registerBootstrapBlazorModule } from "../../modules/utility.js"
+import Data from "../../modules/data.js"
 import EventHandler from "../../modules/event-handler.js"
 
 export function init(id) {
@@ -21,6 +22,19 @@ export function init(id) {
 
         EventHandler.on(document, 'click', e => closePopup(e));
     }
+
+    const module = registerBootstrapBlazorModule('DialButton', {
+        hooked: false,
+        registerClosePopupHandler: function () {
+            if (this.hooked === false) {
+                this.hooked = true;
+
+                EventHandler.on(document, 'click', e => closePopup(e));
+            }
+        }
+    });
+    module.registerClosePopupHandler();
+
 }
 
 export function update(id) {


### PR DESCRIPTION
## Link issues

fixes #5494 

## Summary By Copilot
This pull request includes updates to the `DialButton.razor.js` file to enhance module registration and event handling. The most important changes include importing a new utility function, registering the `DialButton` module, and ensuring the `closePopup` handler is only registered once.

Enhancements to module registration and event handling:

* [`src/BootstrapBlazor/Components/Button/DialButton.razor.js`](diffhunk://#diff-e642f785f52dd7ee83211fabe3698248152de60b584ca354d0baa7ea9b3f382dL1-R2): Imported `registerBootstrapBlazorModule` from `utility.js` and registered the `DialButton` module with a new `registerClosePopupHandler` function to prevent multiple event handler registrations. [[1]](diffhunk://#diff-e642f785f52dd7ee83211fabe3698248152de60b584ca354d0baa7ea9b3f382dL1-R2) [[2]](diffhunk://#diff-e642f785f52dd7ee83211fabe3698248152de60b584ca354d0baa7ea9b3f382dR25-R37)

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Refactor DialButton.razor.js to use registerBootstrapBlazorModule to prevent multiple event handler registrations.