### PR TITLE
fix(Textarea): should trigger keyboard event when set UseShiftEnter to false

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.0-beta03</Version>
+    <Version>9.5.0-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Textarea/Textarea.razor.js
+++ b/src/BootstrapBlazor/Components/Textarea/Textarea.razor.js
@@ -14,7 +14,7 @@ export function init(id) {
         if (e.key === "Enter" || e.key === "NumpadEnter") {
             const useShiftEnter = el.getAttribute('data-bb-shift-enter') === 'true';
             const shiftKey = e.shiftKey;
-            if (!shiftKey || !useShiftEnter) {
+            if (shiftKey && useShiftEnter) {
                 e.preventDefault();
             }
         }


### PR DESCRIPTION
## Link issues
fixes #5654 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes updates to the `BootstrapBlazor` project version and a bug fix in the `Textarea` component's JavaScript file.

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from `9.5.0-beta03` to `9.5.0-beta04`.

Bug fix in `Textarea` component:

* [`src/BootstrapBlazor/Components/Textarea/Textarea.razor.js`](diffhunk://#diff-aac1dea3af4a1f2eb80041e574bc201c69b95f35ca659c7c1585373d12cf9f39L17-R17): Fixed the condition to prevent default behavior on Enter key press when `shiftKey` is pressed and `useShiftEnter` is true.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fixes a bug in the Textarea component where the Enter key's default behavior was not prevented correctly when UseShiftEnter was set to false. Also, updates the project version to 9.5.0-beta04.

Bug Fixes:
- Fixes the condition to prevent default behavior on Enter key press when shiftKey is pressed and useShiftEnter is true. 

Chores:
- Updates the project version to 9.5.0-beta04.