### PR TITLE
refactor(Modal): keep document original style

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.7-beta02</Version>
+    <Version>9.4.7-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -12,7 +12,8 @@ export function init(id, invoke, shownCallback, closeCallback) {
             if (modal) {
                 modal.hide();
             }
-        }
+        },
+        originalStyle: null
     }
     Data.set(id, modal)
 
@@ -33,6 +34,7 @@ export function init(id, invoke, shownCallback, closeCallback) {
     EventHandler.on(window, 'popstate', modal.pop)
 
     modal.show = () => {
+        modal.originalStyle ??= document.body.style;
         const dialogs = el.querySelectorAll('.modal-dialog')
         if (dialogs.length === 1) {
             let backdrop = el.getAttribute('data-bs-backdrop') !== 'static'
@@ -61,6 +63,8 @@ export function init(id, invoke, shownCallback, closeCallback) {
     modal.hide = () => {
         if (el.children.length === 1) {
             modal.modal.hide();
+            document.body.style = modal.originalStyle;
+            modal.originalStyle = null;
         }
         else {
             modal.invoke.invokeMethodAsync(modal.closeCallback)
@@ -142,6 +146,11 @@ export function dispose(id) {
             if (document.body.classList.contains('modal-open')) {
                 dialog._backdrop._config.isAnimated = false;
                 dialog._hideModal();
+            }
+
+            if(modal.originalStyle) {
+                document.body.style = modal.originalStyle;
+                modal.originalStyle = null;
             }
             dialog.dispose()
         }


### PR DESCRIPTION
## Link issues

fixes #5541 
[Please fill in the relevant Issue number after the # above, such as #42]
[请在上方 # 后面填写相关 Issue 编号，如 #42]

## Summary By Copilot
This pull request includes updates to the version number in the `BootstrapBlazor.csproj` file and enhancements to the modal component's JavaScript functionality in `Modal.razor.js`. The most important changes focus on preserving and restoring the original body style when modals are shown and hidden.

### Version Update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated version from `9.4.7-beta02` to `9.4.7-beta03`.

### Modal Component Enhancements:

* [`src/BootstrapBlazor/Components/Modal/Modal.razor.js`](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eL15-R16): Added `originalStyle` property to the modal object to store the original body style.
* [`src/BootstrapBlazor/Components/Modal/Modal.razor.js`](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eR37): Modified the `modal.show` function to save the original body style before applying modal-specific styles.
* [`src/BootstrapBlazor/Components/Modal/Modal.razor.js`](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eR66-R67): Updated the `modal.hide` function to restore the original body style after hiding the modal.
* [`src/BootstrapBlazor/Components/Modal/Modal.razor.js`](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eR150-R154): Ensured the original body style is restored when the modal is disposed.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]
[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Preserve and restore the original body style when modals are shown and hidden, and update the version number.

Enhancements:
- Enhance modal component's JavaScript functionality to preserve and restore the original body style when modals are shown and hidden.
- Store the original body style before applying modal-specific styles.
- Restore the original body style after hiding the modal.
- Ensure the original body style is restored when the modal is disposed.