### PR TITLE
chore(Action): add label check and auto close action

### DIFF
--- a/.github/workflows/issue-check-inactive.yml
+++ b/.github/workflows/issue-check-inactive.yml
@@ -1,0 +1,26 @@
+name: Issue Check Inactive
+
+on:
+  schedule:
+    - cron: "0 0 */15 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  issue-check-inactive:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: check-inactive
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'check-inactive'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          inactive-label: 'inactive'
+          inactive-day: 3
+          body: |
+            Since the issue was labeled with `invalid`, but no response in 3 days. This issue will be closed. If you have any questions, you can comment and reply.
+
+            由于该 issue 被标记为不合规工程，却 3 天未收到回应。现关闭 issue，若有任何问题，可评论回复。

--- a/.github/workflows/issue-close-required.yml
+++ b/.github/workflows/issue-close-required.yml
@@ -1,0 +1,26 @@
+name: Issue Close Require
+
+on:
+  schedule:
+    - cron: "0 10 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  issue-close-require:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: needs repro project
+        uses: actions-cool/issues-helper@v3
+        with:
+          actions: 'close-issues'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'need-repro-project'
+          inactive-day: 2
+          body: |
+            Since the issue was labeled with `need-repro-project`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply.
+
+            由于该 issue 被标记为需要复现工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复。


### PR DESCRIPTION
## Link issues
fixes #5687 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces two new GitHub Actions workflows to manage inactive issues. These workflows automate the process of checking for inactivity and closing issues that require a response but have not received one within a specified timeframe.

New workflows added:

* [`.github/workflows/issue-check-inactive.yml`](diffhunk://#diff-169c4342ef331a9ca8bee39f45668fd67b312f1a23cc5d74d6dca98a1dadb9d5R1-R26): This workflow runs every 15 days and checks for issues labeled as 'inactive'. If an issue is labeled as 'invalid' and has not received a response in 3 days, it will be closed.
* [`.github/workflows/issue-close-required.yml`](diffhunk://#diff-96f1b7f845d3bb37beb68d59147bfbb178376fccf293fdf512afe24246d8f495R1-R26): This workflow runs daily at 10 AM and checks for issues labeled as 'need-repro-project'. If an issue has not received a response in 2 days, it will be closed.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adds two new GitHub Actions workflows to automatically manage and close inactive issues based on specific labels and timeframes.

CI:
- Introduces a workflow that checks for issues labeled as 'inactive' and closes them if they haven't received a response in 3 days.
- Introduces a workflow that checks for issues labeled as 'need-repro-project' and closes them if they haven't received a response in 2 days.