### PR TITLE
feat(Tab): add TabStyle parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Layout/ComponentLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/ComponentLayout.razor
@@ -30,7 +30,7 @@
 </div>
 
 <div class="tabs-coms">
-    <Tab IsBorderCard="true" IsLazyLoadTabItem="true" ShowFullScreen="true" @ref="Tab">
+    <Tab IsBorderCard="true" IsLazyLoadTabItem="true" ShowFullScreen="true" TabStyle="TabStyle.Chrome" @ref="Tab">
         <TabItem Text="Example" Icon="fa-solid fa-desktop">
             <CascadingValue Value="@RazorFileName" Name="RazorFileName">
                 @Body

--- a/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor
@@ -436,6 +436,23 @@ private void Navigation()
     </Tab>
 </DemoBlock>
 
+<DemoBlock Title="@Localizer["TabsIsChromeStyleTitle"]" Introduction="@Localizer["TabsIsChromeStyleIntro"]" Name="IsChromeStyle">
+    <Tab IsCard="true" ShowClose="true" IsChromeStyle="true">
+        <TabItem Text="@Localizer["TabItem1Text"]" Icon="fa-solid fa-user">
+            <div>@Localizer["TabItem1Content"]</div>
+        </TabItem>
+        <TabItem Text="@Localizer["TabItem2Text"]" Icon="fa-solid fa-gauge-high">
+            <div>@Localizer["TabItem2Content"]</div>
+        </TabItem>
+        <TabItem Text="@Localizer["TabItem3Text"]" Icon="fa-solid fa-sitemap">
+            <div>@Localizer["TabItem3Content"]</div>
+        </TabItem>
+        <TabItem Text="@Localizer["TabItem4Text"]" Icon="fa-solid fa-building-columns">
+            <div>@Localizer["TabItem4Content"]</div>
+        </TabItem>
+    </Tab>
+</DemoBlock>
+
 <AttributeTable Items="@GetAttributes()" Title="@Localizer["AttTitle"]" />
 
 <MethodTable Items="@GetMethods()" Title="@Localizer["MethodTitle"]" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor
@@ -436,8 +436,8 @@ private void Navigation()
     </Tab>
 </DemoBlock>
 
-<DemoBlock Title="@Localizer["TabsIsChromeStyleTitle"]" Introduction="@Localizer["TabsIsChromeStyleIntro"]" Name="IsChromeStyle">
-    <Tab IsCard="true" ShowClose="true" IsChromeStyle="true">
+<DemoBlock Title="@Localizer["TabsChromeStyleTitle"]" Introduction="@Localizer["TabsChromeStyleIntro"]" Name="TabStyle">
+    <Tab IsCard="true" ShowClose="true" TabStyle="TabStyle.Chrome">
         <TabItem Text="@Localizer["TabItem1Text"]" Icon="fa-solid fa-user">
             <div>@Localizer["TabItem1Content"]</div>
         </TabItem>

