### PR TITLE
refactor(Modal): add back/restoreBodyStyle function

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.7-beta02</Version>
+    <Version>9.4.7-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -12,7 +12,8 @@ export function init(id, invoke, shownCallback, closeCallback) {
             if (modal) {
                 modal.hide();
             }
-        }
+        },
+        originalStyle: null
     }
     Data.set(id, modal)
 
@@ -33,6 +34,7 @@ export function init(id, invoke, shownCallback, closeCallback) {
     EventHandler.on(window, 'popstate', modal.pop)
 
     modal.show = () => {
+        modal.originalStyle ??= document.body.style;
         const dialogs = el.querySelectorAll('.modal-dialog')
         if (dialogs.length === 1) {
             let backdrop = el.getAttribute('data-bs-backdrop') !== 'static'
@@ -61,6 +63,8 @@ export function init(id, invoke, shownCallback, closeCallback) {
     modal.hide = () => {
         if (el.children.length === 1) {
             modal.modal.hide();
+            document.body.style = modal.originalStyle;
+            modal.originalStyle = null;
         }
         else {
             modal.invoke.invokeMethodAsync(modal.closeCallback)
@@ -142,6 +146,11 @@ export function dispose(id) {
             if (document.body.classList.contains('modal-open')) {
                 dialog._backdrop._config.isAnimated = false;
                 dialog._hideModal();
+            }
+
+            if(modal.originalStyle) {
+                document.body.style = modal.originalStyle;
+                modal.originalStyle = null;
             }
             dialog.dispose()
         }

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.js
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.js
@@ -12,8 +12,7 @@ export function init(id, invoke, shownCallback, closeCallback) {
             if (modal) {
                 modal.hide();
             }
-        },
-        originalStyle: null
+        }
     }
     Data.set(id, modal)
 
@@ -34,7 +33,7 @@ export function init(id, invoke, shownCallback, closeCallback) {
     EventHandler.on(window, 'popstate', modal.pop)
 
     modal.show = () => {
-        modal.originalStyle ??= document.body.style;
+        backupBodyStyle(modal);
         const dialogs = el.querySelectorAll('.modal-dialog')
         if (dialogs.length === 1) {
             let backdrop = el.getAttribute('data-bs-backdrop') !== 'static'
@@ -63,8 +62,7 @@ export function init(id, invoke, shownCallback, closeCallback) {
     modal.hide = () => {
         if (el.children.length === 1) {
             modal.modal.hide();
-            document.body.style = modal.originalStyle;
-            modal.originalStyle = null;
+            restoreBodyStyle(modal);
         }
         else {
             modal.invoke.invokeMethodAsync(modal.closeCallback)
@@ -148,11 +146,21 @@ export function dispose(id) {
                 dialog._hideModal();
             }
 
-            if(modal.originalStyle) {
-                document.body.style = modal.originalStyle;
-                modal.originalStyle = null;
-            }
+            restoreBodyStyle(modal);
             dialog.dispose()
         }
+    }
+}
+
+const backupBodyStyle = modal => {
+    if(modal.originalStyle === void 0) {
+        modal.originalStyle = document.body.style.cssText;
+    }
+}
+
+const restoreBodyStyle = modal => {
+    if(modal.originalStyle !== void 0) {
+        document.body.style.cssText = modal.originalStyle;
+        delete modal.originalStyle;
     }
 }


### PR DESCRIPTION
## Link issues

fixes #5543 
[Please fill in the relevant Issue number after the # above, such as #42]
[请在上方 # 后面填写相关 Issue 编号，如 #42]

## Summary By Copilot
This pull request includes refactoring of the `Modal` component in `src/BootstrapBlazor/Components/Modal/Modal.razor.js` to improve the handling of the document body style when showing and hiding modals. The most important changes include the introduction of helper functions to backup and restore the body style.

Refactoring of modal body style handling:

* [`src/BootstrapBlazor/Components/Modal/Modal.razor.js`](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eL37-R37): Replaced inline style backup and restore logic with `backupBodyStyle` and `restoreBodyStyle` helper functions in `modal.show`, `modal.hide`, and `dispose` functions. [[1]](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eL37-R37) [[2]](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eL66-R66) [[3]](diffhunk://#diff-6308812f3dd0c1a46d1e2da4fdf3f26191548a75be56dd70cae69be6d1786a3eL151-R167)
* Added `backupBodyStyle` function to store the original body style in `modal.originalStyle` if it is not already set.
* Added `restoreBodyStyle` function to revert the body style to the original and delete `modal.originalStyle` if it is set.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]
[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Introduces helper functions backupBodyStyle and restoreBodyStyle to manage the document body style, improving code readability and maintainability.