### PR TITLE
refactor(Textarea): rename private property

### DIFF
--- a/src/BootstrapBlazor/Components/Textarea/Textarea.razor
+++ b/src/BootstrapBlazor/Components/Textarea/Textarea.razor
@@ -8,4 +8,4 @@
 }
 <textarea @attributes="AdditionalAttributes" placeholder="@PlaceHolder" id="@Id" class="@ClassName" disabled="@Disabled"
           @bind-value="CurrentValueAsString" @bind-value:event="@EventString" @onblur="@OnBlur"
-          data-bb-shift-enter="@_shiftEnterString" data-bb-scroll="@AutoScrollString" @ref="FocusElement"></textarea>
+          data-bb-shift-enter="@ShiftEnterString" data-bb-scroll="@AutoScrollString" @ref="FocusElement"></textarea>

--- a/src/BootstrapBlazor/Components/Textarea/Textarea.razor.cs
+++ b/src/BootstrapBlazor/Components/Textarea/Textarea.razor.cs
@@ -45,7 +45,7 @@ public partial class Textarea
     /// </summary>
     private string? AutoScrollString => IsAutoScroll ? "auto" : null;
 
-    private string? _shiftEnterString => UseShiftEnter ? "true" : null;
+    private string? ShiftEnterString => UseShiftEnter ? "true" : null;
 
     /// <summary>
     /// <inheritdoc/>


### PR DESCRIPTION
## Link issues

fixes #5503 

## Summary By Copilot
This pull request includes changes to the `Textarea` component in the `BootstrapBlazor` library to improve code consistency and readability. The most important changes include renaming a private field to a property and updating the corresponding usage in the Razor file.

Code consistency improvements:

* [`src/BootstrapBlazor/Components/Textarea/Textarea.razor`](diffhunk://#diff-3c2f55e9f30a0e9eda959ff3c7fd36fb5d1a5a2d94599eeb378d9d4b5eb270c6L11-R11): Updated the `data-bb-shift-enter` attribute to use the renamed property `ShiftEnterString` instead of the private field `_shiftEnterString`.
* [`src/BootstrapBlazor/Components/Textarea/Textarea.razor.cs`](diffhunk://#diff-5d30c42c54c23e6cbd94afb4ee7c933fd7742d087f2b7082eb3888062deaecd2L48-R48): Renamed the private field `_shiftEnterString` to a property `ShiftEnterString` for better code readability and consistency.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Rename private field to property for better code readability.