### PR TITLE
feat(MultiSelect): add CloseButtonIcon parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.0-beta04</Version>
+    <Version>9.5.0-beta05</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -28,7 +28,7 @@
                         <div class="multi-select-item-group">
                             <DynamicElement TagName="span" class="multi-select-close" data-bb-val="@GetValueString(item)"
                                             TriggerClick="@(!IsPopover)" OnClick="() => ToggleRow(item.Value)">
-                                <i class="@ClearIcon"></i>
+                                <i class="@CloseButtonIcon"></i>
                             </DynamicElement>
                             <span class="multi-select-item">@item.Text</span>
                         </div>
@@ -51,7 +51,7 @@
     </div>
     @if (GetClearable())
     {
-        <span class="@ClearClassString" @onclick="OnClearValue"><i class="@ClearableIcon"></i></span>
+        <span class="@ClearClassString" @onclick="OnClearValue"><i class="@ClearIcon"></i></span>
     }
     <div class="@DropdownMenuClassString">
         @if (ShowSearch)

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -57,6 +57,12 @@ public partial class MultiSelect<TValue>
     public bool ShowCloseButton { get; set; } = true;
 
     /// <summary>
+    /// 获得/设置 关闭按钮图标 默认为 null
+    /// </summary>
+    [Parameter]
+    public string? CloseButtonIcon { get; set; }
+
+    /// <summary>
     /// 获得/设置 是否显示功能按钮 默认为 false 不显示
     /// </summary>
     [Parameter]
@@ -152,14 +158,6 @@ public partial class MultiSelect<TValue>
     [Parameter]
     [NotNull]
     public string? MinErrorMessage { get; set; }
-
-    /// <summary>
-    /// Gets or sets the right-side clear icon. Default is null.
-    /// </summary>
-    [Parameter]
-    [NotNull]
-    public string? ClearableIcon { get; set; }
-
     [Inject]
     [NotNull]
     private IStringLocalizer<MultiSelect<TValue>>? Localizer { get; set; }
@@ -184,8 +182,8 @@ public partial class MultiSelect<TValue>
         NoSearchDataText ??= Localizer[nameof(NoSearchDataText)];
 
         DropdownIcon ??= IconTheme.GetIconByKey(ComponentIcons.MultiSelectDropdownIcon);
+        CloseButtonIcon ??= IconTheme.GetIconByKey(ComponentIcons.MultiSelectCloseIcon);
         ClearIcon ??= IconTheme.GetIconByKey(ComponentIcons.MultiSelectClearIcon);
-        ClearableIcon ??= IconTheme.GetIconByKey(ComponentIcons.MultiSelectClearableIcon);
 
         ResetItems();
         ResetRules();

--- a/src/BootstrapBlazor/Enums/ComponentIcons.cs
+++ b/src/BootstrapBlazor/Enums/ComponentIcons.cs
@@ -451,14 +451,14 @@ public enum ComponentIcons
     MultiSelectDropdownIcon,
 
     /// <summary>
+    /// MultiSelect 组件 CloseButtonIcon 图标
+    /// </summary>
+    MultiSelectCloseIcon,
+
+    /// <summary>
     /// MultiSelect 组件 ClearIcon 图标
     /// </summary>
     MultiSelectClearIcon,
-
-    /// <summary>
-    /// MultiSelect 组件 ClearableIcon 图标
-    /// </summary>
-    MultiSelectClearableIcon,
 
     /// <summary>
     /// SelectTree 组件 DropdownIcon 图标

--- a/src/BootstrapBlazor/Icons/BootstrapIcons.cs
+++ b/src/BootstrapBlazor/Icons/BootstrapIcons.cs
@@ -109,8 +109,8 @@ internal static class BootstrapIcons
         { ComponentIcons.RibbonTabArrowPinIcon, "bi bi-pin bi-pin-angle" },
 
         { ComponentIcons.MultiSelectDropdownIcon, "bi bi-chevron-up" },
-        { ComponentIcons.MultiSelectClearIcon, "bi bi-x" },
-        { ComponentIcons.MultiSelectClearableIcon, "bi bi-x-circle" },
+        { ComponentIcons.MultiSelectCloseIcon, "bi bi-x" },
+        { ComponentIcons.MultiSelectClearIcon, "bi bi-x-circle" },
 
         { ComponentIcons.SelectTreeDropdownIcon, "bi bi-chevron-up" },
 

