### PR TITLE
feat(TreeViewToolbarEditButton): add Icon parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.4.9</Version>
+    <Version>9.5.0-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/TreeView/TreeViewToolbarEditButton.razor
+++ b/src/BootstrapBlazor/Components/TreeView/TreeViewToolbarEditButton.razor
@@ -3,7 +3,7 @@
 @inherits ComponentBase
 
 <div class="tree-node-toolbar-edit" @onclick:preventDefault @onclick:stopPropagation>
-    <PopConfirmButton Icon="fa-solid fa-gear" Title="@Title" OnConfirm="OnConfirm">
+    <PopConfirmButton Icon="@Icon" Title="@Title" OnConfirm="OnConfirm">
         <BodyTemplate>
             <div class="tree-view-edit-form">
                 <span>@Text</span>

--- a/src/BootstrapBlazor/Components/TreeView/TreeViewToolbarEditButton.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeViewToolbarEditButton.razor.cs
@@ -37,10 +37,20 @@ public partial class TreeViewToolbarEditButton<TItem> : ComponentBase
     public string? Title { get; set; }
 
     /// <summary>
-    /// Gets or sets the title of the popup-window. Default is null.
+    /// Gets or sets the text of the popup-window label. Default is null.
     /// </summary>
     [Parameter]
     public string? Text { get; set; }
+
+    /// <summary>
+    /// Gets or sets the icon of the edit button. Default is null.
+    /// </summary>
+    [Parameter]
+    public string? Icon { get; set; }
+
+    [Inject]
+    [NotNull]
+    private IIconTheme? IconTheme { get; set; }
 
     private string? _text;
 
@@ -52,6 +62,7 @@ public partial class TreeViewToolbarEditButton<TItem> : ComponentBase
         base.OnParametersSet();
 
         _text = Item.Text;
+        Icon ??= IconTheme.GetIconByKey(ComponentIcons.TreeViewToolbarEditButton);
     }
 
     private async Task OnConfirm()

--- a/src/BootstrapBlazor/Enums/ComponentIcons.cs
+++ b/src/BootstrapBlazor/Enums/ComponentIcons.cs
@@ -741,6 +741,11 @@ public enum ComponentIcons
     TreeViewLoadingIcon,
 
     /// <summary>
+    /// TreeView 组件 ToolbarEditButton 属性图标
+    /// </summary>
+    TreeViewToolbarEditButton,
+
+    /// <summary>
     /// TreeView 组件 NodeIcon 属性图标
     /// </summary>
     TreeViewNodeIcon,

--- a/src/BootstrapBlazor/Icons/BootstrapIcons.cs
+++ b/src/BootstrapBlazor/Icons/BootstrapIcons.cs
@@ -178,6 +178,7 @@ internal static class BootstrapIcons
         { ComponentIcons.TreeViewSearchIcon, "bi bi-search" },
         { ComponentIcons.TreeViewResetSearchIcon, "bi bi-backspace" },
         { ComponentIcons.TreeViewLoadingIcon, "bi bi-arrow-clockwise bi-spin" },
+        { ComponentIcons.TreeViewToolbarEditButton, "bi bi-check2-square" },
 
         // Upload
         { ComponentIcons.AvatarUploadDeleteIcon, "bi bi-trash3" },

--- a/src/BootstrapBlazor/Icons/FontAwesomeIcons.cs
+++ b/src/BootstrapBlazor/Icons/FontAwesomeIcons.cs
@@ -176,6 +176,7 @@ internal static class FontAwesomeIcons
         { ComponentIcons.TreeViewSearchIcon, "fa-solid fa-magnifying-glass" },
         { ComponentIcons.TreeViewResetSearchIcon, "fa-solid fa-delete-left" },
         { ComponentIcons.TreeViewLoadingIcon, "fa-solid fa-spinner fa-spin" },
+        { ComponentIcons.TreeViewToolbarEditButton, "fa-regular fa-pen-to-square" },
 
         // Upload
         { ComponentIcons.AvatarUploadDeleteIcon, "fa-regular fa-trash-can" },

