### PR TITLE
bug(Modal): styles remain when modal are destroyed

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.7-beta01</Version>
+    <Version>9.4.7-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -137,8 +137,13 @@ export function dispose(id) {
         }
 
         EventHandler.off(window, 'popstate', modal.pop)
-        if (modal.modal) {
-            modal.modal.dispose()
+        const dialog = modal.modal;
+        if (dialog) {
+            if (document.body.classList.contains('modal-open')) {
+                dialog._backdrop._config.isAnimated = false;
+                dialog._hideModal();
+            }
+            dialog.dispose()
         }
     }
 }


### PR DESCRIPTION
## Link issues

fixes #5537 
[Please fill in the relevant Issue number after the # above, such as #42]
[请在上方 # 后面填写相关 Issue 编号，如 #42]

## Summary By Copilot
This pull request includes a version update and an enhancement to the modal disposal logic in the `BootstrapBlazor` project. The most important changes are:

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the version from `9.4.7-beta01` to `9.4.7-beta02`.

Enhancement to modal disposal:

* [`src/BootstrapBlazor/Components/Modal/Modal.razor.js`](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eL140-R146): Improved the modal disposal logic by ensuring that the backdrop animation is disabled and the modal is hidden before disposal if the `modal-open` class is present on the body.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]
[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fixes an issue where modal styles would persist after the modal was destroyed by disabling the backdrop animation and hiding the modal before disposal when the 'modal-open' class is present on the body.