### PR TITLE
feat(Calendar): add FirstDayOfWeek parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Calendars.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Calendars.razor
@@ -6,7 +6,7 @@
 <h4>@Localizer["SubTitle"]</h4>
 
 <DemoBlock Title="@Localizer["BasicUsageTitle"]" Introduction="@Localizer["BasicUsageIntro"]" Name="Normal">
-    <Calendar ValueChanged="@OnValueChanged" />
+    <Calendar ValueChanged="@OnValueChanged" FirstDayOfWeek="DayOfWeek.Monday" />
     <ConsoleLogger @ref="NormalLogger" />
 </DemoBlock>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Calendars.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Calendars.razor.cs
@@ -77,6 +77,14 @@ public sealed partial class Calendars
             Type = "RenderFragment<CalendarCellValue>",
             ValueList = " — ",
             DefaultValue = " — "
+        },
+        new()
+        {
+            Name = nameof(Calendar.FirstDayOfWeek),
+            Description = Localizer["FirstDayOfWeek"],
+            Type = "DayOfWeek",
+            ValueList = " — ",
+            DefaultValue = "Sunday"
         }
     ];
 }

--- a/src/BootstrapBlazor.Server/Components/Samples/DateTimePickers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/DateTimePickers.razor.cs
@@ -222,6 +222,14 @@ public sealed partial class DateTimePickers
         },
         new()
         {
+            Name = nameof(DateTimePicker<DateTime>.FirstDayOfWeek),
+            Description = Localizer["AttrFirstDayOfWeek"],
+            Type = "DayOfWeek",
+            ValueList = " — ",
+            DefaultValue = "Sunday"
+        },
+        new()
+        {
             Name = "ViewMode",
             Description = Localizer["Att9"],
             Type = "DatePickerViewMode",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2572,7 +2572,8 @@
     "FeatureShowHolidaysIntro": "<code>ShowHolidays</code> Whether to display holidays",
     "OnGetDisabledDaysCallbackEvent": "Disable date callback method",
     "AttrEnableDisabledDaysCache": "Whether to enable custom disabled date cache",
-    "AttrDisplayDisabledDayAsEmpty": "Display disabled date as an empty string"
+    "AttrDisplayDisabledDayAsEmpty": "Display disabled date as an empty string",
+    "AttrFirstDayOfWeek": "The first day of the week"
   },
   "BootstrapBlazor.Server.Components.Samples.TimePickers": {
     "Title": "TimePicker",
@@ -3768,7 +3769,8 @@
     "Chinese": "Chinese",
     "Math": "Math",
     "English": "English",
-    "Study": "Study"
+    "Study": "Study",
+    "FirstDayOfWeek": "The first day of the week"
   },
   "BootstrapBlazor.Server.Components.Samples.Cameras": {
     "Title": "Camera",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2572,7 +2572,8 @@
     "FeatureShowHolidaysIntro": "<code>ShowHolidays</code> 是否显示假日",
     "OnGetDisabledDaysCallbackEvent": "获得自定义禁用日期回调方法",
     "AttrEnableDisabledDaysCache": "是否启用获得自定义禁用日期缓存",
-    "AttrDisplayDisabledDayAsEmpty": "显示禁用日期为空字符串"
+    "AttrDisplayDisabledDayAsEmpty": "显示禁用日期为空字符串",
+    "AttrFirstDayOfWeek": "设置每周第一天"
   },
   "BootstrapBlazor.Server.Components.Samples.TimePickers": {
     "Title": "TimePicker 时间选择器",
@@ -3768,7 +3769,8 @@
     "Chinese": "语文",
     "Math": "数学",
     "English": "英语",
-    "Study": "自习"
+    "Study": "自习",
+    "FirstDayOfWeek": "设置每周第一天"
   },
   "BootstrapBlazor.Server.Components.Samples.Cameras": {
     "Title": "Camera 摄像头拍照组件",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.0-beta11</Version>
+    <Version>9.4.11</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Calendar/Calendar.razor.cs
+++ b/src/BootstrapBlazor/Components/Calendar/Calendar.razor.cs
@@ -107,7 +107,7 @@ public partial class Calendar
         PreviousMonth = Localizer[nameof(PreviousMonth)];
         NextMonth = Localizer[nameof(NextMonth)];
         Today = Localizer[nameof(Today)];
-        WeekLists = [.. Localizer[nameof(WeekLists)].Value.Split(',')];
+        WeekLists = GetWeekList();
         PreviousWeek = Localizer[nameof(PreviousWeek)];
         NextWeek = Localizer[nameof(NextWeek)];
         WeekText = Localizer[nameof(WeekText)];
@@ -124,7 +124,7 @@ public partial class Calendar
         get
         {
             var d = Value.AddDays(1 - Value.Day);
-            d = d.AddDays(0 - (int)d.DayOfWeek);
+            d = d.AddDays((int)FirstDayOfWeek - (int)d.DayOfWeek);
             return d;
         }
     }
@@ -196,6 +196,12 @@ public partial class Calendar
     /// </summary>
     [Parameter]
     public bool ShowYearButtons { get; set; } = true;
+
+    /// <summary>
+    /// 获得/设置 星期第一天 默认 <see cref="DayOfWeek.Sunday"/>
+    /// </summary>
+    [Parameter]
+    public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Sunday;
 
     /// <summary>
     /// 选中日期时回调此方法