--- a/src/BootstrapBlazor/Icons/MaterialDesignIcons.cs
+++ b/src/BootstrapBlazor/Icons/MaterialDesignIcons.cs
@@ -178,6 +178,7 @@ internal static class MaterialDesignIcons
         { ComponentIcons.TreeViewSearchIcon, "mdi mdi-magnify" },
         { ComponentIcons.TreeViewResetSearchIcon, "mdi mdi-backspace" },
         { ComponentIcons.TreeViewLoadingIcon, "mdi mdi-loading mdi-spin" },
+        { ComponentIcons.TreeViewToolbarEditButton, "mdi mdi-file-edit-outline" },
 
         // Upload
         { ComponentIcons.AvatarUploadDeleteIcon, "mdi mdi-trash-can-outline" },


### PR DESCRIPTION
## Link issues
fixes #5646 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes updates to the `BootstrapBlazor` project, focusing on adding a new icon for the `TreeViewToolbarEditButton` component and updating its related files accordingly. The most important changes include modifying the project version, adding a new `Icon` parameter, and updating the icon mappings for different icon themes.

### Version Update:
* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated project version from `9.4.9` to `9.5.0-beta01`.

### Component Enhancements:
* [`src/BootstrapBlazor/Components/TreeView/TreeViewToolbarEditButton.razor`](diffhunk://#diff-ff854b41f4817914d98e4d8129e82236b9da285408c218a46e184dbc13fcf18bL6-R6): Modified the `Icon` property in the `PopConfirmButton` to use the new `Icon` parameter.
* [`src/BootstrapBlazor/Components/TreeView/TreeViewToolbarEditButton.razor.cs`](diffhunk://#diff-25fd4ce80a381a66e57d12d4ded4a927f1ec5fd5cc9690b7436ce58e6c37179cL40-R54): Added a new `Icon` parameter and injected the `IIconTheme` service to set a default icon if none is provided. [[1]](diffhunk://#diff-25fd4ce80a381a66e57d12d4ded4a927f1ec5fd5cc9690b7436ce58e6c37179cL40-R54) [[2]](diffhunk://#diff-25fd4ce80a381a66e57d12d4ded4a927f1ec5fd5cc9690b7436ce58e6c37179cR65)

### Icon Theme Updates:
* [`src/BootstrapBlazor/Enums/ComponentIcons.cs`](diffhunk://#diff-44e6baf5b05a3a3355f9b1c5df24031284b30e408c73b42bc7f758c8473de301R743-R747): Added a new enum value `TreeViewToolbarEditButton` for the new icon.
* [`src/BootstrapBlazor/Icons/BootstrapIcons.cs`](diffhunk://#diff-b6784318bec86006634f9237a6912d5a4746a29c799e2c89eec0ac394b87ca76R181): Mapped the new `TreeViewToolbarEditButton` icon to "bi bi-check2-square".
* [`src/BootstrapBlazor/Icons/FontAwesomeIcons.cs`](diffhunk://#diff-90932bc45dd8b8759b8de8e0528e081fb1293b0f12f68ba13b89333b23851618R179): Mapped the new `TreeViewToolbarEditButton` icon to "fa-regular fa-pen-to-square".
* [`src/BootstrapBlazor/Icons/MaterialDesignIcons.cs`](diffhunk://#diff-8f139016f4795de5c28cfa63b5c8969149498586d149776f43d8f77d024d9253R181): Mapped the new `TreeViewToolbarEditButton` icon to "mdi mdi-file-edit-outline".

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adds an Icon parameter to the TreeViewToolbarEditButton component, allowing developers to customize the edit button's icon.

Enhancements:
- Adds an Icon parameter to the TreeViewToolbarEditButton component for icon customization.
- Updates the Icon property in the PopConfirmButton to use the new Icon parameter.
- Sets a default icon for the TreeViewToolbarEditButton using the IIconTheme service if none is provided.
- Maps the new TreeViewToolbarEditButton icon to different icons for Bootstrap, FontAwesome, and Material Design icon themes.
- Increments project version to 9.5.0-beta01.