### PR TITLE
chore(Action): update action add any-of-labels config

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           days-before-issue-stale: 2
           days-before-issue-close: 2
-          any-of-labels: "invalid, need-repro-project"
+          any-of-labels: "invalid,need-repro-project"
           stale-issue-label: "stale"
           stale-issue-message: "Since the issue was labeled with `invalid`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply. \r 由于该 issue 被标记为不合规工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复"
           close-issue-message: "Since the issue was labeled with `need-repro-project`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply. \r 由于该 issue 被标记为需要复现工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复"

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,7 +1,7 @@
 name: Close inactive issues
 on:
   schedule:
-    - cron: "30 2 * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   close-issues:
@@ -13,7 +13,8 @@ jobs:
         with:
           days-before-issue-stale: 2
           days-before-issue-close: 2
+          any-of-labels: "invalid, need-repro-project"
           stale-issue-label: "stale"
-          stale-issue-message: "Since the issue was labeled with `invalid`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply. 由于该 issue 被标记为不合规工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复"
-          close-issue-message: "Since the issue was labeled with `need-repro-project`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply. 由于该 issue 被标记为需要复现工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复"
+          stale-issue-message: "Since the issue was labeled with `invalid`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply. \r 由于该 issue 被标记为不合规工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复"
+          close-issue-message: "Since the issue was labeled with `need-repro-project`, but no response in 2 days. This issue will be closed. If you have any questions, you can comment and reply. \r 由于该 issue 被标记为需要复现工程，却 2 天未收到回应。现关闭 issue，若有任何问题，可评论回复"
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Link issues
fixes #5719 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes updates to the `.github/workflows/close-stale-issues.yml` file to modify the schedule for closing inactive issues and to adjust the configuration for handling stale issues. The most important changes include updating the cron schedule and refining the labels and messages used for stale issues.

Changes to the cron schedule:

* [`.github/workflows/close-stale-issues.yml`](diffhunk://#diff-221ec56332617dc2f33423aaada2c915da7a8a49d88ad5189606cfa78518fea9L4-R4): Changed the cron schedule from "30 2 * * *" to "0 1 * * *" to adjust the timing for closing inactive issues.

Refinements to stale issue handling:

* [`.github/workflows/close-stale-issues.yml`](diffhunk://#diff-221ec56332617dc2f33423aaada2c915da7a8a49d88ad5189606cfa78518fea9R16-R19): Added `any-of-labels` parameter with values "invalid,need-repro-project" to specify labels that trigger the stale issue process.
* [`.github/workflows/close-stale-issues.yml`](diffhunk://#diff-221ec56332617dc2f33423aaada2c915da7a8a49d88ad5189606cfa78518fea9R16-R19): Updated the `stale-issue-message` and `close-issue-message` to include a carriage return for better formatting.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Updates the close-stale-issues workflow to run at a different time and to consider issues with the 'invalid' or 'need-repro-project' labels as stale.

CI:
- Updates the cron schedule for the close-stale-issues workflow.
- Configures the close-stale-issues workflow to consider issues with the 'invalid' or 'need-repro-project' labels as stale.