--- a/src/BootstrapBlazor/Icons/FontAwesomeIcons.cs
+++ b/src/BootstrapBlazor/Icons/FontAwesomeIcons.cs
@@ -107,8 +107,8 @@ internal static class FontAwesomeIcons
         { ComponentIcons.RibbonTabArrowPinIcon, "fa-solid fa-thumbtack fa-rotate-90" },
 
         { ComponentIcons.MultiSelectDropdownIcon, "fa-solid fa-angle-up" },
-        { ComponentIcons.MultiSelectClearIcon, "fa-solid fa-xmark" },
-        { ComponentIcons.MultiSelectClearableIcon, "fa-regular fa-circle-xmark" },
+        { ComponentIcons.MultiSelectCloseIcon, "fa-solid fa-xmark" },
+        { ComponentIcons.MultiSelectClearIcon, "fa-regular fa-circle-xmark" },
 
         { ComponentIcons.SelectTreeDropdownIcon, "fa-solid fa-angle-up" },
 

--- a/src/BootstrapBlazor/Icons/MaterialDesignIcons.cs
+++ b/src/BootstrapBlazor/Icons/MaterialDesignIcons.cs
@@ -109,8 +109,8 @@ internal static class MaterialDesignIcons
         { ComponentIcons.RibbonTabArrowPinIcon, "mdi mdi-pin mdi-pin-off" },
 
         { ComponentIcons.MultiSelectDropdownIcon, "mdi mdi-chevron-up" },
-        { ComponentIcons.MultiSelectClearIcon, "mdi mdi-close" },
-        { ComponentIcons.MultiSelectClearableIcon, "mdi mdi-trash-can-outline" },
+        { ComponentIcons.MultiSelectCloseIcon, "mdi mdi-close" },
+        { ComponentIcons.MultiSelectClearIcon, "mdi mdi-trash-can-outline" },
 
         { ComponentIcons.SelectTreeDropdownIcon, "mdi mdi-chevron-up" },
 

--- a/src/BootstrapBlazor/Icons/MaterialDesignIcons.cs
+++ b/src/BootstrapBlazor/Icons/MaterialDesignIcons.cs
@@ -110,7 +110,7 @@ internal static class MaterialDesignIcons
 
         { ComponentIcons.MultiSelectDropdownIcon, "mdi mdi-chevron-up" },
         { ComponentIcons.MultiSelectCloseIcon, "mdi mdi-close" },
-        { ComponentIcons.MultiSelectClearIcon, "mdi mdi-trash-can-outline" },
+        { ComponentIcons.MultiSelectClearIcon, "mdi mdi-close-circle-outline" },
 
         { ComponentIcons.SelectTreeDropdownIcon, "mdi mdi-chevron-up" },
 

--- a/test/UnitTest/Components/MultiSelectTest.cs
+++ b/test/UnitTest/Components/MultiSelectTest.cs
@@ -168,7 +168,8 @@ public class MultiSelectTest : BootstrapBlazorTestBase
         Assert.Equal(2, values.Count);
 
         // 选中第四个
-        var item = cut.FindAll(".dropdown-menu .dropdown-item").Last();
+        var items = cut.FindAll(".dropdown-menu .dropdown-item");
+        var item = items[items.Count - 1];
         await cut.InvokeAsync(() => item.Click());
         values = cut.FindAll(".multi-select-items .multi-select-item");
         Assert.Equal(3, values.Count);
@@ -644,7 +645,7 @@ public class MultiSelectTest : BootstrapBlazorTestBase
 
         cut.SetParametersAndRender(pb =>
         {
-            pb.Add(a => a.ClearableIcon, "icon-clear-test");
+            pb.Add(a => a.ClearIcon, "icon-clear-test");
         });
         Assert.DoesNotContain("fa-regular fa-circle-xmark", cut.Markup);
         Assert.Contains("icon-clear-test", cut.Markup);