--- a/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor.cs
@@ -195,6 +195,14 @@ public sealed partial class Tabs
         },
         new()
         {
+            Name = "TabStyle",
+            Description = Localizer["TabAtt2TabStyle"].Value,
+            Type = "enum",
+            ValueList = "Default|Chrome",
+            DefaultValue = "Default"
+        },
+        new()
+        {
             Name = "IsOnlyRenderActiveTab",
             Description = Localizer["TabAtt3IsOnlyRenderActiveTab"].Value,
             Type = "boolean",

--- a/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tabs.razor.cs
@@ -195,14 +195,6 @@ public sealed partial class Tabs
         },
         new()
         {
-            Name = "TabStyle",
-            Description = Localizer["TabAtt2TabStyle"].Value,
-            Type = "enum",
-            ValueList = "Default|Chrome",
-            DefaultValue = "Default"
-        },
-        new()
-        {
             Name = "IsOnlyRenderActiveTab",
             Description = Localizer["TabAtt3IsOnlyRenderActiveTab"].Value,
             Type = "boolean",
@@ -212,7 +204,7 @@ public sealed partial class Tabs
         new()
         {
             Name = "IsLazyLoadTabItem",
-            Description = Localizer["AttributeIsLazyLoadTabItem"].Value,
+            Description = Localizer["TabAttIsLazyLoadTabItem"].Value,
             Type = "boolean",
             ValueList = "true/false",
             DefaultValue = "false"
@@ -230,21 +222,21 @@ public sealed partial class Tabs
             Name = "ShowExtendButtons",
             Description = Localizer["TabAtt5ShowExtendButtons"].Value,
             Type = "boolean",
-            ValueList = " — ",
+            ValueList = "true|false",
             DefaultValue = "false"
         },
         new()
         {
-            Name = "ShowExtendButtons",
-            Description = Localizer["TabAttrShowNavigatorButtons"].Value,
+            Name = "ShowNavigatorButtons",
+            Description = Localizer["TabAttShowNavigatorButtons"].Value,
             Type = "boolean",
             ValueList = "true|false",
             DefaultValue = "true"
         },
         new()
         {
-            Name = "ShowExtendButtons",
-            Description = Localizer["TabAttrShowActiveBar"].Value,
+            Name = "ShowActiveBar",
+            Description = Localizer["TabAttShowActiveBar"].Value,
             Type = "boolean",
             ValueList = "true|false",
             DefaultValue = "true"
@@ -256,6 +248,14 @@ public sealed partial class Tabs
             Type = "boolean",
             ValueList = "true/false",
             DefaultValue = "false"
+        },
+        new()
+        {
+            Name = "TabStyle",
+            Description = Localizer["TabAtt2TabStyle"].Value,
+            Type = "TabStyle",
+            ValueList = "Default|Chrome",
+            DefaultValue = "Default"
         },
         new()
         {

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2083,6 +2083,7 @@
     "TabAtt5ShowExtendButtons": "Whether to display the extension button",
     "TabAttShowNavigatorButtons": "Whether to display the previous and next navigation buttons",
     "TabAttShowActiveBar": "Whether to display active bar",
+    "TabAttIsLazyLoadTabItem": "Whether lazy load tab item",
     "TabAtt6ClickTabToNavigation": "Whether to navigate when you click on the title",
     "TabAtt7Placement": "Set the label position",
     "TabAtt8Height": "Set the label height",
@@ -2118,7 +2119,8 @@
     "TabsDisabledTitle": "Disabled",
     "TabsDisabledIntro": "Disable the current <code>TabItem</code> by setting <code>IsDisabled=\"true\"</code> to prohibit click, drag, close etc.",
     "TabsChromeStyleTitle": "Chrome Style",
-    "TabsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>TabStyle=\"TabStyle.Chrome\"</code>"
+    "TabsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>TabStyle=\"TabStyle.Chrome\"</code>",
+    "TabAtt2TabStyle": "Set the tab style"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {
     "Info": "Reset the title of this <code>TabItem</code> by click the button",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2117,8 +2117,8 @@
     "AttributeButtonTemplate": "The template for Buttons",
     "TabsDisabledTitle": "Disabled",
     "TabsDisabledIntro": "Disable the current <code>TabItem</code> by setting <code>IsDisabled=\"true\"</code> to prohibit click, drag, close etc.",
-    "TabsIsChromeStyleTitle": "Chrome Style",
-    "TabsIsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>IsChromeStyle=\"true\"</code>"
+    "TabsChromeStyleTitle": "Chrome Style",
+    "TabsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>TabStyle=\"TabStyle.Chrome\"</code>"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {
     "Info": "Reset the title of this <code>TabItem</code> by click the button",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2119,7 +2119,7 @@
     "TabsDisabledTitle": "Disabled",
     "TabsDisabledIntro": "Disable the current <code>TabItem</code> by setting <code>IsDisabled=\"true\"</code> to prohibit click, drag, close etc.",
     "TabsChromeStyleTitle": "Chrome Style",
-    "TabsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>TabStyle=\"TabStyle.Chrome\"</code>",
+    "TabsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>TabStyle=\"TabStyle.Chrome\"</code>. Currently only supports <code>Placement=\"Placement.Top\"</code> mode",
     "TabAtt2TabStyle": "Set the tab style"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2116,7 +2116,9 @@
     "AttributeExcludeUrls": "Exclude address support for wildcards",
     "AttributeButtonTemplate": "The template for Buttons",
     "TabsDisabledTitle": "Disabled",
-    "TabsDisabledIntro": "Disable the current <code>TabItem</code> by setting <code>IsDisabled=\"true\"</code> to prohibit click, drag, close etc."
+    "TabsDisabledIntro": "Disable the current <code>TabItem</code> by setting <code>IsDisabled=\"true\"</code> to prohibit click, drag, close etc.",
+    "TabsIsChromeStyleTitle": "Chrome Style",
+    "TabsIsChromeStyleIntro": "Set the Chrome browser tab style by setting <code>IsChromeStyle=\"true\"</code>"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {
     "Info": "Reset the title of this <code>TabItem</code> by click the button",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2117,8 +2117,8 @@
     "AttributeButtonTemplate": "按钮模板",
     "TabsDisabledTitle": "禁用",
     "TabsDisabledIntro": "通过设置 <code>IsDisabled=\"true\"</code> 禁用当前 <code>TabItem</code> 禁止点击、拖动、关闭等操作",
-    "TabsIsChromeStyleTitle": "Chrome 样式",
-    "TabsIsChromeStyleIntro": "通过设置 <code>IsChromeStyle=\"true\"</code> 设置 Chrome 浏览器标签页样式"
+    "TabsChromeStyleTitle": "Chrome 样式",
+    "TabsChromeStyleIntro": "通过设置 <code>TabStyle=\"TabStyle.Chrome\"</code> 设置 Chrome 浏览器标签页样式"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {
     "Info": "点击下方按钮，本 <code>TabItem</code> 标题更改为当前分钟与秒",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2083,6 +2083,7 @@
     "TabAtt5ShowExtendButtons": "是否显示扩展按钮",
     "TabAttShowNavigatorButtons": "是否显示前后导航按钮",
     "TabAttShowActiveBar": "是否显示活动标签",
+    "TabAttIsLazyLoadTabItem": "是否延时加载标签内容",
     "TabAtt6ClickTabToNavigation": "点击标题时是否导航",
     "TabAtt7Placement": "设置标签位置",
     "TabAtt8Height": "设置标签高度",
@@ -2118,7 +2119,8 @@
     "TabsDisabledTitle": "禁用",
     "TabsDisabledIntro": "通过设置 <code>IsDisabled=\"true\"</code> 禁用当前 <code>TabItem</code> 禁止点击、拖动、关闭等操作",
     "TabsChromeStyleTitle": "Chrome 样式",
-    "TabsChromeStyleIntro": "通过设置 <code>TabStyle=\"TabStyle.Chrome\"</code> 设置 Chrome 浏览器标签页样式"
+    "TabsChromeStyleIntro": "通过设置 <code>TabStyle=\"TabStyle.Chrome\"</code> 设置 Chrome 浏览器标签页样式",
+    "TabAtt2TabStyle": "设置标签页样式"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {
     "Info": "点击下方按钮，本 <code>TabItem</code> 标题更改为当前分钟与秒",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2119,7 +2119,7 @@
     "TabsDisabledTitle": "禁用",
     "TabsDisabledIntro": "通过设置 <code>IsDisabled=\"true\"</code> 禁用当前 <code>TabItem</code> 禁止点击、拖动、关闭等操作",
     "TabsChromeStyleTitle": "Chrome 样式",
-    "TabsChromeStyleIntro": "通过设置 <code>TabStyle=\"TabStyle.Chrome\"</code> 设置 Chrome 浏览器标签页样式",
+    "TabsChromeStyleIntro": "通过设置 <code>TabStyle=\"TabStyle.Chrome\"</code> 设置 Chrome 浏览器标签页样式，目前仅支持 <code>Placement=\"Placement.Top\"</code> 模式",
     "TabAtt2TabStyle": "设置标签页样式"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2116,7 +2116,9 @@
     "AttributeExcludeUrls": "排除地址支持通配符",
     "AttributeButtonTemplate": "按钮模板",
     "TabsDisabledTitle": "禁用",
-    "TabsDisabledIntro": "通过设置 <code>IsDisabled=\"true\"</code> 禁用当前 <code>TabItem</code> 禁止点击、拖动、关闭等操作"
+    "TabsDisabledIntro": "通过设置 <code>IsDisabled=\"true\"</code> 禁用当前 <code>TabItem</code> 禁止点击、拖动、关闭等操作",
+    "TabsIsChromeStyleTitle": "Chrome 样式",
+    "TabsIsChromeStyleIntro": "通过设置 <code>IsChromeStyle=\"true\"</code> 设置 Chrome 浏览器标签页样式"
   },
   "BootstrapBlazor.Server.Components.Components.DemoTabItem": {
     "Info": "点击下方按钮，本 <code>TabItem</code> 标题更改为当前分钟与秒",

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor
@@ -45,39 +45,17 @@ else
                             }
                             @foreach (var item in Items)
                             {
-                                if (item.HeaderTemplate != null)
+                                @if (item.HeaderTemplate != null)
                                 {
                                     @item.HeaderTemplate(item)
                                 }
                                 else if (item.IsDisabled)
                                 {
-                                    <div role="tab" class="@GetClassString(item)">
-                                        @if (!string.IsNullOrEmpty(item.Icon))
-                                        {
-                                            <i class="@GetIconClassString(item.Icon)"></i>
-                                        }
-                                        <span class="tabs-item-text">@item.Text</span>
-                                    </div>
+                                    @RenderDisabledHeaderByStyle(item)
                                 }
                                 else
                                 {
-                                    <a @key="item" href="@item.Url" role="tab" tabindex="-1" class="@GetClassString(item)" @onclick="@(() => OnClickTabItem(item))" @onclick:preventDefault="@(!ClickTabToNavigation)" draggable="@DraggableString">
-                                        @if (!string.IsNullOrEmpty(item.Icon))
-                                        {
-                                            <i class="@GetIconClassString(item.Icon)"></i>
-                                        }
-                                        <span class="tabs-item-text">@item.Text</span>
-                                        @if (ShowFullScreen && item.ShowFullScreen)
-                                        {
-                                            <FullScreenButton TargetId="@GetIdByTabItem(item)"></FullScreenButton>
-                                        }
-                                        @if (ShowClose && item.Closable)
-                                        {
-                                            <span class="tabs-item-close" @onclick:stopPropagation @onclick:preventDefault @onclick="() => RemoveTab(item)">
-                                                <i class="@CloseIcon"></i>
-                                            </span>
-                                        }
-                                    </a>
+                                    @RenderHeaderByStyle(item)
                                 }
                             }
                             @if (IsCard || IsBorderCard)
@@ -145,4 +123,59 @@ else
     @<CascadingValue Value="item" IsFixed="true">
         @RenderTabItemContent(item)
     </CascadingValue>;
+
+    RenderFragment RenderChromeDisabledHeader(TabItem item) =>
+    @<div @key="@item" class="@GetItemWrapClassString(item)">
+        <div role="tab" class="@GetClassString(item)">
+            @if (!string.IsNullOrEmpty(item.Icon))
+            {
+                <i class="@GetIconClassString(item.Icon)"></i>
+            }
+            <span class="tabs-item-text">@item.Text</span>
+        </div>
+        <i class="tab-corner tab-corner-left"></i>
+        <i class="tab-corner tab-corner-right"></i>
+    </div>;
+
+    RenderFragment RenderDefaultDisabledHeader(TabItem item) =>
+    @<div @key="item" role="tab" class="@GetClassString(item)">
+        @if (!string.IsNullOrEmpty(item.Icon))
+        {
+            <i class="@GetIconClassString(item.Icon)"></i>
+        }
+        <span class="tabs-item-text">@item.Text</span>
+    </div>;
+
+    RenderFragment RenderChromeHeader(TabItem item) =>
+    @<div @key="@item" class="@GetItemWrapClassString(item)">
+        <a href="@item.Url" role="tab" tabindex="-1" class="@GetClassString(item)" @onclick="@(() => OnClickTabItem(item))" @onclick:preventDefault="@(!ClickTabToNavigation)" draggable="@DraggableString">
+            @RenderHeaderContent(item)
+        </a>
+        <i class="tab-corner tab-corner-left"></i>
+        <i class="tab-corner tab-corner-right"></i>
+    </div>;
+
+    RenderFragment RenderDefaultHeader(TabItem item) =>
+    @<a @key="item" href="@item.Url" role="tab" tabindex="-1" class="@GetClassString(item)" @onclick="@(() => OnClickTabItem(item))" @onclick:preventDefault="@(!ClickTabToNavigation)" draggable="@DraggableString">
+        @RenderHeaderContent(item)
+    </a>;
+
+    RenderFragment RenderHeaderContent(TabItem item) =>
+    @<div class="tabs-item-body">
+        @if (!string.IsNullOrEmpty(item.Icon))
+        {
+            <i class="@GetIconClassString(item.Icon)"></i>
+        }
+        <span class="tabs-item-text">@item.Text</span>
+        @if (ShowFullScreen && item.ShowFullScreen)
+        {
+            <FullScreenButton TargetId="@GetIdByTabItem(item)"></FullScreenButton>
+        }
+        @if (ShowClose && item.Closable)
+        {
+            <span class="tabs-item-close" @onclick:stopPropagation @onclick:preventDefault @onclick="() => RemoveTab(item)">
+                <i class="@CloseIcon"></i>
+            </span>
+        }
+    </div>;
 }

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor
@@ -127,11 +127,7 @@ else
     RenderFragment RenderChromeDisabledHeader(TabItem item) =>
     @<div @key="@item" class="@GetItemWrapClassString(item)">
         <div role="tab" class="@GetClassString(item)">
-            @if (!string.IsNullOrEmpty(item.Icon))
-            {
-                <i class="@GetIconClassString(item.Icon)"></i>
-            }
-            <span class="tabs-item-text">@item.Text</span>
+            @RenderHeaderContent(item)
         </div>
         <i class="tab-corner tab-corner-left"></i>
         <i class="tab-corner tab-corner-right"></i>
@@ -139,11 +135,7 @@ else
 
     RenderFragment RenderDefaultDisabledHeader(TabItem item) =>
     @<div @key="item" role="tab" class="@GetClassString(item)">
-        @if (!string.IsNullOrEmpty(item.Icon))
-        {
-            <i class="@GetIconClassString(item.Icon)"></i>
-        }
-        <span class="tabs-item-text">@item.Text</span>
+        @RenderHeaderContent(item)
     </div>;
 
     RenderFragment RenderChromeHeader(TabItem item) =>
@@ -167,15 +159,18 @@ else
             <i class="@GetIconClassString(item.Icon)"></i>
         }
         <span class="tabs-item-text">@item.Text</span>
-        @if (ShowFullScreen && item.ShowFullScreen)
+        @if (!item.IsDisabled)
         {
-            <FullScreenButton TargetId="@GetIdByTabItem(item)"></FullScreenButton>
-        }
-        @if (ShowClose && item.Closable)
-        {
-            <span class="tabs-item-close" @onclick:stopPropagation @onclick:preventDefault @onclick="() => RemoveTab(item)">
-                <i class="@CloseIcon"></i>
-            </span>
+            @if (ShowFullScreen && item.ShowFullScreen)
+            {
+                <FullScreenButton TargetId="@GetIdByTabItem(item)"></FullScreenButton>
+            }
+            @if (ShowClose && item.Closable)
+            {
+                <span class="tabs-item-close" @onclick:stopPropagation @onclick:preventDefault @onclick="() => RemoveTab(item)">
+                    <i class="@CloseIcon"></i>
+                </span>
+            }
         }
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -29,7 +29,7 @@ public partial class Tab : IHandlerException
         .Build();
 
     private string? GetClassString(TabItem item) => CssBuilder.Default("tabs-item")
-        .AddClass("active", item.IsActive && !item.IsDisabled)
+        .AddClass("active", !IsChromeStyle && item.IsActive && !item.IsDisabled)
         .AddClass("disabled", item.IsDisabled)
         .AddClass(item.CssClass)
         .AddClass("is-closeable", ShowClose)

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -363,6 +363,11 @@ public partial class Tab : IHandlerException
 
         AdditionalAssemblies ??= new[] { Assembly.GetEntryAssembly()! };
 
+        if (Placement != Placement.Top && TabStyle == TabStyle.Chrome)
+        {
+            TabStyle = TabStyle.Default;
+        }
+
         if (ClickTabToNavigation)
         {
             if (!HandlerNavigation)

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -24,6 +24,10 @@ public partial class Tab : IHandlerException
         .AddClass("extend", ShouldShowExtendButtons())
         .Build();
 
+    private string? GetItemWrapClassString(TabItem item) => CssBuilder.Default("tabs-item-wrap")
+        .AddClass("active", item.IsActive)
+        .Build();
+
     private string? GetClassString(TabItem item) => CssBuilder.Default("tabs-item")
         .AddClass("active", item.IsActive)
         .AddClass("disabled", item.IsDisabled)
@@ -282,6 +286,12 @@ public partial class Tab : IHandlerException
     /// </summary>
     [Parameter]
     public Func<TabItem, Task>? OnDragItemEndAsync { get; set; }
+
+    /// <summary>
+    /// Gets or sets Whether the tab style is Chrome. Default is false.
+    /// </summary>
+    [Parameter]
+    public bool IsChromeStyle { get; set; }
 
     [CascadingParameter]
     private Layout? Layout { get; set; }
@@ -853,6 +863,10 @@ public partial class Tab : IHandlerException
     }
 
     private string? GetIdByTabItem(TabItem item) => (ShowFullScreen && item.ShowFullScreen) ? ComponentIdGenerator.Generate(item) : null;
+
+    private RenderFragment RenderDisabledHeaderByStyle(TabItem item) => IsChromeStyle ? RenderChromeDisabledHeader(item) : RenderDefaultDisabledHeader(item);
+
+    private RenderFragment RenderHeaderByStyle(TabItem item) => IsChromeStyle ? RenderChromeHeader(item) : RenderDefaultHeader(item);
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -43,7 +43,8 @@ public partial class Tab : IHandlerException
         .AddClass("tabs-card", IsCard)
         .AddClass("tabs-border-card", IsBorderCard)
         .AddClass($"tabs-{Placement.ToDescriptionString()}", Placement == Placement.Top || Placement == Placement.Right || Placement == Placement.Bottom || Placement == Placement.Left)
-        .AddClass($"tabs-vertical", Placement == Placement.Left || Placement == Placement.Right)
+        .AddClass("tabs-vertical", Placement == Placement.Left || Placement == Placement.Right)
+        .AddClass("tabs-chrome", IsChromeStyle)
        .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -24,12 +24,12 @@ public partial class Tab : IHandlerException
         .AddClass("extend", ShouldShowExtendButtons())
         .Build();
 
-    private string? GetItemWrapClassString(TabItem item) => CssBuilder.Default("tabs-item-wrap")
-        .AddClass("active", item.IsActive)
+    private static string? GetItemWrapClassString(TabItem item) => CssBuilder.Default("tabs-item-wrap")
+        .AddClass("active", item.IsActive && !item.IsDisabled)
         .Build();
 
     private string? GetClassString(TabItem item) => CssBuilder.Default("tabs-item")
-        .AddClass("active", item.IsActive)
+        .AddClass("active", item.IsActive && !item.IsDisabled)
         .AddClass("disabled", item.IsDisabled)
         .AddClass(item.CssClass)
         .AddClass("is-closeable", ShowClose)
@@ -793,6 +793,14 @@ public partial class Tab : IHandlerException
     public void SetDisabledItem(TabItem item, bool disabled)
     {
         item.SetDisabledWithoutRender(disabled);
+        if (disabled)
+        {
+            item.SetActive(false);
+        }
+        if (TabItems.Any(i => i.IsActive) == false)
+        {
+            TabItems.Where(i => !i.IsDisabled).FirstOrDefault()?.SetActive(true);
+        }
         StateHasChanged();
     }
 

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -29,7 +29,7 @@ public partial class Tab : IHandlerException
         .Build();
 
     private string? GetClassString(TabItem item) => CssBuilder.Default("tabs-item")
-        .AddClass("active", !IsChromeStyle && item.IsActive && !item.IsDisabled)
+        .AddClass("active", TabStyle == TabStyle.Default && item.IsActive && !item.IsDisabled)
         .AddClass("disabled", item.IsDisabled)
         .AddClass(item.CssClass)
         .AddClass("is-closeable", ShowClose)
@@ -44,7 +44,7 @@ public partial class Tab : IHandlerException
         .AddClass("tabs-border-card", IsBorderCard)
         .AddClass($"tabs-{Placement.ToDescriptionString()}", Placement == Placement.Top || Placement == Placement.Right || Placement == Placement.Bottom || Placement == Placement.Left)
         .AddClass("tabs-vertical", Placement == Placement.Left || Placement == Placement.Right)
-        .AddClass("tabs-chrome", IsChromeStyle)
+        .AddClass("tabs-chrome", TabStyle == TabStyle.Chrome)
        .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
@@ -289,10 +289,10 @@ public partial class Tab : IHandlerException
     public Func<TabItem, Task>? OnDragItemEndAsync { get; set; }
 
     /// <summary>
-    /// Gets or sets Whether the tab style is Chrome. Default is false.
+    /// Gets or sets the tab style. Default is <see cref="TabStyle.Default"/>.
     /// </summary>
     [Parameter]
-    public bool IsChromeStyle { get; set; }
+    public TabStyle TabStyle { get; set; }
 
     [CascadingParameter]
     private Layout? Layout { get; set; }
@@ -873,9 +873,9 @@ public partial class Tab : IHandlerException
 
     private string? GetIdByTabItem(TabItem item) => (ShowFullScreen && item.ShowFullScreen) ? ComponentIdGenerator.Generate(item) : null;
 
-    private RenderFragment RenderDisabledHeaderByStyle(TabItem item) => IsChromeStyle ? RenderChromeDisabledHeader(item) : RenderDefaultDisabledHeader(item);
+    private RenderFragment RenderDisabledHeaderByStyle(TabItem item) => TabStyle == TabStyle.Chrome ? RenderChromeDisabledHeader(item) : RenderDefaultDisabledHeader(item);
 
-    private RenderFragment RenderHeaderByStyle(TabItem item) => IsChromeStyle ? RenderChromeHeader(item) : RenderDefaultHeader(item);
+    private RenderFragment RenderHeaderByStyle(TabItem item) => TabStyle == TabStyle.Chrome ? RenderChromeHeader(item) : RenderDefaultHeader(item);
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -488,105 +488,112 @@
     }
 }
 
-.tabs-item-wrap {
+.tabs-chrome {
     --bb-tabs-header-bg-color: var(--bs-border-color);
-    --bb-tabs-item-hover-bg-color: #b1cbe6;
+    --bb-tabs-item-hover-bg-color: rgba(var(--bs-body-color-rgb), 0.1);
     --bb-tabs-item-active-bg-color: var(--bs-body-color);
     --bb-tabs-item-active-color: var(--bs-body-color);
     --bb-tabs-item-hover-color: var(--bs-body-color);
-    overflow: hidden;
-    position: relative;
-    background-color: var(--bb-tabs-header-bg-color);
-    display: flex;
-    align-items: flex-end;
-    padding: 0 1rem;
-    z-index: 1;
 
-    &.active {
-        z-index: 5;
+    .tabs-item-wrap {
+        overflow: hidden;
+        position: relative;
+        background-color: var(--bb-tabs-header-bg-color);
+        display: flex;
+        align-items: flex-end;
+        padding: 0 1rem;
+        z-index: 1;
+
+        &.active {
+            z-index: 5;
+
+            .tab-corner {
+                background-color: var(--bs-body-bg);
+            }
+        }
+
+        &:not(.active) {
+            .tabs-item:not(.disabled) .tabs-item-body {
+                &:hover {
+                    border-radius: 20px;
+                    background-color: var(--bb-tabs-item-hover-bg-color);
+                }
+            }
+        }
+
+        &:not(:first-child) {
+            margin-left: -2rem;
+        }
+
+        .tabs-item {
+            background-color: var(--bb-tabs-header-bg-color);
+            border: none !important;
+            border-top-left-radius: 10px;
+            border-top-right-radius: 10px;
+            height: 36px !important;
+
+            .active {
+                background-color: var(--bb-tabs-item-active-bg-color);
+            }
+
+            .tabs-item-body {
+                padding: 4px 10px;
+                display: flex;
+                align-items: center;
+                flex-wrap: nowrap;
+                margin-bottom: 4px;
+
+                .tabs-item-text {
+                    padding: 0 .25rem;
+                }
+
+                .tabs-item-close {
+                    display: flex;
+                    position: unset;
+                    width: 21px;
+                    height: 21px;
+                    border-radius: 50%;
+                }
+            }
+        }
 
         .tab-corner {
-            background-color: var(--bs-body-bg);
-        }
-    }
-
-    &:not(.active) {
-        .tabs-item:not(.disabled) .tabs-item-body {
-            &:hover {
-                border-radius: 20px;
-                background-color: var(--bb-tabs-item-hover-bg-color);
-            }
-        }
-    }
-
-    &:not(:first-child) {
-        margin-left: -2rem;
-    }
-
-    .tabs-item {
-        background-color: var(--bb-tabs-header-bg-color);
-        border: none !important;
-        border-top-left-radius: 10px;
-        border-top-right-radius: 10px;
-        height: 36px !important;
-
-        .active {
-            background-color: var(--bb-tabs-item-active-bg-color);
-        }
-
-        .tabs-item-body {
-            padding: 4px 10px;
-            display: flex;
+            height: 2rem;
+            width: 2rem;
+            display: inline-flex;
+            justify-content: center;
             align-items: center;
-            flex-wrap: nowrap;
-            margin-bottom: 4px;
-
-            .tabs-item-text {
-                padding: 0 .25rem;
-            }
-
-            .tabs-item-close {
-                display: flex;
-                position: unset;
-                width: 21px;
-                height: 21px;
-                border-radius: 50%;
-            }
-        }
-    }
-
-    .tab-corner {
-        height: 2rem;
-        width: 2rem;
-        display: inline-flex;
-        justify-content: center;
-        align-items: center;
-        position: absolute;
-
-        &::after {
-            content: '';
             position: absolute;
-            height: 100%;
-            width: 100%;
-            background-color: var(--bb-tabs-header-bg-color);
+
+            &::after {
+                content: '';
+                position: absolute;
+                height: 100%;
+                width: 100%;
+                background-color: var(--bb-tabs-header-bg-color);
+            }
+        }
+
+        .tab-corner-left {
+            bottom: 0;
+            left: -1rem;
+
+            &::after {
+                border-bottom-right-radius: 50%;
+            }
+        }
+
+        .tab-corner-right {
+            bottom: 0;
+            right: -1rem;
+
+            &::after {
+                border-bottom-left-radius: 50%;
+            }
         }
     }
 
-    .tab-corner-left {
-        bottom: 0;
-        left: -1rem;
-
-        &::after {
-            border-bottom-right-radius: 50%;
-        }
-    }
-
-    .tab-corner-right {
-        bottom: 0;
-        right: -1rem;
-
-        &::after {
-            border-bottom-left-radius: 50%;
-        }
+    .tabs-item-fix {
+        background-color: var(--bb-tabs-header-bg-color);
     }
 }

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -598,7 +598,7 @@
         }
     }
 
-    .tabs-item-fix {
+    > .tabs-header .tabs-item-fix {
         background-color: var(--bb-tabs-header-bg-color);
         border: none;
     }

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -544,7 +544,7 @@
                 margin-bottom: 4px;
 
                 .tabs-item-text {
-                    padding: 0 .25rem;
+                    padding: 0 .5rem;
                 }
 
                 .tabs-item-close {
@@ -590,6 +590,10 @@
             &::after {
                 border-bottom-left-radius: 50%;
             }
+        }
+
+        .btn-fs {
+            padding: 0;
         }
     }
 

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -491,7 +491,7 @@
 .tabs-chrome {
     --bb-tabs-header-bg-color: var(--bs-border-color);
     --bb-tabs-item-hover-bg-color: rgba(var(--bs-body-color-rgb), 0.1);
-    --bb-tabs-item-active-bg-color: var(--bs-body-color);
+    --bb-tabs-item-active-bg-color: var(--bs-body-bg);
     --bb-tabs-item-active-color: var(--bs-body-color);
     --bb-tabs-item-hover-color: var(--bs-body-color);
 
@@ -509,6 +509,10 @@
 
             .tab-corner {
                 background-color: var(--bs-body-bg);
+            }
+
+            .tabs-item {
+                background-color: var(--bb-tabs-item-active-bg-color);
             }
         }
 
@@ -531,10 +535,6 @@
             border-top-left-radius: 10px;
             border-top-right-radius: 10px;
             height: 36px !important;
-
-            .active {
-                background-color: var(--bb-tabs-item-active-bg-color);
-            }
 
             .tabs-item-body {
                 padding: 4px 10px;

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -487,3 +487,105 @@
         background-color: var(--bs-primary);
     }
 }
+
+.tabs-item-wrap {
+    --bb-tabs-header-bg-color: var(--bs-border-color);
+    --bb-tabs-item-hover-bg-color: #b1cbe6;
+    --bb-tabs-item-active-bg-color: var(--bs-body-color);
+    --bb-tabs-item-active-color: var(--bs-body-color);
+    --bb-tabs-item-hover-color: var(--bs-body-color);
+    overflow: hidden;
+    position: relative;
+    background-color: var(--bb-tabs-header-bg-color);
+    display: flex;
+    align-items: flex-end;
+    padding: 0 1rem;
+    z-index: 1;
+
+    .tab-corner {
+        height: 2rem;
+        width: 2rem;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        position: absolute;
+        background-color: var(--bb-tabs-header-bg-color);
+
+        &::after {
+            content: '';
+            position: absolute;
+            height: 100%;
+            width: 100%;
+            background-color: var(--bb-tabs-header-bg-color);
+        }
+    }
+
+    .tab-corner-left {
+        bottom: 0;
+        left: -1rem;
+
+        &::after {
+            border-bottom-right-radius: 50%;
+        }
+    }
+
+    .tab-corner-right {
+        bottom: 0;
+        right: -1rem;
+
+        &::after {
+            border-bottom-left-radius: 50%;
+        }
+    }
+
+    .tabs-item {
+        background-color: var(--bb-tabs-header-bg-color);
+        border: none !important;
+        border-top-left-radius: 10px;
+        border-top-right-radius: 10px;
+        height: 36px !important;
+
+        .active {
+            background-color: var(--bb-tabs-item-active-bg-color);
+        }
+
+        .tabs-item-body {
+            padding: 4px 10px;
+            display: flex;
+            align-items: center;
+            flex-wrap: nowrap;
+            margin-bottom: 4px;
+
+            .tabs-item-text {
+                padding: 0 .25rem;
+            }
+
+            .tabs-item-close {
+                display: block;
+                position: unset;
+                width: 1em;
+            }
+        }
+    }
+
+    &:not(.active) {
+        .tabs-item .tabs-item-body {
+            &:hover {
+                border-radius: 20px;
+                background-color: var(--bb-tabs-item-hover-bg-color);
+            }
+        }
+    }
+
+    &:not(:first-child) {
+        margin-left: -2rem;
+    }
+
+    &.active {
+        z-index: 5;
+
+        .tab-corner {
+            background-color: var(--bs-body-bg);
+        }
+    }
+}

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -502,40 +502,25 @@
     padding: 0 1rem;
     z-index: 1;
 
-    .tab-corner {
-        height: 2rem;
-        width: 2rem;
-        display: inline-flex;
-        justify-content: center;
-        align-items: center;
-        position: absolute;
-        background-color: var(--bb-tabs-header-bg-color);
+    &.active {
+        z-index: 5;
 
-        &::after {
-            content: '';
-            position: absolute;
-            height: 100%;
-            width: 100%;
-            background-color: var(--bb-tabs-header-bg-color);
+        .tab-corner {
+            background-color: var(--bs-body-bg);
         }
     }
 
-    .tab-corner-left {
-        bottom: 0;
-        left: -1rem;
-
-        &::after {
-            border-bottom-right-radius: 50%;
+    &:not(.active) {
+        .tabs-item:not(.disabled) .tabs-item-body {
+            &:hover {
+                border-radius: 20px;
+                background-color: var(--bb-tabs-item-hover-bg-color);
+            }
         }
     }
 
-    .tab-corner-right {
-        bottom: 0;
-        right: -1rem;
-
-        &::after {
-            border-bottom-left-radius: 50%;
-        }
+    &:not(:first-child) {
+        margin-left: -2rem;
     }
 
     .tabs-item {
@@ -561,31 +546,47 @@
             }
 
             .tabs-item-close {
-                display: block;
+                display: flex;
                 position: unset;
-                width: 1em;
+                width: 21px;
+                height: 21px;
+                border-radius: 50%;
             }
         }
     }
 
-    &:not(.active) {
-        .tabs-item .tabs-item-body {
-            &:hover {
-                border-radius: 20px;
-                background-color: var(--bb-tabs-item-hover-bg-color);
-            }
+    .tab-corner {
+        height: 2rem;
+        width: 2rem;
+        display: inline-flex;
+        justify-content: center;
+        align-items: center;
+        position: absolute;
+
+        &::after {
+            content: '';
+            position: absolute;
+            height: 100%;
+            width: 100%;
+            background-color: var(--bb-tabs-header-bg-color);
         }
     }
 
-    &:not(:first-child) {
-        margin-left: -2rem;
+    .tab-corner-left {
+        bottom: 0;
+        left: -1rem;
+
+        &::after {
+            border-bottom-right-radius: 50%;
+        }
     }
 
-    &.active {
-        z-index: 5;
+    .tab-corner-right {
+        bottom: 0;
+        right: -1rem;
 
-        .tab-corner {
-            background-color: var(--bs-body-bg);
+        &::after {
+            border-bottom-left-radius: 50%;
         }
     }
 }

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -501,6 +501,7 @@
         background-color: var(--bb-tabs-header-bg-color);
         display: flex;
         align-items: flex-end;
+        flex-shrink: 0;
         padding: 0 1rem;
         z-index: 1;
 

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -600,5 +600,6 @@
 
     .tabs-item-fix {
         background-color: var(--bb-tabs-header-bg-color);
+        border: none;
     }
 }

--- a/src/BootstrapBlazor/Enums/TabStyle.cs
+++ b/src/BootstrapBlazor/Enums/TabStyle.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+namespace BootstrapBlazor.Components;
+
+/// <summary>
+/// Tab style emnu
+/// </summary>
+public enum TabStyle
+{
+    /// <summary>
+    /// The default style
+    /// </summary>
+    Default,
+
+    /// <summary>
+    /// The Chrome style
+    /// </summary>
+    Chrome
+}

--- a/test/UnitTest/Components/TabTest.cs
+++ b/test/UnitTest/Components/TabTest.cs
@@ -461,6 +461,13 @@ public class TabTest : BootstrapBlazorTestBase
         var link = cut.Find("a");
         await cut.InvokeAsync(() => link.Click());
         Assert.True(clicked);
+
+        // placement top and chrome style
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.Placement, Placement.Left);
+        });
+        Assert.Equal(TabStyle.Default, cut.Instance.TabStyle);
     }
 
     [Fact]

--- a/test/UnitTest/Components/TabTest.cs
+++ b/test/UnitTest/Components/TabTest.cs
@@ -406,13 +406,13 @@ public class TabTest : BootstrapBlazorTestBase
                 pb.AddChildContent<DisableTabItemButton>();
             });
         });
