### PR TITLE
fix(Table): add IsAutoInitializeModelProperty parameter control create instance logic

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.5</Version>
+    <Version>9.4.6</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -294,18 +294,28 @@ public partial class Table<TItem>
     [Parameter]
     public Func<TItem>? CreateItemCallback { get; set; }
 
+    /// <summary>
+    /// Get or sets Whether to automatically initialize model properties default value is false.
+    /// </summary>
+    [Parameter]
+    public bool IsAutoInitializeModelProperty { get; set; }
+
     private TItem CreateTItem() => CreateItemCallback?.Invoke() ?? CreateInstance();
+
+    private readonly string ErrorMessage = $"{typeof(TItem)} create instrance failed. Please provide {nameof(CreateItemCallback)} create the {typeof(TItem)} instance. {typeof(TItem)} 自动创建实例失败，请通过 {nameof(CreateItemCallback)} 回调方法手动创建实例";
 
     private TItem CreateInstance()
     {
+        TItem? item;
         try
         {
-            return ObjectExtensions.CreateInstanceWithCascade<TItem>();
+            item = ObjectExtensions.CreateInstanceWithCascade<TItem>(IsAutoInitializeModelProperty);
         }
         catch (Exception ex)
         {
-            throw new InvalidOperationException($"{typeof(TItem)} missing new() method. Please provide {nameof(CreateItemCallback)} create the {typeof(TItem)} instance. {typeof(TItem)} 未提供无参构造函数 new() 请通过 {nameof(CreateItemCallback)} 回调方法创建实例", ex);
+            throw new InvalidOperationException(ErrorMessage, ex);
         }
+        return item ?? throw new InvalidOperationException(ErrorMessage);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -309,13 +309,13 @@ public partial class Table<TItem>
         TItem? item;
         try
         {
-            item = ObjectExtensions.CreateInstanceWithCascade<TItem>(IsAutoInitializeModelProperty);
+            item = ObjectExtensions.CreateInstance<TItem>(IsAutoInitializeModelProperty);
         }
         catch (Exception ex)
         {
             throw new InvalidOperationException(ErrorMessage, ex);
         }
-        return item ?? throw new InvalidOperationException(ErrorMessage);
+        return item!;
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -244,7 +244,7 @@ public static class ObjectExtensions
     /// <typeparam name="TItem">The type to create an instance of.</typeparam>
     /// <param name="isAutoInitializeModelProperty">Whether to automatically initialize model properties default value is false.</param>
     /// <returns>An instance of the specified type with initialized properties.</returns>
-    public static TItem? CreateInstanceWithCascade<TItem>(bool isAutoInitializeModelProperty = false)
+    public static TItem? CreateInstance<TItem>(bool isAutoInitializeModelProperty = false)
     {
         TItem? instance;
         try

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -246,36 +246,20 @@ public static class ObjectExtensions
     /// <returns>An instance of the specified type with initialized properties.</returns>
     public static TItem? CreateInstance<TItem>(bool isAutoInitializeModelProperty = false)
     {
-        TItem? instance;
-        try
+        var instance = Activator.CreateInstance<TItem>();
+        if (isAutoInitializeModelProperty)
         {
-            instance = Activator.CreateInstance<TItem>();
-            if (isAutoInitializeModelProperty)
-            {
-                instance.EnsureInitialized(isAutoInitializeModelProperty);
-            }
-        }
-        catch
-        {
-            throw;
+            instance.EnsureInitialized(isAutoInitializeModelProperty);
         }
         return instance;
     }
 
     private static object? CreateInstance(Type type, bool isAutoInitializeModelProperty = false)
     {
-        object? instance;
-        try
+        var instance = Activator.CreateInstance(type);
+        if (isAutoInitializeModelProperty)
         {
-            instance = Activator.CreateInstance(type);
-            if (isAutoInitializeModelProperty)
-            {
-                instance.EnsureInitialized();
-            }
-        }
-        catch
-        {
-            throw;
+            instance.EnsureInitialized();
         }
         return instance;
     }

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -242,20 +242,56 @@ public static class ObjectExtensions
     /// Creates an instance of a type and ensures all class-type properties are initialized.
     /// </summary>
     /// <typeparam name="TItem">The type to create an instance of.</typeparam>
+    /// <param name="isAutoInitializeModelProperty">Whether to automatically initialize model properties default value is false.</param>
     /// <returns>An instance of the specified type with initialized properties.</returns>
-    public static TItem CreateInstanceWithCascade<TItem>()
+    public static TItem? CreateInstanceWithCascade<TItem>(bool isAutoInitializeModelProperty = false)
     {
-        var instance = Activator.CreateInstance<TItem>();
-        instance!.EnsureInitialized();
+        TItem? instance;
+        try
+        {
+            instance = Activator.CreateInstance<TItem>();
+            if (isAutoInitializeModelProperty)
+            {
+                instance.EnsureInitialized(isAutoInitializeModelProperty);
+            }
+        }
+        catch
+        {
+            throw;
+        }
+        return instance;
+    }
+
+    private static object? CreateInstance(Type type, bool isAutoInitializeModelProperty = false)
+    {
+        object? instance;
+        try
+        {
+            instance = Activator.CreateInstance(type);
+            if (isAutoInitializeModelProperty)
+            {
+                instance.EnsureInitialized();
+            }
+        }
+        catch
+        {
+            throw;
+        }
         return instance;
     }
 
     /// <summary>
     /// Ensures that all class-type properties of the instance are initialized.
     /// </summary>
+    /// <param name="isAutoInitializeModelProperty">Whether to automatically initialize model properties default value is false.</param>
     /// <param name="instance">The instance to initialize properties for.</param>
-    private static void EnsureInitialized(this object instance)
+    private static void EnsureInitialized(this object? instance, bool isAutoInitializeModelProperty = false)
     {
+        if (instance is null)
+        {
+            return;
+        }
+
         // Reflection performance needs to be optimized here
         foreach (var propertyInfo in instance.GetType().GetProperties().Where(p => p.PropertyType.IsClass && p.PropertyType != typeof(string)))
         {
@@ -263,16 +299,12 @@ public static class ObjectExtensions
             var value = propertyInfo.GetValue(instance, null);
             if (value is null)
             {
-                var pv = CreateInstance(type);
-                propertyInfo.SetValue(instance, pv);
+                var pv = CreateInstance(type, isAutoInitializeModelProperty);
+                if (pv is not null)
+                {
+                    propertyInfo.SetValue(instance, pv);
+                }
             }
         }
-    }
-
-    private static object? CreateInstance(Type type)
-    {
-        var instance = Activator.CreateInstance(type);
-        instance!.EnsureInitialized();
-        return instance;
     }
 }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -127,6 +127,7 @@ public class TableTest : BootstrapBlazorTestBase
         {
             pb.AddChildContent<Table<Foo>>(pb =>
             {
+                pb.Add(a => a.IsAutoInitializeModelProperty, true);
                 pb.Add(a => a.Items, items);
                 if (bind)
                 {

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -311,6 +311,10 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
         var mi = typeof(ObjectExtensions).GetMethod("EnsureInitialized", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
         Assert.NotNull(mi);
         mi.Invoke(null, [null, false]);
+
+        var instance = ObjectExtensions.CreateInstance<MockComplexObject>(false);
+        Assert.NotNull(instance);
+        Assert.Null(instance.Test);
     }
 
     private class MockComplexObject

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -306,7 +306,11 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
     [Fact]
     public void CreateInstance_Ok()
     {
-        var exception = Assert.ThrowsAny<Exception>(() => ObjectExtensions.CreateInstanceWithCascade<MockComplexObject>(true));
+        var exception = Assert.ThrowsAny<Exception>(() => ObjectExtensions.CreateInstance<MockComplexObject>(true));
+
+        var mi = typeof(ObjectExtensions).GetMethod("EnsureInitialized", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(mi);
+        mi.Invoke(null, [null, false]);
     }
 
     private class MockComplexObject

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -304,7 +304,7 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void CreateInstanceWithCascade_Ok()
+    public void CreateInstance_Ok()
     {
         var exception = Assert.ThrowsAny<Exception>(() => ObjectExtensions.CreateInstanceWithCascade<MockComplexObject>(true));
     }

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -303,6 +303,19 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
         Assert.True(pi.IsStatic());
     }
 
+    [Fact]
+    public void CreateInstanceWithCascade_Ok()
+    {
+        var exception = Assert.ThrowsAny<Exception>(() => ObjectExtensions.CreateInstanceWithCascade<MockComplexObject>(true));
+    }
+
+    private class MockComplexObject
+    {
+        public Foo? Foo { get; set; }
+
+        public (string Name, int Count)[]? Test { get; set; }
+    }
+
     private class MockStatic
     {
         private static int _test;


### PR DESCRIPTION
## Link issues

[请在下方 # 后面填写相关 Issue 编号，如 #42]
fixes #5529 

## Summary By Copilot
This pull request includes several changes to the `BootstrapBlazor` project, focusing on version updates, enhancements to model property initialization, and improvements to unit tests. The most important changes include updating the project version, adding a new parameter for automatic model property initialization, and modifying the `CreateInstance` method to support this new parameter.

### Version Update:
* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from 9.4.5 to 9.4.6.

### Enhancements to Model Property Initialization:
* [`src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs`](diffhunk://#diff-f110e93a49468f41a886de0ccf4717f076d9f74aa3f2aab9c827d52d38d6f7d8R297-R318): Added a new parameter `IsAutoInitializeModelProperty` to the `InternalOnAddAsync` method and updated the `CreateInstance` method to use this parameter.
* [`src/BootstrapBlazor/Extensions/ObjectExtensions.cs`](diffhunk://#diff-c019f4fd02def072688edb19f028f96307ee26ca2682b9a9b2c60df8247f30f7R245-L276): Modified the `CreateInstance` method to accept the `isAutoInitializeModelProperty` parameter and ensure class-type properties are initialized based on this parameter.

### Unit Test Improvements:
* [`test/UnitTest/Components/TableTest.cs`](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160R130): Added a test case to verify the `IsAutoInitializeModelProperty` parameter functionality.
* [`test/UnitTest/Extensions/ObjectExtensionsTest.cs`](diffhunk://#diff-697976fa45b5c8faad3772df477df5b590c541888053d215f4b7ed8741309056R306-R326): Added a test case for the `CreateInstance` method to ensure it works correctly with the `isAutoInitializeModelProperty` parameter.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]

[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