### PR DESCRIPTION
## Link issues
fixes #5661 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes several changes to the `MultiSelect` component in the `BootstrapBlazor` project. The changes mainly focus on renaming and updating icon properties, as well as updating related tests.

### Icon Property Updates:

* [`src/BootstrapBlazor/Components/Select/MultiSelect.razor`](diffhunk://#diff-2cb97003291f7d660837bc70e2a14c2191233f3608f327a2338309af44dbc93aL31-R31): Replaced `ClearIcon` with `CloseButtonIcon` in the `DynamicElement` and updated the clearable icon reference. [[1]](diffhunk://#diff-2cb97003291f7d660837bc70e2a14c2191233f3608f327a2338309af44dbc93aL31-R31) [[2]](diffhunk://#diff-2cb97003291f7d660837bc70e2a14c2191233f3608f327a2338309af44dbc93aL54-R54)
* [`src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs`](diffhunk://#diff-8f99e0c768ac320cab9d8e3c3dd15e910ae8655d64925647e7ec07a72f35cb63R59-R64): Added a new `CloseButtonIcon` parameter and removed the `ClearableIcon` parameter. Updated the `OnParametersSet` method to set default values for `CloseButtonIcon` and `ClearIcon`. [[1]](diffhunk://#diff-8f99e0c768ac320cab9d8e3c3dd15e910ae8655d64925647e7ec07a72f35cb63R59-R64) [[2]](diffhunk://#diff-8f99e0c768ac320cab9d8e3c3dd15e910ae8655d64925647e7ec07a72f35cb63L155-L162) [[3]](diffhunk://#diff-8f99e0c768ac320cab9d8e3c3dd15e910ae8655d64925647e7ec07a72f35cb63R185-L188)

### Enum and Icon Mapping Updates:

* [`src/BootstrapBlazor/Enums/ComponentIcons.cs`](diffhunk://#diff-44e6baf5b05a3a3355f9b1c5df24031284b30e408c73b42bc7f758c8473de301L454-R461): Renamed `MultiSelectClearIcon` to `MultiSelectCloseIcon` and `MultiSelectClearableIcon` to `MultiSelectClearIcon`.
* Updated icon mappings in `BootstrapIcons`, `FontAwesomeIcons`, and `MaterialDesignIcons` to reflect the new icon names. [[1]](diffhunk://#diff-b6784318bec86006634f9237a6912d5a4746a29c799e2c89eec0ac394b87ca76L112-R113) [[2]](diffhunk://#diff-90932bc45dd8b8759b8de8e0528e081fb1293b0f12f68ba13b89333b23851618L110-R111) [[3]](diffhunk://#diff-8f139016f4795de5c28cfa63b5c8969149498586d149776f43d8f77d024d9253L112-R113)

### Version Update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from `9.5.0-beta04` to `9.5.0-beta05`.

### Test Updates:

* [`test/UnitTest/Components/MultiSelectTest.cs`](diffhunk://#diff-d2916f882d0841612900bdbc070aa78c1f893062d40404c793b8b7c27399fc38L171-R172): Updated tests to reflect the changes in icon properties, including renaming `ClearableIcon` to `ClearIcon` and modifying item selection logic. [[1]](diffhunk://#diff-d2916f882d0841612900bdbc070aa78c1f893062d40404c793b8b7c27399fc38L171-R172) [[2]](diffhunk://#diff-d2916f882d0841612900bdbc070aa78c1f893062d40404c793b8b7c27399fc38L647-R648)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adds a CloseButtonIcon parameter to the MultiSelect component, allowing customization of the close button icon. Also renames ClearableIcon to ClearIcon and updates related icon mappings and tests.

Enhancements:
- Renames ClearableIcon to ClearIcon to better reflect its purpose.
- Updates icon mappings in BootstrapIcons, FontAwesomeIcons, and MaterialDesignIcons to reflect the new icon names.
- Sets default values for CloseButtonIcon and ClearIcon using the IconTheme.
- Updates tests to reflect the changes in icon properties, including renaming ClearableIcon to ClearIcon and modifying item selection logic.
- Renames MultiSelectClearIcon to MultiSelectCloseIcon in ComponentIcons enum.
- Removes the ClearableIcon parameter from the MultiSelect component.