### PR TITLE
refactor(registerBootstrapBlazorModule): reset init field when items is empty

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.5-beta01</Version>
+    <Version>9.4.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -828,6 +828,7 @@ export function registerBootstrapBlazorModule(name, identifier, callback) {
                 this._items = this._items.filter(item => item !== id);
             }
             if (this._items.length === 0 && cb) {
+                this._init = false;
                 cb();
             }
         }


### PR DESCRIPTION
## Link issues

[请在下方 # 后面填写相关 Issue 编号，如 #42]
fixes #5527 

## Summary By Copilot
This pull request includes changes to the `BootstrapBlazor` project to update the version and improve the utility module. The most important changes include updating the project version and modifying the `registerBootstrapBlazorModule` function to reset the `_init` property.

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from `9.4.5-beta01` to `9.4.5`.

Utility module improvement:

* [`src/BootstrapBlazor/wwwroot/modules/utility.js`](diffhunk://#diff-69557a77580a81d680849888c42138fbc61db40fa3b0960106dc456deb1c6da8R831): Modified the `registerBootstrapBlazorModule` function to reset the `_init` property when the `_items` array is empty and a callback is provided.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where the _init property was not being reset when the _items array was empty, leading to unexpected behavior when the module was re-registered.