-        Assert.Contains("<div role=\"tab\" class=\"tabs-item disabled\"><i class=\"fa fa-fa\"></i><span class=\"tabs-item-text\">Text1</span></div>", cut.Markup);
+        Assert.Contains("<div role=\"tab\" class=\"tabs-item disabled\"><div class=\"tabs-item-body\"><i class=\"fa fa-fa\"></i><span class=\"tabs-item-text\">Text1</span></div></div>", cut.Markup);
 
         var button = cut.FindComponent<DisableTabItemButton>();
         Assert.NotNull(button);
 
         await cut.InvokeAsync(() => button.Instance.OnDisabledTabItem());
-        Assert.Contains("<div role=\"tab\" class=\"tabs-item active disabled\"><span class=\"tabs-item-text\">Text2</span></div>", cut.Markup);
+        Assert.Contains("<div role=\"tab\" class=\"tabs-item disabled\"><div class=\"tabs-item-body\"><span class=\"tabs-item-text\">Text2</span></div></div>", cut.Markup);
     }
 
     [Fact]
@@ -420,6 +420,47 @@ public class TabTest : BootstrapBlazorTestBase
     {
         var cut = Context.RenderComponent<TabItem>();
         cut.Instance.SetDisabled(true);
+    }
+
+    [Fact]
+    public async Task TabStyle_Chrome_Ok()
+    {
+        var clicked = false;
+        var cut = Context.RenderComponent<Tab>(pb =>
+        {
+            pb.Add(a => a.TabStyle, TabStyle.Chrome);
+            pb.Add(a => a.OnClickTabItemAsync, item =>
+            {
+                clicked = true;
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Text1");
+                pb.Add(a => a.ChildContent, builder => builder.AddContent(0, "Test1"));
+                pb.Add(a => a.Icon, "fa fa-fa");
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.IsActive, true);
+                pb.Add(a => a.Text, "Text2");
+                pb.AddChildContent<DisableTabItemButton>();
+            });
+        });
+        cut.Contains("tabs tabs-top tabs-chrome");
+        cut.Contains("tabs-item-wrap active");
+        cut.Contains("<i class=\"tab-corner tab-corner-left\"></i>");
+        cut.Contains("<i class=\"tab-corner tab-corner-right\"></i>");
+
+        var button = cut.FindComponent<DisableTabItemButton>();
+        Assert.NotNull(button);
+        await cut.InvokeAsync(() => button.Instance.OnDisabledTabItem());
+        cut.Contains("<div role=\"tab\" class=\"tabs-item disabled\"><div class=\"tabs-item-body\"><span class=\"tabs-item-text\">Text2</span></div></div>");
+
+        // trigger click
+        var link = cut.Find("a");
+        await cut.InvokeAsync(() => link.Click());
+        Assert.True(clicked);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #5639 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces a new "Chrome" tab style to the `Tab` component in the `BootstrapBlazor` library. The changes include updates to the `Tabs.razor` file, localization files, and the addition of a new `TabStyle` enum. The most important changes are listed below:

