### PR TITLE
feat(TreeView): add OverscanCount parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.0-beta09</Version>
+    <Version>9.4.10</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor
@@ -47,7 +47,7 @@ else
         @if (IsVirtualize)
         {
             <div class="tree-root scroll is-virtual" tabindex="0">
-                <Virtualize ItemSize="RowHeight" OverscanCount="10" Items="@Rows">
+                <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@Rows">
                     @RenderRow(context)
                 </Virtualize>
             </div>

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -218,11 +218,11 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     public bool IsVirtualize { get; set; }
 
     /// <summary>
-    /// Gets or sets the row height for virtual scrolling. Default is 38.
+    /// Gets or sets the row height for virtual scrolling. Default is 29f.
     /// </summary>
-    /// <remarks>Effective when <see cref="ScrollMode"/> is set to Virtual.</remarks>
+    /// <remarks>Effective when <see cref="IsVirtualize"/> is set to true.</remarks>
     [Parameter]
-    public float RowHeight { get; set; } = 38f;
+    public float RowHeight { get; set; } = 29f;
 
     /// <summary>
     /// Gets or sets the overscan count for virtual scrolling. Default is 10.

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -225,6 +225,13 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     public float RowHeight { get; set; } = 38f;
 
     /// <summary>
+    /// Gets or sets the overscan count for virtual scrolling. Default is 10.
+    /// </summary>
+    /// <remarks>Effective when <see cref="IsVirtualize"/> is set to true.</remarks>
+    [Parameter]
+    public int OverscanCount { get; set; } = 10;
+
+    /// <summary>
     /// Gets or sets the toolbar content template. Default is null.
     /// </summary>
     [Parameter]

--- a/test/UnitTest/Components/TimerTest.cs
+++ b/test/UnitTest/Components/TimerTest.cs
@@ -132,13 +132,12 @@ public class TimerTest : BootstrapBlazorTestBase
         var downs = cut.FindAll(".time-spinner-arrow.fa-angle-down");
         await cut.InvokeAsync(() => downs[0].Click());
         await cut.InvokeAsync(() => cut.Find(".time-panel-btn.confirm").Click());
-        await Task.Delay(1000);
-        var buttons = cut.FindAll(".timer-buttons button");
+
         // pause
+        var buttons = cut.FindAll(".timer-buttons button");
         Assert.True(buttons[1].ClassList.Contains("btn-warning"));
         Assert.Equal("暂停", buttons[1].GetInnerText());
         await cut.InvokeAsync(() => buttons[1].Click());
-        await Task.Delay(500);
 
         // resume
         buttons = cut.FindAll(".timer-buttons button");
@@ -156,6 +155,5 @@ public class TimerTest : BootstrapBlazorTestBase
         downs = cut.FindAll(".time-spinner-arrow.fa-angle-down");
         await cut.InvokeAsync(() => downs[0].Click());
         await cut.InvokeAsync(() => cut.Find(".time-panel-btn.confirm").Click());
-        await Task.Delay(1000);
     }
 }


### PR DESCRIPTION
## Link issues
fixes #5672 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes changes to the `BootstrapBlazor` project, focusing on version adjustment, improvements to the `TreeView` component, and cleanup in unit tests. The most important changes are listed below:

### Version Adjustment:
* Updated the project version in `src/BootstrapBlazor/BootstrapBlazor.csproj` from `9.5.0-beta09` to `9.4.10`.

### TreeView Component Improvements:
* Modified the `Virtualize` component in `src/BootstrapBlazor/Components/TreeView/TreeView.razor` to use the `OverscanCount` property instead of a hardcoded value.
* Updated the `TreeView` class in `src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs`:
  * Changed the default `RowHeight` for virtual scrolling from `38f` to `29f`.
  * Added a new parameter `OverscanCount` with a default value of `10` for virtual scrolling.

### Unit Test Cleanup:
* Removed unnecessary `Task.Delay` calls in the `OnCancel_Ok` method of `test/UnitTest/Components/TimerTest.cs` to streamline the test execution. [[1]](diffhunk://#diff-540cb390dfb9df9041c836424d222ffd191f350f2fd83e8aac92065f99451254L135-L141) [[2]](diffhunk://#diff-540cb390dfb9df9041c836424d222ffd191f350f2fd83e8aac92065f99451254L159)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Configures the TreeView component's Virtualize component to use the OverscanCount property instead of a hardcoded value, and updates the default RowHeight. Also, this PR removes unnecessary Task.Delay calls in the TimerTest unit tests.

Enhancements:
- Expose OverscanCount parameter to the TreeView component to allow users to configure the number of items rendered outside of the visible viewport in the Virtualize component.
- Update the default RowHeight for virtual scrolling in the TreeView component from 38f to 29f.
- Remove unnecessary Task.Delay calls in the OnCancel_Ok method of TimerTest.cs to streamline test execution.