### PR TITLE
doc(Translation): translate comments and documentation from Chinese to English

### DIFF
--- a/src/BootstrapBlazor/Attributes/AutoGenerateBaseAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/AutoGenerateBaseAttribute.cs
@@ -6,69 +6,69 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// AutoGenerateColumn 标签基类，用于 <see cref="Table{TItem}"/> 标识自动生成列
+/// Base class for AutoGenerateColumn attribute, used to mark auto-generated columns in <see cref="Table{TItem}"/>
 /// </summary>
 public abstract class AutoGenerateBaseAttribute : Attribute
 {
     /// <summary>
-    /// 获得/设置 当前列是否可编辑 默认为 true 当设置为 false 时自动生成编辑 UI 不生成此列
+    /// Gets or sets whether the current column is editable. Default is true. When set to false, the auto-generated edit UI will not generate this column.
     /// </summary>
-    [Obsolete("已弃用，是否可编辑改用 Readonly 参数，是否可见改用 Ignore 参数; Deprecated If it is editable, use the Readonly parameter. If it is visible, use the Ignore parameter.")]
+    [Obsolete("Deprecated. If it is editable, use the Readonly parameter. If it is visible, use the Ignore parameter.")]
     [ExcludeFromCodeCoverage]
     public bool Editable { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 当前列是否渲染 默认为 false 当设置为 true 时 UI 不生成此列
+    /// Gets or sets whether the current column is rendered. Default is false. When set to true, the UI will not generate this column.
     /// </summary>
     public bool Ignore { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前编辑项是否只读 默认为 false
+    /// Gets or sets whether the current edit item is read-only. Default is false.
     /// </summary>
     public bool Readonly { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前编辑项是否显示 默认为 true
+    /// Gets or sets whether the current edit item is visible. Default is true.
     /// </summary>
     public bool Visible { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 是否允许排序 默认为 false
+    /// Gets or sets whether sorting is allowed. Default is false.
     /// </summary>
     public bool Sortable { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否允许过滤数据 默认为 false
+    /// Gets or sets whether data filtering is allowed. Default is false.
     /// </summary>
     public bool Filterable { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否参与搜索 默认为 false
+    /// Gets or sets whether the column participates in search. Default is false.
     /// </summary>
     public bool Searchable { get; set; }
 
     /// <summary>
-    /// 获得/设置 本列是否允许换行 默认为 false
+    /// Gets or sets whether text wrapping is allowed in this column. Default is false.
     /// </summary>
     public bool TextWrap { get; set; }
 
     /// <summary>
-    /// 获得/设置 本列文本超出省略 默认为 false
+    /// Gets or sets whether text overflow is ellipsis in this column. Default is false.
     /// </summary>
     public bool TextEllipsis { get; set; }
 
     /// <summary>
-    /// 获得/设置 文字对齐方式 默认为 Alignment.None
+    /// Gets or sets the text alignment. Default is Alignment.None.
     /// </summary>
     public Alignment Align { get; set; }
 
     /// <summary>
-    /// 获得/设置 字段鼠标悬停提示 默认为 false
+    /// Gets or sets whether to show tooltips on mouse hover. Default is false.
     /// </summary>
     public bool ShowTips { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否可以拷贝列 默认 false 不可以
+    /// Gets or sets whether the column can be copied. Default is false.
     /// </summary>
     public bool ShowCopyColumn { get; set; }
 }

--- a/src/BootstrapBlazor/Attributes/AutoGenerateClassAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/AutoGenerateClassAttribute.cs
@@ -6,7 +6,7 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// AutoGenerateColumn 标签类，用于 <see cref="Table{TItem}"/> 标识自动生成列
+/// AutoGenerateColumn attribute class, used to mark auto-generated columns in <see cref="Table{TItem}"/>
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class AutoGenerateClassAttribute : AutoGenerateBaseAttribute

--- a/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
@@ -6,34 +6,34 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// AutoGenerateColumn 标签类，用于 <see cref="Table{TItem}"/> 标识自动生成列
+/// AutoGenerateColumn attribute class, used to mark auto-generated columns in <see cref="Table{TItem}"/>
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
 public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColumn
 {
     /// <summary>
-    /// 获得/设置 显示顺序 ，规则如下：
+    /// Gets or sets the display order. The rules are as follows:
     /// <para></para>
-    /// &gt;0时排前面，1,2,3...
+    /// &gt;0 for the front, 1,2,3...
     /// <para></para>
-    /// =0时排中间(默认)
+    /// =0 for the middle (default)
     /// <para></para>
-    /// &lt;0时排后面，...-3,-2,-1
+    /// &lt;0 for the back, ...-3,-2,-1
     /// </summary>
     public int Order { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否为默认排序列 默认为 false
+    /// <inheritdoc/>
     /// </summary>
     public bool DefaultSort { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否不进行验证 默认为 false
+    /// <inheritdoc/>
     /// </summary>
     public bool SkipValidate { get; set; }
 
     /// <summary>
-    /// <inheritdoc/>
+    /// Gets or sets whether the column is read-only when adding a new item. Default is null, using the <see cref="IEditorItem.Readonly"/> value.
     /// </summary>
     public bool IsReadonlyWhenAdd { get; set; }
 
@@ -44,7 +44,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// <inheritdoc/>
+    /// Gets or sets whether the column is read-only when editing an item. Default is null, using the <see cref="IEditorItem.Readonly"/> value.
     /// </summary>
     public bool IsReadonlyWhenEdit { get; set; }
 
@@ -55,7 +55,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// <inheritdoc/>
+    /// Gets or sets whether the column is visible when adding a new item. Default is null, using the <see cref="Visible"/> value.
     /// </summary>
     public bool IsVisibleWhenAdd { get; set; } = true;
 
@@ -66,13 +66,10 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// <inheritdoc/>
+    /// Gets or sets whether the column is visible when editing an item. Default is null, using the <see cref="Visible"/> value.
     /// </summary>
     public bool IsVisibleWhenEdit { get; set; } = true;
 
-    /// <summary>
-    /// 自定义搜索方法
-    /// </summary>
     Func<ITableColumn, string?, SearchFilterAction>? ITableColumn.CustomSearch { get; set; }
 
     bool? ITableColumn.IsVisibleWhenEdit
@@ -82,7 +79,6 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     bool? IEditorItem.Required { get; set; }
-
 
     bool? ITableColumn.IsRequiredWhenAdd { get; set; }
 
@@ -94,7 +90,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     public string? RequiredErrorMessage { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示标签 Tooltip 多用于标签文字过长导致裁减时使用 默认 false
+    /// Gets or sets whether to show label tooltip. Mostly used when the label text is too long and gets truncated. Default is false.
     /// </summary>
     public bool ShowLabelTooltip { get; set; }
 
@@ -105,14 +101,14 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// 获得/设置 是否为默认排序规则 默认为 SortOrder.Unset
+    /// Gets or sets the default sort order. Default is SortOrder.Unset.
     /// </summary>
     public SortOrder DefaultSortOrder { get; set; }
 
     IEnumerable<SelectedItem>? IEditorItem.Items { get; set; }
 
     /// <summary>
-    /// 获得/设置 列宽
+    /// Gets or sets the column width.
     /// </summary>
     public int Width { get; set; }
 
@@ -123,27 +119,27 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// 获得/设置 是否固定本列 默认 false 不固定
+    /// <inheritdoc/>
     /// </summary>
     public bool Fixed { get; set; }
 
     /// <summary>
-    /// 获得/设置 列 td 自定义样式 默认为 null 未设置
+    /// <inheritdoc/>
     /// </summary>
     public string? CssClass { get; set; }
 
     /// <summary>
-    /// 获得/设置 显示节点阈值 默认值 BreakPoint.None 未设置
+    /// <inheritdoc/>
     /// </summary>
     public BreakPoint ShownWithBreakPoint { get; set; }
 
     /// <summary>
-    /// 获得/设置 格式化字符串 如时间类型设置 yyyy-MM-dd
+    /// <inheritdoc/>
     /// </summary>
     public string? FormatString { get; set; }
 
     /// <summary>
-    /// 获得/设置 placeholder 文本 默认为 null
+    /// <inheritdoc/>
     /// </summary>
     public string? PlaceHolder { get; set; }
 
@@ -152,104 +148,47 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     /// </summary>
     public Func<object?, Task<string?>>? Formatter { get; set; }
 
-    /// <summary>
-    /// 获得/设置 编辑模板
-    /// </summary>
     RenderFragment<object>? IEditorItem.EditTemplate { get; set; }
 
-    /// <summary>
-    /// 获得/设置 表头模板
-    /// </summary>
     RenderFragment<ITableColumn>? ITableColumn.HeaderTemplate { get; set; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     RenderFragment<ITableColumn>? ITableColumn.ToolboxTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件类型 默认为 null
+    /// <inheritdoc/>
     /// </summary>
     public Type? ComponentType { get; set; }
 
-    /// <summary>
-    /// 获得/设置 组件自定义类型参数集合 默认为 null
-    /// </summary>
     IEnumerable<KeyValuePair<string, object>>? IEditorItem.ComponentParameters { get; set; }
 
-    /// <summary>
-    /// 获得/设置 显示模板
-    /// </summary>
     RenderFragment<object>? ITableColumn.Template { get; set; }
 
-    /// <summary>
-    /// 获得/设置 搜索模板
-    /// </summary>
     RenderFragment<object>? ITableColumn.SearchTemplate { get; set; }
 
-    /// <summary>
-    /// 获得/设置 过滤模板
-    /// </summary>
     RenderFragment? ITableColumn.FilterTemplate { get; set; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     Func<object?, Task<string?>>? ITableColumn.GetTooltipTextCallback { get; set; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.Searchable { get => Searchable; set => Searchable = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.Filterable { get => Filterable; set => Filterable = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.Sortable { get => Sortable; set => Sortable = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.TextWrap { get => TextWrap; set => TextWrap = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.TextEllipsis { get => TextEllipsis; set => TextEllipsis = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? IEditorItem.Ignore { get => Ignore; set => Ignore = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? IEditorItem.Readonly { get => Readonly; set => Readonly = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.Visible { get => Visible; set => Visible = value ?? true; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.ShowTips { get => ShowTips; set => ShowTips = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     bool? ITableColumn.ShowCopyColumn { get => ShowCopyColumn; set => ShowCopyColumn = value ?? false; }
 
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
     Alignment? ITableColumn.Align { get => Align; set => Align = value ?? Alignment.None; }
 
     /// <summary>
@@ -258,28 +197,25 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     public string? Step { get; set; }
 
     /// <summary>
-    /// 获得/设置 行数
+    /// <inheritdoc/>
     /// </summary>
     public int Rows { get; set; }
 
     /// <summary>
-    /// 获得/设置 控件的占列数值范围 1-12
+    /// <inheritdoc/>
     /// </summary>
     public int Cols { get; set; }
 
-    /// <summary>
-    /// 获得/设置 列过滤器
-    /// </summary>
     IFilter? ITableColumn.Filter { get; set; }
 
     /// <summary>
-    /// 获得 属性类型
+    /// <inheritdoc/>
     /// </summary>
     [NotNull]
     public Type? PropertyType { get; internal set; }
 
     /// <summary>
-    /// 获得/设置 当前属性显示文字 列头或者标签名称
+    /// <inheritdoc/>
     /// </summary>
     public string? Text { get; set; }
 
@@ -290,7 +226,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     internal string? FieldName { get; set; }
 
     /// <summary>
-    /// 获得/设置 字段数据源下拉框是否显示搜索栏 默认 false 不显示
+    /// <inheritdoc/>
     /// </summary>
     public bool ShowSearchWhenSelect { get; set; }
 
@@ -324,35 +260,27 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     /// </summary>
     public StringComparison LookupStringComparison { get; set; } = StringComparison.OrdinalIgnoreCase;
 
-    /// <summary>
-    /// 获得/设置 单元格回调方法
-    /// </summary>
     Action<TableCellArgs>? ITableColumn.OnCellRender { get; set; }
 
-    /// <summary>
-    /// 获得/设置 自定义验证集合
-    /// </summary>
     List<IValidator>? IEditorItem.ValidateRules { get; set; }
 
     /// <summary>
-    /// 获取绑定字段显示名称方法
+    /// <inheritdoc/>
     /// </summary>
-    /// <returns></returns>
     public virtual string GetDisplayName() => Text ?? "";
 
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    /// <returns></returns>
     public string GetFieldName() => FieldName;
 
     /// <summary>
-    /// 获得/设置 当前属性分组
+    /// <inheritdoc/>
     /// </summary>
     public string? GroupName { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前属性分组排序 默认 0
+    /// <inheritdoc/>
     /// </summary>
     public int GroupOrder { get; set; }
 

--- a/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs
@@ -55,7 +55,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// Gets or sets whether the column is visible when adding a new item. Default is null, using the <see cref="Visible"/> value.
+    /// Gets or sets whether the column is visible when adding a new item. Default is null, using the <see cref="AutoGenerateBaseAttribute.Visible"/> value.
     /// </summary>
     public bool IsVisibleWhenAdd { get; set; } = true;
 
@@ -66,7 +66,7 @@ public class AutoGenerateColumnAttribute : AutoGenerateBaseAttribute, ITableColu
     }
 
     /// <summary>
-    /// Gets or sets whether the column is visible when editing an item. Default is null, using the <see cref="Visible"/> value.
+    /// Gets or sets whether the column is visible when editing an item. Default is null, using the <see cref="AutoGenerateBaseAttribute.Visible"/> value.
     /// </summary>
     public bool IsVisibleWhenEdit { get; set; } = true;
 

--- a/src/BootstrapBlazor/Attributes/BootstrapModuleAutoLoaderAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/BootstrapModuleAutoLoaderAttribute.cs
@@ -6,13 +6,13 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// 构造函数
+/// Constructor
 /// </summary>
 /// <param name="path"></param>
 class BootstrapModuleAutoLoaderAttribute(string? path = null) : JSModuleAutoLoaderAttribute(path)
 {
     /// <summary>
-    /// 获得/设置 模块名称 自动使用 modules 文件夹下脚本
+    /// Gets or sets the module name. Automatically uses scripts from the modules folder.
     /// </summary>
     public string? ModuleName { get; set; }
 }

--- a/src/BootstrapBlazor/Attributes/JSModuleAutoLoaderAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/JSModuleAutoLoaderAttribute.cs
@@ -8,27 +8,27 @@ namespace BootstrapBlazor.Components;
 /// <summary>
 /// JSModuleAutoLoaderAttribute class
 /// </summary>
-/// <param name="path"></param>
+/// <param name="path">The path to the JavaScript module</param>
 [AttributeUsage(AttributeTargets.Class)]
 public class JSModuleAutoLoaderAttribute(string? path = null) : Attribute
 {
     /// <summary>
-    /// 获得 Name 属性
+    /// Gets the path property
     /// </summary>
     public string? Path { get; } = path;
 
     /// <summary>
-    /// Represents a reference to a JavaScript object Default value false
+    /// Represents a reference to a JavaScript object. Default value is false.
     /// </summary>
     public bool JSObjectReference { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否自动调用 init 默认 true
+    /// Gets or sets whether to automatically invoke init. Default is true.
     /// </summary>
     public bool AutoInvokeInit { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 是否自动调用 dispose 默认 true
+    /// Gets or sets whether to automatically invoke dispose. Default is true.
     /// </summary>
     public bool AutoInvokeDispose { get; set; } = true;
 }

--- a/src/BootstrapBlazor/Attributes/NullableBoolItemsAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/NullableBoolItemsAttribute.cs
@@ -6,23 +6,23 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// 可为空布尔类型转换器
+/// Nullable boolean type converter
 /// </summary>
 [AttributeUsage(AttributeTargets.Property)]
 public class NullableBoolItemsAttribute : Attribute
 {
     /// <summary>
-    /// 获得/设置 空值显示文本
+    /// Gets or sets the display text for null value
     /// </summary>
     public string? NullValueDisplayText { get; set; }
 
     /// <summary>
-    /// 获得/设置 True 值显示文本
+    /// Gets or sets the display text for true value
     /// </summary>
     public string? TrueValueDisplayText { get; set; }
 
     /// <summary>
-    /// 获得/设置 False 值显示文本
+    /// Gets or sets the display text for false value
     /// </summary>
     public string? FalseValueDisplayText { get; set; }
 }

--- a/src/BootstrapBlazor/Attributes/PlaceHolderAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/PlaceHolderAttribute.cs
@@ -6,22 +6,14 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// PlaceHolderAttribute 占位符标签类
+/// PlaceHolderAttribute class used to define a placeholder for a property.
 /// </summary>
+/// <param name="placeholder">The placeholder text.</param>
 [AttributeUsage(AttributeTargets.Property)]
-public class PlaceHolderAttribute : Attribute
+public class PlaceHolderAttribute(string placeholder) : Attribute
 {
     /// <summary>
-    /// 获得 Text 属性
+    /// Gets the placeholder text.
     /// </summary>
-    public string Text { get; }
-
-    /// <summary>
-    /// 构造函数
-    /// </summary>
-    /// <param name="placeholder"></param>
-    public PlaceHolderAttribute(string placeholder)
-    {
-        Text = placeholder;
-    }
+    public string Text { get; } = placeholder;
 }

--- a/src/BootstrapBlazor/Attributes/TabItemOptionAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/TabItemOptionAttribute.cs
@@ -6,23 +6,23 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// TabItem 标签页配置属性类
+/// TabItem configuration attribute class
 /// </summary>
 [AttributeUsage(AttributeTargets.Class)]
 public class TabItemOptionAttribute : Attribute
 {
     /// <summary>
-    /// 获得/设置 文本文字
+    /// Gets or sets the text of the tab item.
     /// </summary>
     public string? Text { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前 TabItem 是否可关闭 默认为 true 可关闭
+    /// Gets or sets whether the current TabItem is closable. Default is true.
     /// </summary>
     public bool Closable { get; set; } = true;
 
     /// <summary>
-    /// 获得/设置 图标字符串
+    /// Gets or sets the icon string.
     /// </summary>
     public string? Icon { get; set; }
 }

--- a/src/BootstrapBlazor/Attributes/TableMetadataForAttribute.cs
+++ b/src/BootstrapBlazor/Attributes/TableMetadataForAttribute.cs
@@ -56,7 +56,7 @@ namespace BootstrapBlazor.Components;
 public class TableMetadataForAttribute(Type dataType) : Attribute
 {
     /// <summary>
-    /// The target model/data type
+    /// Gets the target model/data type
     /// </summary>
     public Type DataType => dataType;
 }

--- a/src/BootstrapBlazor/Components/EditorForm/IEditorItem.cs
+++ b/src/BootstrapBlazor/Components/EditorForm/IEditorItem.cs
@@ -6,128 +6,128 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// IEditorItem 接口
+/// IEditorItem interface
 /// </summary>
 public interface IEditorItem : ILookup
 {
     /// <summary>
-    /// 获得/设置 绑定列类型
+    /// Gets or sets the type of the bound column.
     /// </summary>
     Type PropertyType { get; }
 
     /// <summary>
-    /// 获得/设置 当前编辑项是否可编辑 默认为 true
+    /// Gets or sets whether the current edit item is editable. Default is true.
     /// </summary>
-    [Obsolete("已弃用，是否显示使用 Visible 参数，新建时使用 IsVisibleWhenAdd 编辑时使用 IsVisibleWhenEdit 只读使用 Readonly 参数，新建时使用 IsReadonlyWhenAdd 编辑时使用 IsReadonlyWhenEdit 参数; Deprecated use Visible parameter. IsVisibleWhenAdd should be used when creating a new one, and IsVisibleWhenEdit should be used when editing")]
+    [Obsolete("Deprecated. Use the Visible parameter. IsVisibleWhenAdd should be used when creating a new one, and IsVisibleWhenEdit should be used when editing. Use the Readonly parameter for read-only. IsReadonlyWhenAdd should be used when creating a new one, and IsReadonlyWhenEdit should be used when editing.")]
     bool Editable { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前编辑项是否只读 默认为 false
+    /// Gets or sets whether the current edit item is read-only. Default is false.
     /// </summary>
     bool? Readonly { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前编辑项是否忽略 默认为 false 当设置为 true 时 UI 不生成此列
+    /// Gets or sets whether the current edit item is ignored. Default is false. When set to true, the UI will not generate this column.
     /// </summary>
     bool? Ignore { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否不进行验证 默认为 false
+    /// Gets or sets whether to skip validation. Default is false.
     /// </summary>
     bool SkipValidate { get; set; }
 
     /// <summary>
-    /// 获得/设置 表头显示文字
+    /// Gets or sets the header display text.
     /// </summary>
     string? Text { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示标签 Tooltip 多用于标签文字过长导致裁减时使用 默认 null
+    /// Gets or sets whether to show label tooltip. Mostly used when the label text is too long and gets truncated. Default is null.
     /// </summary>
     bool? ShowLabelTooltip { get; set; }
 
     /// <summary>
-    /// 获得/设置 placeholder 文本 默认为 null
+    /// Gets or sets the placeholder text. Default is null.
     /// </summary>
     string? PlaceHolder { get; set; }
 
     /// <summary>
-    /// 获得/设置 额外数据源一般用于 Select 或者 CheckboxList 这种需要额外配置数据源组件使用
+    /// Gets or sets the additional data source, generally used for components like Select or CheckboxList that require additional configuration.
     /// </summary>
     IEnumerable<SelectedItem>? Items { get; set; }
 
     /// <summary>
-    /// 获得/设置 步长 默认为 null 设置 any 时忽略检查
+    /// Gets or sets the step. Default is null. When set to "any", validation is ignored.
     /// </summary>
     string? Step { get; set; }
 
     /// <summary>
-    /// 获得/设置 Textarea 行数 默认为 0
+    /// Gets or sets the number of rows for a Textarea. Default is 0.
     /// </summary>
     int Rows { get; set; }
 
     /// <summary>
-    /// 获得/设置 编辑模板
+    /// Gets or sets the edit template.
     /// </summary>
     RenderFragment<object>? EditTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件类型 默认为 null
+    /// Gets or sets the component type. Default is null.
     /// </summary>
     Type? ComponentType { get; set; }
 
     /// <summary>
-    /// 获得/设置 组件自定义类型参数集合 默认为 null
+    /// Gets or sets the custom component parameters. Default is null.
     /// </summary>
     IEnumerable<KeyValuePair<string, object>>? ComponentParameters { get; set; }
 
     /// <summary>
-    /// 获得/设置 字段数据源下拉框是否显示搜索栏 默认 false 不显示
+    /// Gets or sets whether to show the search bar in the dropdown list. Default is false.
     /// </summary>
     bool ShowSearchWhenSelect { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否使用 Popover 渲染下拉框 默认 false
+    /// Gets or sets whether to use Popover to render the dropdown list. Default is false.
     /// </summary>
     bool IsPopover { get; set; }
 
     /// <summary>
-    /// 获得/设置 自定义验证集合
+    /// Gets or sets the custom validation rules.
     /// </summary>
     List<IValidator>? ValidateRules { get; set; }
 
     /// <summary>
-    /// 获取绑定字段显示名称方法
+    /// Gets the display name of the bound field.
     /// </summary>
     string GetDisplayName();
 
     /// <summary>
-    /// 获取绑定字段信息方法
+    /// Gets the field information of the bound field.
     /// </summary>
     string GetFieldName();
 
     /// <summary>
-    /// 获得/设置 顺序号
+    /// Gets or sets the order number.
     /// </summary>
     int Order { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前属性分组
+    /// Gets or sets the group name of the current property.
     /// </summary>
     string? GroupName { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前属性分组排序 默认 0
+    /// Gets or sets the group order of the current property. Default is 0.
     /// </summary>
     int GroupOrder { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否为必填项 默认为 null
+    /// Gets or sets whether the field is required. Default is null.
     /// </summary>
     bool? Required { get; set; }
 
     /// <summary>
-    /// 获得/设置 必填项缺失时错误提示文本 默认为 null
+    /// Gets or sets the error message when the required field is missing. Default is null.
     /// </summary>
     string? RequiredErrorMessage { get; set; }
 }

--- a/src/BootstrapBlazor/Components/Table/ITableColumn.cs
+++ b/src/BootstrapBlazor/Components/Table/ITableColumn.cs
@@ -6,192 +6,192 @@
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// ITableHeader 接口
+/// ITableHeader interface
 /// </summary>
 public interface ITableColumn : IEditorItem
 {
     /// <summary>
-    /// 获得/设置 是否允许排序 默认为 null
+    /// Gets or sets whether sorting is allowed. Default is null.
     /// </summary>
     bool? Sortable { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否为默认排序列 默认为 false
+    /// Gets or sets whether it is the default sort column. Default is false.
     /// </summary>
     bool DefaultSort { get; set; }
 
     /// <summary>
-    /// 获得/设置 默认排序规则 默认为 SortOrder.Unset
+    /// Gets or sets the default sort order. Default is SortOrder.Unset.
     /// </summary>
     SortOrder DefaultSortOrder { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否允许过滤数据 默认为 null
+    /// Gets or sets whether data filtering is allowed. Default is null.
     /// </summary>
     bool? Filterable { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否参与搜索 默认为 null
+    /// Gets or sets whether the column participates in search. Default is null.
     /// </summary>
     bool? Searchable { get; set; }
 
     /// <summary>
-    /// 获得/设置 列宽
+    /// Gets or sets the column width.
     /// </summary>
     int? Width { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否固定本列 默认 false 不固定
+    /// Gets or sets whether the column is fixed. Default is false.
     /// </summary>
     bool Fixed { get; set; }
 
     /// <summary>
-    /// 获得/设置 本列是否允许换行 默认为 null
+    /// Gets or sets whether text wrapping is allowed in this column. Default is null.
     /// </summary>
     bool? TextWrap { get; set; }
 
     /// <summary>
-    /// 获得/设置 本列文本超出省略 默认为 null
+    /// Gets or sets whether text overflow is ellipsis in this column. Default is null.
     /// </summary>
     bool? TextEllipsis { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否表头允许折行 默认 false 不折行
+    /// Gets or sets whether the header text is allowed to wrap. Default is false.
     /// </summary>
     bool HeaderTextWrap { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否表头显示 Tooltip 默认 false 不显示 可配合 <see cref="HeaderTextEllipsis"/> 使用 设置 <see cref="HeaderTextWrap"/> 为 true 时本参数不生效
+    /// Gets or sets whether the header shows a tooltip. Default is false. Can be used with <see cref="HeaderTextEllipsis"/>. This parameter is not effective when <see cref="HeaderTextWrap"/> is set to true.
     /// </summary>
     bool ShowHeaderTooltip { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否表头 Tooltip 内容
+    /// Gets or sets the header tooltip content.
     /// </summary>
     string? HeaderTextTooltip { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否表头溢出时截断 默认 false 不截断 可配合 <see cref="HeaderTextTooltip"/> 使用 设置 <see cref="HeaderTextWrap"/> 为 true 时本参数不生效
+    /// Gets or sets whether the header text is truncated when overflowing. Default is false. Can be used with <see cref="HeaderTextTooltip"/>. This parameter is not effective when <see cref="HeaderTextWrap"/> is set to true.
     /// </summary>
     bool HeaderTextEllipsis { get; set; }
 
     /// <summary>
-    /// 获得/设置 列 td 自定义样式 默认为 null 未设置
+    /// Gets or sets the custom CSS class for the column td. Default is null.
     /// </summary>
     string? CssClass { get; set; }
 
     /// <summary>
-    /// 显示节点阈值 默认值 BreakPoint.None 未设置
+    /// Gets or sets the breakpoint at which the column is shown. Default is BreakPoint.None.
     /// </summary>
     BreakPoint ShownWithBreakPoint { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否可以拷贝列 默认 null 不可以
+    /// Gets or sets whether the column can be copied. Default is null.
     /// </summary>
     bool? ShowCopyColumn { get; set; }
 
     /// <summary>
-    /// 获得/设置 显示模板
+    /// Gets or sets the display template.
     /// </summary>
     RenderFragment<object>? Template { get; set; }
 
     /// <summary>
-    /// 获得/设置 搜索模板
+    /// Gets or sets the search template.
     /// </summary>
     RenderFragment<object>? SearchTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 过滤模板
+    /// Gets or sets the filter template.
     /// </summary>
     RenderFragment? FilterTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 表头模板
+    /// Gets or sets the header template.
     /// </summary>
     RenderFragment<ITableColumn>? HeaderTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 工具栏模板 默认 null
+    /// Gets or sets the toolbox template. Default is null.
     /// </summary>
     RenderFragment<ITableColumn>? ToolboxTemplate { get; set; }
 
     /// <summary>
-    /// 获得/设置 列过滤器
+    /// Gets or sets the column filter.
     /// </summary>
     IFilter? Filter { get; set; }
 
     /// <summary>
-    /// 获得/设置 格式化字符串 如时间类型设置 yyyy-MM-dd
+    /// Gets or sets the format string, such as "yyyy-MM-dd" for date types.
     /// </summary>
     string? FormatString { get; set; }
 
     /// <summary>
-    /// 获得/设置 列格式化回调委托 <see cref="TableColumnContext{TItem, TValue}"/>
+    /// Gets or sets the column format callback delegate <see cref="TableColumnContext{TItem, TValue}"/>.
     /// </summary>
     Func<object?, Task<string?>>? Formatter { get; set; }
 
     /// <summary>
-    /// 获得/设置 文字对齐方式 默认为 null 使用 Alignment.None
+    /// Gets or sets the text alignment. Default is null, using Alignment.None.
     /// </summary>
     Alignment? Align { get; set; }
 
     /// <summary>
-    /// 获得/设置 字段鼠标悬停提示 默认为 null 使用 false 值
+    /// Gets or sets whether to show tooltips on mouse hover. Default is null, using false value.
     /// </summary>
     bool? ShowTips { get; set; }
 
     /// <summary>
-    /// 获得/设置 鼠标悬停提示自定义内容回调委托 默认 null 使用当前值
+    /// Gets or sets the custom tooltip content callback delegate. Default is null, using the current value.
     /// </summary>
     Func<object?, Task<string?>>? GetTooltipTextCallback { get; set; }
 
     /// <summary>
-    /// 获得/设置 单元格回调方法
+    /// Gets or sets the cell render callback method.
     /// </summary>
     Action<TableCellArgs>? OnCellRender { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否为 MarkupString 默认 false
+    /// Gets or sets whether the column is a MarkupString. Default is false.
     /// </summary>
     bool IsMarkupString { get; set; }
 
     /// <summary>
-    /// 获得/设置 新建时是否为必填项 默认为 null
+    /// Gets or sets whether the column is required when adding a new item. Default is null.
     /// </summary>
     bool? IsRequiredWhenAdd { get; set; }
 
     /// <summary>
-    /// 获得/设置 编辑时是否为必填项 默认为 null
+    /// Gets or sets whether the column is required when editing an item. Default is null.
     /// </summary>
     bool? IsRequiredWhenEdit { get; set; }
 
     /// <summary>
-    /// 获得/设置 新建时此列只读 默认为 null 使用 <see cref="IEditorItem.Readonly"/> 值
+    /// Gets or sets whether the column is read-only when adding a new item. Default is null, using the <see cref="IEditorItem.Readonly"/> value.
     /// </summary>
     bool? IsReadonlyWhenAdd { get; set; }
 
     /// <summary>
-    /// 获得/设置 编辑时此列只读 默认为 null 使用 <see cref="IEditorItem.Readonly"/> 值
+    /// Gets or sets whether the column is read-only when editing an item. Default is null, using the <see cref="IEditorItem.Readonly"/> value.
     /// </summary>
     bool? IsReadonlyWhenEdit { get; set; }
 
     /// <summary>
-    /// 获得/设置 当前编辑项是否显示 默认为 null 未设置时为 true
+    /// Gets or sets whether the current edit item is visible. Default is null, using true value.
     /// </summary>
     bool? Visible { get; set; }
 
     /// <summary>
-    /// 获得/设置 新建时是否此列显示  默认为 null 使用 <see cref="Visible"/> 值
+    /// Gets or sets whether the column is visible when adding a new item. Default is null, using the <see cref="Visible"/> value.
     /// </summary>
     bool? IsVisibleWhenAdd { get; set; }
 
     /// <summary>
-    /// 获得/设置 编辑时是否此列显示  默认为 null 使用 <see cref="Visible"/> 值
+    /// Gets or sets whether the column is visible when editing an item. Default is null, using the <see cref="Visible"/> value.
     /// </summary>
     bool? IsVisibleWhenEdit { get; set; }
 
     /// <summary>
-    /// 获得/设置 自定义搜索逻辑
+    /// Gets or sets the custom search logic.
     /// </summary>
     Func<ITableColumn, string?, SearchFilterAction>? CustomSearch { get; set; }
 }

--- a/src/BootstrapBlazor/Converter/JsonDescriptionEnumConverter.cs
+++ b/src/BootstrapBlazor/Converter/JsonDescriptionEnumConverter.cs
@@ -9,17 +9,18 @@ using System.Text.Json.Serialization;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// 枚举类型转换器 序列化时把枚举类型的 [Description] 标签内容序列化成字符串 推荐使用 <see cref="JsonEnumConverter"/> 转换器
+/// Enum type converter that serializes the [Description] attribute of enum values to strings.
+/// It is recommended to use <see cref="JsonEnumConverter"/> instead.
 /// </summary>
 public class JsonDescriptionEnumConverter<T> : JsonConverter<T> where T : struct, Enum
 {
     /// <summary>
-    /// <inheritdoc/>
+    /// Reads and converts the JSON to the specified enum type.
     /// </summary>
-    /// <param name="reader"></param>
-    /// <param name="typeToConvert"></param>
-    /// <param name="options"></param>
-    /// <returns></returns>
+    /// <param name="reader">The reader.</param>
+    /// <param name="typeToConvert">The type to convert.</param>
+    /// <param name="options">The serializer options.</param>
+    /// <returns>The converted enum value.</returns>
     public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
     {
         T ret = default;
@@ -36,11 +37,11 @@ public class JsonDescriptionEnumConverter<T> : JsonConverter<T> where T : struct
     }
 
     /// <summary>
-    /// <inheritdoc/>
+    /// Writes the specified enum value as a string using its [Description] attribute.
     /// </summary>
-    /// <param name="writer"></param>
-    /// <param name="value"></param>
-    /// <param name="options"></param>
+    /// <param name="writer">The writer.</param>
+    /// <param name="value">The value to write.</param>
+    /// <param name="options">The serializer options.</param>
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
     {
         writer.WriteStringValue(value.ToDescriptionString());

--- a/src/BootstrapBlazor/Converter/JsonEnumConverter.cs
+++ b/src/BootstrapBlazor/Converter/JsonEnumConverter.cs
@@ -9,17 +9,17 @@ using System.Text.Json.Serialization;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// JsonEnumConverter 枚举转换器
+/// JsonEnumConverter is an enum converter that allows customization of enum serialization.
 /// </summary>
 /// <param name="camelCase">Optional naming policy for writing enum values.</param>
 /// <param name="allowIntegerValues">True to allow undefined enum values. When true, if an enum value isn't defined it will output as a number rather than a string.</param>
 public class JsonEnumConverter(bool camelCase = false, bool allowIntegerValues = true) : JsonConverterAttribute
 {
     /// <summary>
-    /// <inheritdoc/>
+    /// Creates a JsonConverter for the specified type.
     /// </summary>
-    /// <param name="typeToConvert"></param>
-    /// <returns></returns>
+    /// <param name="typeToConvert">The type to convert.</param>
+    /// <returns>A JsonConverter for the specified type.</returns>
     public override JsonConverter? CreateConverter(Type typeToConvert)
     {
         var converter = camelCase

--- a/test/UnitTest/Components/TimerTest.cs
+++ b/test/UnitTest/Components/TimerTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using AngleSharp.Dom;
 using Timer = BootstrapBlazor.Components.Timer;
 
 namespace UnitTest.Components;
@@ -135,16 +136,19 @@ public class TimerTest : BootstrapBlazorTestBase
         var buttons = cut.FindAll(".timer-buttons button");
         // pause
         Assert.True(buttons[1].ClassList.Contains("btn-warning"));
+        Assert.Equal("暂停", buttons[1].GetInnerText());
         await cut.InvokeAsync(() => buttons[1].Click());
         await Task.Delay(500);
 
         // resume
         buttons = cut.FindAll(".timer-buttons button");
         Assert.True(buttons[1].ClassList.Contains("btn-success"));
+        Assert.Equal("继续", buttons[1].GetInnerText());
         await cut.InvokeAsync(() => buttons[1].Click());
 
         // cancel
         buttons = cut.FindAll(".timer-buttons button");
+        Assert.Equal("取消", buttons[0].GetInnerText());
         await cut.InvokeAsync(() => buttons[0].Click());
         Assert.True(cancelled);
 


### PR DESCRIPTION
## Link issues
fixes #5603 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes updates to several attribute classes in the `BootstrapBlazor` library to improve code readability and consistency by translating comments and documentation from Chinese to English.

### Documentation Translation:

* [`src/BootstrapBlazor/Attributes/AutoGenerateBaseAttribute.cs`](diffhunk://#diff-c717a8141c024c2d442dedf3af46b68f2946f2b79102aa57686262c4dc7ed934L9-R71): Translated comments and documentation to English to improve readability for non-Chinese speakers.
* [`src/BootstrapBlazor/Attributes/AutoGenerateClassAttribute.cs`](diffhunk://#diff-820722df2ee599dd9def1a71f4c396cec27c7dc115f309e882fbd68bc205973dL9-R9): Updated comments to English for better understanding.
* [`src/BootstrapBlazor/Attributes/AutoGenerateColumnAttribute.cs`](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL9-R36): Translated all comments and documentation to English, and replaced some `<inheritdoc/>` tags with explicit descriptions. [[1]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL9-R36) [[2]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL47-R47) [[3]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL58-R58) [[4]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL69-L75) [[5]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL86) [[6]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL97-R93) [[7]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL108-R111) [[8]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL126-R142) [[9]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL155-L252) [[10]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL261-R218) [[11]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL293-R229) [[12]](diffhunk://#diff-de1e5f91f3b983538bb363adecf14020fb890fac8390f265596cf129a6f7f0caL327-R283)
* [`src/BootstrapBlazor/Attributes/BootstrapModuleAutoLoaderAttribute.cs`](diffhunk://#diff-013248507eda79415031a841d381d3c34150ffb1a57c503e98fb2fce44e3edeeL9-R15): Translated constructor and property comments to English.
* [`src/BootstrapBlazor/Attributes/JSModuleAutoLoaderAttribute.cs`](diffhunk://#diff-6341010adfe2e43353c7d0e87cd856157a23718cba4f0f893a625f40c8b0c3e7L11-R31): Updated parameter and property comments to English for clarity.
* [`src/BootstrapBlazor/Attributes/NullableBoolItemsAttribute.cs`](diffhunk://#diff-ccf057fba74f1ad4d3324e41f5ce2b76d419c477342cc501a18cbe544750c0beL9-R25): Translated comments to English.
* [`src/BootstrapBlazor/Attributes/PlaceHolderAttribute.cs`](diffhunk://#diff-fef9931482d8d158991c436d53abd3e1bd60ce26f37bebf20a45b25196cb99e0L9-R18): Translated comments and improved the constructor for better readability.
* [`src/BootstrapBlazor/Attributes/TabItemOptionAttribute.cs`](diffhunk://#diff-5209bb2b8465311fa9c2b1c485fc1aa100543d215b01a55ee69d970a2e2d2970L9-R25): Translated comments to English for better understanding.
* [`src/BootstrapBlazor/Attributes/TableMetadataForAttribute.cs`](diffhunk://#diff-8af217103a82405870a226e541e436f335989b265d10c691d24059538c1130c1L59-R59): Updated comments to English.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Documentation:
- Translate comments and documentation from Chinese to English in several attribute classes.