### PR TITLE
chore(BootstrapIcon): mssing add bi-rotate-315 style

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="BootstrapBlazor.BaiduOcr" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.BarCode" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.BarcodeGenerator" Version="9.0.0" />
-    <PackageReference Include="BootstrapBlazor.BootstrapIcon" Version="9.0.0" />
+    <PackageReference Include="BootstrapBlazor.BootstrapIcon" Version="9.0.1" />
     <PackageReference Include="BootstrapBlazor.Chart" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="9.0.0" />


### PR DESCRIPTION
## Link issues
fixes #5567 
<!--
[Please fill in the relevant Issue number after the # above, such as #42]
[请在上方 # 后面填写相关 Issue 编号，如 #42]
-->
## Summary By Copilot
This pull request includes a minor version update to the `BootstrapBlazor.BootstrapIcon` package in the `BootstrapBlazor.Server` project file. The version has been updated from `9.0.0` to `9.0.1`.

* [`src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj`](diffhunk://#diff-acda8ffd7b0362074afe236cb631a348f2c8a44568a1f235743982c2a0ad6416L30-R30): Updated `BootstrapBlazor.BootstrapIcon` package version from `9.0.0` to `9.0.1`.

## Regression?
- [ ] Yes
- [ ] No

<!--
[If yes, specify the version the behavior has regressed from]
[是否影响老版本]
-->
## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--
[Justify the selection above]
-->
## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Chores:
- Update BootstrapBlazor.BootstrapIcon package version.