### PR TITLE
doc(SourceCodePath): add SourceCodePath configuration section

### DIFF
--- a/src/BootstrapBlazor.Server/Services/CodeSnippetService.cs
+++ b/src/BootstrapBlazor.Server/Services/CodeSnippetService.cs
@@ -14,11 +14,13 @@ namespace BootstrapBlazor.Server.Services;
 /// <param name="factory"></param>
 /// <param name="cacheManager"></param>
 /// <param name="options"></param>
+/// <param name="configuration"></param>
 /// <param name="localizerOptions"></param>
 class CodeSnippetService(
     IHttpClientFactory factory,
     ICacheManager cacheManager,
     IOptions<WebsiteOptions> options,
+    IConfiguration configuration,
     IOptions<JsonLocalizationOptions> localizerOptions)
 {
     /// <summary>
@@ -88,7 +90,7 @@ class CodeSnippetService(
         string? payload;
         var file = options.Value.IsDevelopment
             ? $"{options.Value.ContentRootPath}\\..\\BootstrapBlazor.Server\\Components\\Samples\\{fileName}"
-            : $"{options.Value.SourceCodePath}BootstrapBlazor.Server\\Components\\Samples\\{fileName}";
+            : $"{GetSourceCodePath()}BootstrapBlazor.Server\\Components\\Samples\\{fileName}";
         if (!OperatingSystem.IsWindows())
         {
             file = file.Replace('\\', '/');
@@ -103,6 +105,8 @@ class CodeSnippetService(
         }
         return payload;
     }
+
+    private string GetSourceCodePath() => $"{configuration.GetValue<string>("SourceCodePath") ?? options.Value.SourceCodePath}";
 
     private static string ReplaceSymbols(string payload) => payload
         .Replace("@@", "@")


### PR DESCRIPTION
## Link issues
fixes #5601 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes several changes to the `CodeSnippetService` class in the `BootstrapBlazor.Server` project. The most important changes involve adding a new dependency, modifying the logic for determining the source code path, and introducing a helper method to retrieve this path.

Dependency addition:

* [`src/BootstrapBlazor.Server/Services/CodeSnippetService.cs`](diffhunk://#diff-c6bd77b235c1816cd4c07101ae0e1a8378fdc2dd3d9a04db0c1b41ddd1d76269R17-R23): Added `IConfiguration` as a new parameter to the `CodeSnippetService` constructor to allow configuration settings to be injected.

Source code path logic improvement:

* [`src/BootstrapBlazor.Server/Services/CodeSnippetService.cs`](diffhunk://#diff-c6bd77b235c1816cd4c07101ae0e1a8378fdc2dd3d9a04db0c1b41ddd1d76269L91-R93): Modified the logic in `ReadFileAsync` to use the new `GetSourceCodePath` method instead of directly accessing `options.Value.SourceCodePath`.
* [`src/BootstrapBlazor.Server/Services/CodeSnippetService.cs`](diffhunk://#diff-c6bd77b235c1816cd4c07101ae0e1a8378fdc2dd3d9a04db0c1b41ddd1d76269R109-R110): Introduced a new private method `GetSourceCodePath` to retrieve the source code path from the configuration or fallback to the options value.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
