### PR TITLE
refactor(Dropdown): update dark style

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.0-beta15</Version>
+    <Version>9.4.12</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.scss
+++ b/src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.scss
@@ -1,0 +1,3 @@
+[data-bs-theme='dark'] .dropdown-menu {
+    --bs-dropdown-bg: #{$bs-dropdown-bg-dark};
+}

--- a/src/BootstrapBlazor/wwwroot/scss/bootstrapblazor-dark.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/bootstrapblazor-dark.scss
@@ -10,6 +10,9 @@ $bb-layout-menu-user-border-color-dark: #2c3034;
 $bb-layout-logo-border-color-dark: var(--bs-border-color);
 $bb-layout-logo-bg-dark: #606266;
 
+// Dropdown
+$bs-dropdown-bg-dark: #343a40;
+
 // Dial-Button
 $bb-dial-item-hover-bg-dark: #313131;
 

--- a/src/BootstrapBlazor/wwwroot/scss/components.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/components.scss
@@ -34,6 +34,7 @@
 @import "../../Components/Divider/Divider.razor.scss";
 @import "../../Components/DragDrap/DragDrop.razor.scss";
 @import "../../Components/Drawer/Drawer.razor.scss";
+@import "../../Components/Dropdown/Dropdown.razor.scss";
 @import "../../Components/DropdownWidget/DropdownWidget.razor.scss";
 @import "../../Components/EditorForm/EditorForm.razor.scss";
 @import "../../Components/Empty/Empty.razor.scss";


### PR DESCRIPTION
## Link issues
fixes #5710 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes several changes to the BootstrapBlazor project, focusing on version adjustments and theme updates for dropdown components. The most important changes are listed below:

### Version Adjustment:
* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Downgraded the project version from `9.5.0-beta15` to `9.4.12`.

### Theme Updates:
* [`src/BootstrapBlazor/Components/Dropdown/Dropdown.razor.scss`](diffhunk://#diff-d2c35f12b802f1ae941dfeea85d55d3c710cd3bc3f764ed31b56a7c541b23aa0R1-R3): Added dark theme styling for dropdown menus.
* [`src/BootstrapBlazor/wwwroot/scss/bootstrapblazor-dark.scss`](diffhunk://#diff-34c5fb9e627f43f81da468ff15f338d609871d12ec3d3c0cd57081ac2fa95a7cR13-R15): Introduced a new variable `$bs-dropdown-bg-dark` for dark theme dropdown background color.
* [`src/BootstrapBlazor/wwwroot/scss/components.scss`](diffhunk://#diff-27d94475876fea26efaf2d688f09d8d9aa288d4d625abce0677a7e3043021a96R37): Included the `Dropdown.razor.scss` file to ensure the new dropdown styles are imported.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Updates the dropdown component to support dark theme styling by introducing a new CSS variable and applying it when the dark theme is active.

Enhancements:
- Adds dark theme styling for dropdown menus.
- Introduces a new CSS variable `$bs-dropdown-bg-dark` for dark theme dropdown background color.
- Includes the `Dropdown.razor.scss` file to ensure the new dropdown styles are imported.