### PR TITLE
refactor(Modal): use BootstrapBlazorRootOutlet wrap Modal component

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Layout/BaseLayout.razor.css
+++ b/src/BootstrapBlazor.Server/Components/Layout/BaseLayout.razor.css
@@ -6,4 +6,6 @@
 
 main {
     min-height: calc(100vh - var(--bs-header-height));
+    position: relative;
+    z-index: 10;
 }

--- a/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor.css
+++ b/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor.css
@@ -4,6 +4,8 @@
 
 .main {
     padding: var(--bb-main-pading);
+    position: relative;
+    z-index: 5;
 }
 
 .sidebar-title {

--- a/src/BootstrapBlazor/Components/Dialog/Dialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Dialog/Dialog.razor.cs
@@ -55,7 +55,7 @@ public partial class Dialog : IDisposable
         }
     }
 
-    private async Task Show(DialogOption option)
+    private Task Show(DialogOption option)
     {
         _onShownAsync = async () =>
         {
@@ -158,7 +158,8 @@ public partial class Dialog : IDisposable
 
         // Add ModalDialog to the container
         DialogParameters.Add(parameters, (_isKeyboard, _isBackdrop));
-        await InvokeAsync(StateHasChanged);
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     private static RenderFragment RenderDialog(int index, Dictionary<string, object> parameter) => builder =>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor
@@ -2,8 +2,10 @@
 @inherits BootstrapModuleComponentBase
 @attribute [BootstrapModuleAutoLoader(JSObjectReference = true)]
 
-<div @attributes="@AdditionalAttributes" class="@ClassString" tabindex="-1" role="dialog" data-bs-backdrop="@Backdrop" data-bs-keyboard="@KeyboardString" id="@Id">
-    <CascadingValue Value="this" IsFixed="true">
-        @ChildContent
-    </CascadingValue>
-</div>
+<BootstrapBlazorRootContent>
+    <div @attributes="@AdditionalAttributes" class="@ClassString" tabindex="-1" role="dialog" data-bs-backdrop="@Backdrop" data-bs-keyboard="@KeyboardString" id="@Id">
+        <CascadingValue Value="this" IsFixed="true">
+            @ChildContent
+        </CascadingValue>
+    </div>
+</BootstrapBlazorRootContent>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.cs
@@ -17,6 +17,7 @@ public partial class Modal
     /// </summary>
     private string? ClassString => CssBuilder.Default("modal")
         .AddClass("fade", IsFade)
+        .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.cs
@@ -8,68 +8,68 @@ using System.Collections.Concurrent;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// Modal 组件
+/// Modal component
 /// </summary>
 public partial class Modal
 {
     /// <summary>
-    /// 获得 样式字符串
+    /// Gets the style string
     /// </summary>
     private string? ClassString => CssBuilder.Default("modal")
         .AddClass("fade", IsFade)
         .Build();
 
     /// <summary>
-    /// 获得 ModalDialog 集合
+    /// Gets the collection of ModalDialog
     /// </summary>
     protected List<ModalDialog> Dialogs { get; } = new(8);
 
     private readonly ConcurrentDictionary<IComponent, Func<Task>> _shownCallbackCache = [];
 
     /// <summary>
-    /// 获得/设置 是否后台关闭弹窗 默认 false
+    /// Gets or sets whether to close the popup in the background, default is false
     /// </summary>
     [Parameter]
     public bool IsBackdrop { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否开启键盘支持 默认 true 响应键盘 ESC 按键
+    /// Gets or sets whether to enable keyboard support, default is true to respond to the ESC key
     /// </summary>
     [Parameter]
     public bool IsKeyboard { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 是否开启淡入淡出动画 默认为 true 开启动画
+    /// Gets or sets whether to enable fade in and out animation, default is true to enable animation
     /// </summary>
     [Parameter]
     public bool IsFade { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 子组件
+    /// Gets or sets the child component
     /// </summary>
     [Parameter]
     public RenderFragment? ChildContent { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件已经渲染完毕回调方法
+    /// Gets or sets the callback method when the component has finished rendering
     /// </summary>
     [Parameter]
     public Func<Modal, Task>? FirstAfterRenderCallbackAsync { get; set; }
 
     /// <summary>
-    /// 获得/设置 弹窗已显示时回调此方法
+    /// Gets or sets the callback method when the popup is shown
     /// </summary>
     [Parameter]
     public Func<Task>? OnShownAsync { get; set; }
 
     /// <summary>
-    /// 获得/设置 关闭弹窗回调委托
+    /// Gets or sets the callback delegate when the popup is closed
     /// </summary>
     [Parameter]
     public Func<Task>? OnCloseAsync { get; set; }
 
     /// <summary>
-    /// 获得 后台关闭弹窗设置
+    /// Gets the background close popup setting
     /// </summary>
     private string? Backdrop => IsBackdrop ? null : "static";
 
@@ -97,7 +97,7 @@ public partial class Modal
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, nameof(ShownCallback), nameof(CloseCallback));
 
     /// <summary>
-    /// 添加对话框方法
+    /// Method to add a dialog
     /// </summary>
     /// <param name="dialog"></param>
     internal void AddDialog(ModalDialog dialog)
@@ -107,12 +107,12 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 移除对话框方法
+    /// Method to remove a dialog
     /// </summary>
     /// <param name="dialog"></param>
     internal void RemoveDialog(ModalDialog dialog)
     {
-        // 移除当前弹窗
+        // Remove the current popup
         Dialogs.Remove(dialog);
 
         if (Dialogs.Count > 0)
@@ -123,7 +123,7 @@ public partial class Modal
 
     private void ResetShownDialog(ModalDialog dialog)
     {
-        // 保证新添加的 Dialog 为当前弹窗
+        // Ensure the newly added Dialog is the current popup
         Dialogs.ForEach(d =>
         {
             d.IsShown = d == dialog;
@@ -131,7 +131,7 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 弹窗已经弹出回调方法 JSInvoke 调用
+    /// Callback method when the popup has been shown, called by JSInvoke
     /// </summary>
     /// <returns></returns>
     [JSInvokable]
@@ -149,20 +149,20 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 弹窗已经关闭回调方法 JSInvoke 调用
+    /// Callback method when the popup has been closed, called by JSInvoke
     /// </summary>
     /// <returns></returns>
     [JSInvokable]
     public async Task CloseCallback()
     {
-        // 移除当前弹窗
+        // Remove the current popup
         var dialog = Dialogs.FirstOrDefault(d => d.IsShown);
         if (dialog != null)
         {
             Dialogs.Remove(dialog);
         }
 
-        // 多级弹窗支持
+        // Support for multi-level popups
         if (Dialogs.Count > 0)
         {
             ResetShownDialog(Dialogs.Last());
@@ -175,7 +175,7 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 弹窗状态切换方法
+    /// Method to toggle the popup state
     /// </summary>
     public async Task Toggle()
     {
@@ -184,7 +184,7 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 显示弹窗方法
+    /// Method to show the popup
     /// </summary>
     /// <returns></returns>
     public async Task Show()
@@ -194,13 +194,13 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 关闭当前弹窗方法
+    /// Method to close the current popup
     /// </summary>
     /// <returns></returns>
     public Task Close() => InvokeVoidAsync("execute", Id, "hide");
 
     /// <summary>
-    /// 设置 Header 文字方法
+    /// Method to set the header text
     /// </summary>
     /// <param name="text"></param>
     public void SetHeaderText(string text)
@@ -210,19 +210,19 @@ public partial class Modal
     }
 
     /// <summary>
-    /// 注册弹窗显示后回调方法，供代码调用等效 OnShownAsync 参数赋值
+    /// Registers a callback method to be called after the popup is shown, equivalent to setting the OnShownAsync parameter
     /// </summary>
-    /// <param name="component">组件</param>
-    /// <param name="value">回调方法</param>
+    /// <param name="component">Component</param>
+    /// <param name="value">Callback method</param>
     public void RegisterShownCallback(IComponent component, Func<Task> value)
     {
         _shownCallbackCache.AddOrUpdate(component, _ => value, (_, _) => value);
     }
 
     /// <summary>
-    /// 取消注册窗口显示后回调方法
+    /// Unregisters the callback method to be called after the popup is shown
     /// </summary>
-    /// <param name="component">组件</param>
+    /// <param name="component">Component</param>
     public void UnRegisterShownCallback(IComponent component)
     {
         _shownCallbackCache.TryRemove(component, out _);

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor
@@ -2,7 +2,7 @@
 @inherits BootstrapModuleComponentBase
 @attribute [BootstrapModuleAutoLoader("Modal/ModalDialog.razor.js", JSObjectReference = true)]
 
-<div class="@ClassName" id="@Id">
+<div @attributes="AdditionalAttributes" class="@ClassName" id="@Id">
     <div class="modal-content">
         @if (ShowHeader)
         {

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -27,6 +27,7 @@ public partial class ModalDialog : IHandlerException
         .AddClass("is-draggable-center", IsCentered && IsDraggable && _firstRender)
         .AddClass("d-none", !IsShown)
         .AddClass(Class, !string.IsNullOrEmpty(Class))
+        .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor
@@ -2,6 +2,6 @@
 @inherits BootstrapComponentBase
 @inject SwalService Swal
 
-<Modal @ref="ModalContainer" IsKeyboard="false" OnCloseAsync="OnCloseAsync">
+<Modal @ref="ModalContainer" IsKeyboard="false" OnCloseAsync="OnCloseAsync" class="swal">
     @RenderDialog()
 </Modal>

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor
@@ -2,8 +2,6 @@
 @inherits BootstrapComponentBase
 @inject SwalService Swal
 
-<div class="swal">
-    <Modal @ref="ModalContainer" IsKeyboard="false" OnCloseAsync="OnCloseAsync">
-        @RenderDialog()
-    </Modal>
-</div>
+<Modal @ref="ModalContainer" IsKeyboard="false" OnCloseAsync="OnCloseAsync">
+    @RenderDialog()
+</Modal>

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.cs
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.cs
@@ -6,18 +6,18 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// SweetAlert 组件
+/// SweetAlert component
 /// </summary>
 public partial class SweetAlert : IAsyncDisposable
 {
     /// <summary>
-    /// 获得/设置 Modal 容器组件实例
+    /// Gets or sets the Modal container component instance
     /// </summary>
     [NotNull]
     private Modal? ModalContainer { get; set; }
 
     /// <summary>
-    /// DialogServices 服务实例
+    /// Gets or sets the DialogServices service instance
     /// </summary>
     [Inject]
     [NotNull]
@@ -46,10 +46,10 @@ public partial class SweetAlert : IAsyncDisposable
     {
         base.OnInitialized();
 
-        // 注册 Swal 弹窗事件
+        // Register Swal popup event
         SwalService.Register(this, Show);
 
-        // 设置 OnCloseAsync 回调方法
+        // Set OnCloseAsync callback method
         OnCloseAsync = () =>
         {
             IsShowDialog = false;
@@ -78,10 +78,10 @@ public partial class SweetAlert : IAsyncDisposable
 
         if (IsShowDialog)
         {
-            // 打开弹窗
+            // Open popup
             await ModalContainer.Show();
 
-            // 自动关闭处理逻辑
+            // Auto close handling logic
             if (AutoHideCheck())
             {
                 try
@@ -112,7 +112,7 @@ public partial class SweetAlert : IAsyncDisposable
     {
         if (!IsShowDialog)
         {
-            // 保证仅打开一个弹窗
+            // Ensure only one popup is opened
             IsShowDialog = true;
 
             IsAutoHide = option.IsAutoHide;
@@ -131,7 +131,7 @@ public partial class SweetAlert : IAsyncDisposable
 
             OnCloseCallbackAsync = AutoHideCheck() ? option.OnCloseAsync : null;
 
-            // 渲染 UI 准备弹窗 Dialog
+            // Render UI to prepare popup Dialog
             await InvokeAsync(StateHasChanged);
         }
     }
@@ -151,7 +151,7 @@ public partial class SweetAlert : IAsyncDisposable
     private bool disposed;
 
     /// <summary>
-    /// Dispose 方法
+    /// Dispose method
     /// </summary>
     /// <param name="disposing"></param>
     protected virtual async ValueTask DisposeAsync(bool disposing)
@@ -162,22 +162,22 @@ public partial class SweetAlert : IAsyncDisposable
 
             if (IsShowDialog)
             {
-                // 关闭弹窗
+                // Close popup
                 DelayToken.Cancel();
                 await ModalContainer.Close();
                 IsShowDialog = false;
             }
 
-            // 释放 Token
+            // Release Token
             DelayToken.Dispose();
 
-            // 注销服务
+            // Unregister service
             SwalService.UnRegister(this);
         }
     }
 
     /// <summary>
-    /// Dispose 方法
+    /// <inheritdoc/>
     /// </summary>
     public async ValueTask DisposeAsync()
     {

--- a/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.scss
+++ b/src/BootstrapBlazor/Components/SweetAlert/SweetAlert.razor.scss
@@ -1,9 +1,3 @@
-.swal {
-    position: fixed;
-    --bb-swal-zindex: 1075;
-    z-index: var(--bb-swal-zindex);
-}
-
 .swal2-header {
     display: flex;
     flex-direction: column;

--- a/src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs
+++ b/src/BootstrapBlazor/Services/BootstrapBlazorRootRegisterService.cs
@@ -99,17 +99,12 @@ public class BootstrapBlazorRootRegisterService
     /// <param name="provider"></param>
     public void NotifyContentProviderChanged(object identifier, BootstrapBlazorRootContent provider)
     {
-        if (!_providersByIdentifier.TryGetValue(identifier, out var providers))
+        if (!_providersByIdentifier.TryGetValue(identifier, out _))
         {
             throw new InvalidOperationException($"There are no content providers with the given root ID '{identifier}'.");
         }
 
-        // We only notify content changed for subscribers when the content of the
-        // most recently added provider changes.
-        if (providers.Count != 0 && providers[^1] == provider)
-        {
-            NotifyContentChangedForSubscriber(identifier, provider);
-        }
+        NotifyContentChangedForSubscriber(identifier, provider);
     }
 
     private static BootstrapBlazorRootContent? GetCurrentProviderContentOrDefault(List<BootstrapBlazorRootContent> providers)

--- a/src/BootstrapBlazor/wwwroot/scss/root.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/root.scss
@@ -76,6 +76,10 @@ a, a:hover, a:focus {
     --bs-popover-body-padding-y: 0.5rem;
 }
 
+.modal-backdrop.show + .modal-backdrop.show {
+    display: none;
+}
+
 ::view-transition-old(*) {
     mix-blend-mode: normal;
     animation: none;

--- a/test/UnitTest/Components/ErrorHandlerTest.cs
+++ b/test/UnitTest/Components/ErrorHandlerTest.cs
@@ -28,7 +28,7 @@ public class ErrorHandlerTest : BootstrapBlazorTestBase
         Assert.Contains("<div class=\"modal-body\"><div class=\"error-stack\">", cut.Markup);
 
         // 关闭弹窗
-        var btn = cut.Find(".btn-close");
+        var btn = cut.Find(".modal-header .btn-close");
         await cut.InvokeAsync(() => btn.Click());
 
         cut.Contains("<div class=\"toast-body\">test error logger</div>");

--- a/test/UnitTest/Components/InputTest.cs
+++ b/test/UnitTest/Components/InputTest.cs
@@ -339,11 +339,14 @@ public class InputTest : BootstrapBlazorTestBase
     [Fact]
     public void Focus_Ok()
     {
-        var cut = Context.RenderComponent<Modal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
-            pb.AddChildContent<BootstrapInput<string>>(pb =>
+            pb.AddChildContent<Modal>(pb =>
             {
-                pb.Add(a => a.IsAutoFocus, true);
+                pb.AddChildContent<BootstrapInput<string>>(pb =>
+                {
+                    pb.Add(a => a.IsAutoFocus, true);
+                });
             });
         });
     }

--- a/test/UnitTest/Components/ModalTest.cs
+++ b/test/UnitTest/Components/ModalTest.cs
@@ -12,47 +12,67 @@ public class ModalTest : BootstrapBlazorTestBase
     [Fact]
     public void IsBackdrop_Ok()
     {
-        var cut = Context.RenderComponent<Modal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
         {
-            pb.Add(m => m.IsBackdrop, true);
-            pb.Add(m => m.IsFade, false);
+            builder.AddChildContent<Modal>(pb =>
+            {
+                pb.Add(m => m.IsBackdrop, true);
+                pb.Add(m => m.IsFade, false);
+                pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
+            });
         });
-        Assert.DoesNotContain("static", cut.Markup);
-        Assert.DoesNotContain("modal fade", cut.Markup);
 
-        cut.SetParametersAndRender(pb =>
+        var modal = cut.Find(".backdrop");
+        Assert.Null(modal.GetAttribute("data-bs-backdrop"));
+
+        var m = cut.FindComponent<Modal>();
+        m.SetParametersAndRender(pb =>
         {
             pb.Add(m => m.IsBackdrop, false);
         });
-        Assert.Contains("static", cut.Markup);
+        modal = cut.Find(".backdrop");
+        Assert.Equal("static", modal.GetAttribute("data-bs-backdrop"));
     }
 
     [Fact]
-    public void Toggle_Ok()
+    public async Task Toggle_Ok()
     {
-        var cut = Context.RenderComponent<Modal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
         {
-            pb.AddChildContent<ModalDialog>();
+            builder.AddChildContent<Modal>(pb =>
+            {
+                pb.AddChildContent<ModalDialog>();
+                pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
+            });
         });
-        cut.InvokeAsync(async () => await cut.Instance.Toggle());
-        Assert.Contains("modal fade", cut.Markup);
-        Assert.Contains("modal-dialog", cut.Markup);
+
+        var modal = cut.FindComponent<Modal>();
+        await cut.InvokeAsync(modal.Instance.Toggle);
+        Assert.Contains("modal fade backdrop", cut.Markup);
     }
 
     [Fact]
-    public void Close_Ok()
+    public async Task Close_Ok()
     {
-        var cut = Context.RenderComponent<Modal>();
-        cut.InvokeAsync(async () => await cut.Instance.Close());
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
+        {
+            builder.AddChildContent<Modal>(pb =>
+            {
+                pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
+            });
+        });
 
-        cut.SetParametersAndRender(pb =>
+        var modal = cut.FindComponent<Modal>();
+        await cut.InvokeAsync(modal.Instance.Close);
+
+        modal.SetParametersAndRender(pb =>
         {
             pb.AddChildContent<ModalDialog>();
         });
-        cut.InvokeAsync(async () => await cut.Instance.Close());
+        await cut.InvokeAsync(modal.Instance.Close);
 
         // 多弹窗
-        cut.SetParametersAndRender(pb =>
+        modal.SetParametersAndRender(pb =>
         {
             pb.AddChildContent(builder =>
             {
@@ -62,56 +82,76 @@ public class ModalTest : BootstrapBlazorTestBase
                 builder.CloseComponent();
             });
         });
-        cut.InvokeAsync(async () => await cut.Instance.Close());
+        await modal.InvokeAsync(modal.Instance.Close);
     }
 
     [Fact]
     public async Task SetHeaderText_Ok()
     {
-        var cut = Context.RenderComponent<Modal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
         {
-            pb.AddChildContent<ModalDialog>();
+            builder.AddChildContent<Modal>(pb =>
+            {
+                pb.AddChildContent<ModalDialog>();
+                pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
+            });
         });
-        var header = cut.Find(".modal-title");
+
+        var header = cut.Find(".backdrop .modal-title");
         Assert.Equal("", header.TextContent);
 
-        await cut.InvokeAsync(() => cut.Instance.SetHeaderText("Test-Header"));
-        header = cut.Find(".modal-title");
+        var modal = cut.FindComponent<Modal>();
+        await cut.InvokeAsync(() => modal.Instance.SetHeaderText("Test-Header"));
+        header = cut.Find(".backdrop .modal-title");
         Assert.Equal("Test-Header", header.TextContent);
     }
 
     [Fact]
     public void SetHeaderText_Null()
     {
-        var cut = Context.RenderComponent<MockModal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
         {
-            pb.AddChildContent<ModalDialog>();
+            builder.AddChildContent<MockModal>(pb =>
+            {
+                pb.AddChildContent<ModalDialog>();
+                pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
+            });
         });
-        cut.Instance.TestSetHeaderText();
+
+        var modal = cut.FindComponent<MockModal>();
+        modal.Instance.TestSetHeaderText();
     }
 
     [Fact]
     public async Task ShownCallbackAsync_Ok()
     {
-        var cut = Context.RenderComponent<MockComponent>();
-        var modal = cut.FindComponent<MockModal>();
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
+        {
+            builder.AddChildContent<MockComponent>();
+        });
+
+        var mock = Context.RenderComponent<MockComponent>();
+        var modal = mock.FindComponent<MockModal>();
         await cut.InvokeAsync(() => modal.Instance.Show_Test());
 
-        Assert.True(cut.Instance.Value);
+        Assert.True(mock.Instance.Value);
     }
 
     [Fact]
     public void FirstAfterRenderAsync_Ok()
     {
         var render = false;
-        var cut = Context.RenderComponent<Modal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
         {
-            pb.Add(a => a.FirstAfterRenderCallbackAsync, modal =>
+            builder.AddChildContent<Modal>(pb =>
             {
-                render = true;
-                return Task.CompletedTask;
+                pb.Add(a => a.FirstAfterRenderCallbackAsync, modal =>
+                {
+                    render = true;
+                    return Task.CompletedTask;
+                });
+                pb.AddChildContent<ModalDialog>();
             });
-            pb.AddChildContent<ModalDialog>();
         });
         Assert.True(render);
     }
@@ -119,15 +159,19 @@ public class ModalTest : BootstrapBlazorTestBase
     [Fact]
     public async Task RegisterShownCallback_Ok()
     {
-        var cut = Context.RenderComponent<Modal>(pb =>
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
         {
-            pb.AddChildContent<MockFocusComponent>();
+            builder.AddChildContent<Modal>(pb =>
+            {
+                pb.AddChildContent<MockFocusComponent>();
+            });
         });
 
+        var modal = cut.FindComponent<Modal>();
         var component = cut.FindComponent<MockFocusComponent>();
         Assert.False(component.Instance.Pass);
 
-        await cut.InvokeAsync(cut.Instance.ShownCallback);
+        await cut.InvokeAsync(modal.Instance.ShownCallback);
         Assert.True(component.Instance.Pass);
     }
 

--- a/test/UnitTest/Components/ModalTest.cs
+++ b/test/UnitTest/Components/ModalTest.cs
@@ -37,18 +37,15 @@ public class ModalTest : BootstrapBlazorTestBase
     [Fact]
     public async Task Toggle_Ok()
     {
-        var cut = Context.RenderComponent<BootstrapBlazorRoot>(builder =>
+        var container = Context.RenderComponent<BootstrapBlazorRootOutlet>();
+        var cut = Context.RenderComponent<Modal>(pb =>
         {
-            builder.AddChildContent<Modal>(pb =>
-            {
-                pb.AddChildContent<ModalDialog>();
-                pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
-            });
+            pb.AddChildContent<ModalDialog>();
+            pb.Add(m => m.AdditionalAttributes, new Dictionary<string, object> { { "class", "backdrop" } });
         });
 
-        var modal = cut.FindComponent<Modal>();
-        await cut.InvokeAsync(modal.Instance.Toggle);
-        Assert.Contains("modal fade backdrop", cut.Markup);
+        await cut.InvokeAsync(cut.Instance.Toggle);
+        Assert.Contains("modal fade backdrop", container.Markup);
     }
 
     [Fact]

--- a/test/UnitTest/Components/TableDialogTest.cs
+++ b/test/UnitTest/Components/TableDialogTest.cs
@@ -322,7 +322,6 @@ public class TableDialogTest : TableDialogTestBase
         // 检查 dialog 是否显示
         var editDialog = cut.FindComponents<Dialog>().FirstOrDefault(i => i.Instance == dialog);
         Assert.NotNull(editDialog);
-        Assert.Contains("新建窗口", editDialog.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #5594 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactors the Modal component to use BootstrapBlazorRootOutlet to wrap the Modal component, ensuring proper rendering and functionality within the BootstrapBlazor framework. This change addresses issue #5594.

Enhancements:
- Wraps the Modal component with BootstrapBlazorRootOutlet to improve rendering and integration within the BootstrapBlazor framework.
- Updates unit tests to reflect the changes in the Modal component's rendering structure.
- Removes the swal div and moves the Modal component to the root.
- Updates the main and base layout to have relative positioning and z-index