### PR TITLE
doc(Editor): update jQuery script vesion to 3.6.0

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Editors.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Editors.razor
@@ -9,7 +9,7 @@
 
 <p>@((MarkupString)Localizer["EditorsTips"].Value)</p>
 
-<Pre class="no-highlight mb-3">&lt;script src="_content/BootstrapBlazor.SummerNote/js/jquery-3.5.1.min.js"&gt;&lt;/script&gt;</Pre>
+<Pre class="no-highlight mb-3">&lt;script src="_content/BootstrapBlazor.SummerNote/js/jquery-3.6.0.min.js"&gt;&lt;/script&gt;</Pre>
 
 <Pre class="no-highlight mb-3">builder.Services.Configure&lt;HubOptions&gt;(option => option.MaximumReceiveMessageSize = null);</Pre>
 


### PR DESCRIPTION
## Link issues

fixes #5546
[Please fill in the relevant Issue number after the # above, such as #42]
[请在上方 # 后面填写相关 Issue 编号，如 #42]

## Summary By Copilot
This pull request includes an update to the `src/BootstrapBlazor.Server/Components/Samples/Editors.razor` file. The change involves updating the version of the jQuery library used.

* Updated the jQuery library version from 3.5.1 to 3.6.0 in the `Editors.razor` file.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]
[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Chores:
- Update jQuery script version to 3.6.0