### PR TITLE
refactor(BootstrapBlazorRoot): support nested usage

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.7-beta04</Version>
+    <Version>9.4.7</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs
+++ b/src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs
@@ -77,7 +77,7 @@ public class BootstrapBlazorRootRegisterService
     {
         if (_subscribersByIdentifier.ContainsKey(identifier))
         {
-            throw new InvalidOperationException($"There is already a subscriber to the content with the given root ID '{identifier}'.");
+            return;
         }
 
         _subscribersByIdentifier.Add(identifier, subscriber);
@@ -89,10 +89,7 @@ public class BootstrapBlazorRootRegisterService
     /// <param name="identifier"></param>
     public void Unsubscribe(object identifier)
     {
-        if (!_subscribersByIdentifier.Remove(identifier))
-        {
-            throw new InvalidOperationException($"The subscriber with the given root ID '{identifier}' is already unsubscribed.");
-        }
+        _subscribersByIdentifier.Remove(identifier);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs
+++ b/src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs
@@ -14,7 +14,7 @@ public class BootstrapBlazorRootRegisterService
     private readonly Dictionary<object, List<BootstrapBlazorRootContent>> _providersByIdentifier = [];
 
     /// <summary>
-    /// add provider
+    /// Add provider
     /// </summary>
     /// <param name="identifier"></param>
     /// <param name="provider"></param>
@@ -30,7 +30,7 @@ public class BootstrapBlazorRootRegisterService
     }
 
     /// <summary>
-    /// remove provider
+    /// Remove provider
     /// </summary>
     /// <param name="identifier"></param>
     /// <param name="provider"></param>
@@ -58,7 +58,7 @@ public class BootstrapBlazorRootRegisterService
     }
 
     /// <summary>
-    /// get all providers by identifier
+    /// Get all providers by identifier
     /// </summary>
     /// <param name="identifier"></param>
     /// <returns></returns>
@@ -69,7 +69,7 @@ public class BootstrapBlazorRootRegisterService
     }
 
     /// <summary>
-    /// subscribe
+    /// Subscribe
     /// </summary>
     /// <param name="identifier"></param>
     /// <param name="subscriber"></param>
@@ -84,7 +84,7 @@ public class BootstrapBlazorRootRegisterService
     }
 
     /// <summary>
-    /// 取消订阅
+    /// Unsubscribe
     /// </summary>
     /// <param name="identifier"></param>
     public void Unsubscribe(object identifier)

--- a/test/UnitTest/Services/BootstrapBlazorRootRegisterServiceTest.cs
+++ b/test/UnitTest/Services/BootstrapBlazorRootRegisterServiceTest.cs
@@ -28,11 +28,7 @@ public class BootstrapBlazorRootRegisterServiceTest
         var service = new BootstrapBlazorRootRegisterService();
         var identifier = new object();
         service.Subscribe(identifier, new BootstrapBlazorRootOutlet());
-        var exception = Assert.ThrowsAny<InvalidOperationException>(() => service.Subscribe(identifier, new BootstrapBlazorRootOutlet()));
-        Assert.Equal("There is already a subscriber to the content with the given root ID 'System.Object'.", exception.Message);
-
-        exception = Assert.ThrowsAny<InvalidOperationException>(() => service.Unsubscribe(new object()));
-        Assert.Equal("The subscriber with the given root ID 'System.Object' is already unsubscribed.", exception.Message);
+        service.Unsubscribe(new object());
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues

fixes #5551 
[Please fill in the relevant Issue number after the # above, such as #42]
[请在上方 # 后面填写相关 Issue 编号，如 #42]

## Summary By Copilot
This pull request includes several changes to the `BootstrapBlazor` project, focusing on version updates, code comments, and the `BootstrapBlazorRootRegisterService` class. The most important changes include updating the project version, modifying method comments for consistency, and altering the behavior of the `Subscribe` and `Unsubscribe` methods in the `BootstrapBlazorRootRegisterService` class.

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from `9.4.7-beta04` to `9.4.7`.

Code comments:

* [`src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs`](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L17-R17): Standardized the comments for methods such as `AddProvider`, `RemoveProvider`, `GetProviders`, `Subscribe`, and `Unsubscribe` to start with an uppercase letter. [[1]](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L17-R17) [[2]](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L33-R33) [[3]](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L61-R61) [[4]](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L72-R92)

Behavior changes in `BootstrapBlazorRootRegisterService`:

* [`src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs`](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L72-R92): Modified the `Subscribe` method to return early instead of throwing an `InvalidOperationException` if a subscriber already exists.
* [`src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs`](diffhunk://#diff-b49e86a4b98263adfa173e1f9ca9f3a7a884caeb29a520cc7364ffc984226f19L72-R92): Simplified the `Unsubscribe` method by removing the check and exception throw for already unsubscribed identifiers.

Test updates:

* [`test/UnitTest/Services/BootstrapBlazorRootRegisterServiceTest.cs`](diffhunk://#diff-d6e416abea811276070f8cae9763effb24dd8668387257fb779747803c71d8ebL31-R31): Removed the tests that checked for exceptions in the `Subscribe` and `Unsubscribe` methods, as these methods no longer throw exceptions.

## Regression?

- [ ] Yes
- [ ] No

[If yes, specify the version the behavior has regressed from]
[是否影响老版本]

## Risk

- [ ] High
- [ ] Medium
- [ ] Low

[Justify the selection above]

## Verification

- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?

- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge

⚠️ Please check all items below before review. ⚠️

- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