### New Tab Style Implementation:
* [`src/BootstrapBlazor/Components/Tab/Tab.razor`](diffhunk://#diff-41b1c5919c2aed658650a24a6b28ecd5763566ed708ff322a9fca34e4d5fac15L48-R58): Added logic to render tabs with the new "Chrome" style, including methods for rendering headers and disabled headers based on the tab style. [[1]](diffhunk://#diff-41b1c5919c2aed658650a24a6b28ecd5763566ed708ff322a9fca34e4d5fac15L48-R58) [[2]](diffhunk://#diff-41b1c5919c2aed658650a24a6b28ecd5763566ed708ff322a9fca34e4d5fac15R126-R175) [[3]](diffhunk://#diff-f16bfc11b19f5f5ca874276674010a254f12dcfbc065320a1be81bf91721de64R876-R879)
* [`src/BootstrapBlazor/Components/Tab/Tab.razor.cs`](diffhunk://#diff-f16bfc11b19f5f5ca874276674010a254f12dcfbc065320a1be81bf91721de64R291-R296): Introduced the `TabStyle` property to the `Tab` component and updated methods to support the new style. [[1]](diffhunk://#diff-f16bfc11b19f5f5ca874276674010a254f12dcfbc065320a1be81bf91721de64R291-R296) [[2]](diffhunk://#diff-f16bfc11b19f5f5ca874276674010a254f12dcfbc065320a1be81bf91721de64R797-R804)

### Localization Updates:
* [`src/BootstrapBlazor.Server/Locales/en-US.json`](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L2119-R2123): Added new localization entries for the "Chrome" tab style.
* [`src/BootstrapBlazor.Server/Locales/zh-CN.json`](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL2119-R2123): Added corresponding localization entries in Chinese.

### Style and CSS Changes:
* [`src/BootstrapBlazor/Components/Tab/Tab.razor.scss`](diffhunk://#diff-fe8d4d4ac0c2d492d632197c04891b12d9d846bbddb42a2187a04ba384645c02R490-R599): Added CSS rules for the "Chrome" tab style to define the appearance of the tabs and their headers.

### Enum Addition:
* [`src/BootstrapBlazor/Enums/TabStyle.cs`](diffhunk://#diff-c350bc9313f6713ac0fcff523f5033c2adcc0d64cbe3fdfd3469293475ecf363R1-R22): Created a new `TabStyle` enum to define the available tab styles, including "Default" and "Chrome".

### Attribute and Method Updates:
* [`src/BootstrapBlazor.Server/Components/Samples/Tabs.razor.cs`](diffhunk://#diff-c3c88e9dde6e875517c6ca92d15dc7cb5167cedd4dffe4a0d248735bdf4d78a7L207-R207): Updated attribute descriptions and added a new attribute for `TabStyle`. [[1]](diffhunk://#diff-c3c88e9dde6e875517c6ca92d15dc7cb5167cedd4dffe4a0d248735bdf4d78a7L207-R207) [[2]](diffhunk://#diff-c3c88e9dde6e875517c6ca92d15dc7cb5167cedd4dffe4a0d248735bdf4d78a7L225-R239) [[3]](diffhunk://#diff-c3c88e9dde6e875517c6ca92d15dc7cb5167cedd4dffe4a0d248735bdf4d78a7R253-R260)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a new 'Chrome' tab style to the Tab component, including updates to rendering logic, CSS, and localization files.

New Features:
- Introduce a new 'Chrome' tab style to the Tab component, allowing users to select between 'Default' and 'Chrome' styles.

Enhancements:
- Add CSS rules to support the new 'Chrome' tab style, defining the appearance of tabs and their headers.

Documentation:
- Update localization files to include entries for the new 'Chrome' tab style in both English and Chinese.