@@ -296,5 +302,13 @@ public partial class Calendar
         var context = new BodyTemplateContext();
         context.Values.AddRange(Enumerable.Range(0, 7).Select(i => CreateCellValue(week.AddDays(i))));
         return context;
+    }
+    private List<string> GetWeekList()
+    {
+        var list = Localizer[nameof(WeekLists)].Value.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList();
+
+        // 调整顺序
+        var firstDayIndex = (int)FirstDayOfWeek;
+        return [.. list.Skip(firstDayIndex), .. list.Take(firstDayIndex)];
     }
 }

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -537,7 +537,7 @@ public partial class DatePickerBody
 
         // 调整顺序
         var firstDayIndex = (int)FirstDayOfWeek;
-        return list.Skip(firstDayIndex).Concat(list.Take(firstDayIndex)).ToList();
+        return [.. list.Skip(firstDayIndex), .. list.Take(firstDayIndex)];
     }
 
     private async Task UpdateDisabledDaysCache(bool force)

--- a/test/UnitTest/Components/CalendarTest.cs
+++ b/test/UnitTest/Components/CalendarTest.cs
@@ -233,4 +233,17 @@ public class CalendarTest : BootstrapBlazorTestBase
         });
         Assert.NotEqual(v, DateTime.MinValue);
     }
+
+    [Fact]
+    public void FirstDayOfWeek_Ok()
+    {
+        var cut = Context.RenderComponent<Calendar>(pb =>
+        {
+            pb.Add(a => a.Value, new DateTime(2025, 02, 20));
+            pb.Add(a => a.FirstDayOfWeek, DayOfWeek.Monday);
+        });
+        var labels = cut.FindAll(".calendar-table thead > tr > th");
+        Assert.Equal("一", labels[0].TextContent);
+        Assert.Equal("日", labels[6].TextContent);
+    }
 }


### PR DESCRIPTION
## Link issues
fixes #5691 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces several changes across multiple files to add the `FirstDayOfWeek` parameter to the `Calendar` and `DateTimePicker` components, along with corresponding localization updates. Additionally, there are minor adjustments to the project version and the method of generating week lists.

### Key Changes:

#### New Feature: `FirstDayOfWeek` Parameter
* [`src/BootstrapBlazor.Server/Components/Samples/Calendars.razor`](diffhunk://#diff-e1e20ae1267930dc12d66ab8b1df4c9f9c57b6ca85e640b4094da53ba6409b88L9-R9): Added `FirstDayOfWeek` parameter to the `Calendar` component.
* [`src/BootstrapBlazor.Server/Components/Samples/Calendars.razor.cs`](diffhunk://#diff-b7f6d3222cfc72f7ecee3eeb4a88cdc8a604d302d081fa71e18338bd20564cc4R80-R87): Updated `GetAttributes` method to include `FirstDayOfWeek` attribute for `Calendar`.
* [`src/BootstrapBlazor.Server/Components/Samples/DateTimePickers.razor.cs`](diffhunk://#diff-8abd802d8a9c24a82d327f516b0c5b12bfb3dd252437336acde9f55ca6ef0aa5R224-R231): Updated `GetAttributes` method to include `FirstDayOfWeek` attribute for `DateTimePicker`.
* [`src/BootstrapBlazor/Components/Calendar/Calendar.razor.cs`](diffhunk://#diff-1cfbc492c039e189cd741e61dd605b35a9af51b5cdc508abe709e2e813ba74fdL110-R110): Added `FirstDayOfWeek` parameter and modified `StartDate` and `GetWeekList` methods to respect this parameter. [[1]](diffhunk://#diff-1cfbc492c039e189cd741e61dd605b35a9af51b5cdc508abe709e2e813ba74fdL110-R110) [[2]](diffhunk://#diff-1cfbc492c039e189cd741e61dd605b35a9af51b5cdc508abe709e2e813ba74fdL127-R127) [[3]](diffhunk://#diff-1cfbc492c039e189cd741e61dd605b35a9af51b5cdc508abe709e2e813ba74fdR200-R205) [[4]](diffhunk://#diff-1cfbc492c039e189cd741e61dd605b35a9af51b5cdc508abe709e2e813ba74fdR306-R313)
* [`src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs`](diffhunk://#diff-3d45053d5647e5835bf3cd17a9cbe49e9edd0123c032672060f9b127f114d2c3L540-R540): Updated `GetWeekList` method to use the new list slicing syntax.

#### Localization Updates
* [`src/BootstrapBlazor.Server/Locales/en-US.json`](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L2575-R2576): Added localization entries for `FirstDayOfWeek` and `AttrFirstDayOfWeek`. [[1]](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L2575-R2576) [[2]](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L3771-R3773)
* [`src/BootstrapBlazor.Server/Locales/zh-CN.json`](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL2575-R2576): Added localization entries for `FirstDayOfWeek` and `AttrFirstDayOfWeek`. [[1]](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL2575-R2576) [[2]](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL3771-R3773)

#### Project Version Update
* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Downgraded project version from `9.5.0-beta11` to `9.4.11`.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

New Features:
- Adds FirstDayOfWeek parameter to Calendar and DateTimePicker components to configure the first day of the week.