### PR TITLE
fix(Table): column list overflow when too many drop items are present

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.scss
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.scss
@@ -11,8 +11,8 @@
     --bb-table-footer-font-weight: blod;
     --bb-table-card-row-padding: .75rem .5rem;
     --bb-table-columnlist-max-height: var(--bb-dropdown-max-height);
-    --bs-table-striped-bg: rgba(0,0,0,.05);
-    --bs-table-hover-bg: rgba(0,0,0,.075);
+    --bs-table-striped-bg: rgba(0, 0, 0, .05);
+    --bs-table-hover-bg: rgba(0, 0, 0, .075);
     --bb-table-search-body-margin: 1rem;
     --bb-table-copy-column-margin-right: .5rem;
     --bb-table-column-fixed-border-color: rgba(var(--bs-body-color-rgb), .18);

--- a/src/BootstrapBlazor/Components/Table/Table.razor.scss
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.scss
@@ -309,6 +309,7 @@
 
 .table-toolbar .dropdown-menu {
     max-height: var(--bb-table-columnlist-max-height);
+    overflow: auto;
 }
 
 .table-toolbar .dropdown-menu .dropdown-item span {


### PR DESCRIPTION
## Link issues
fixes #5724 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes a minor change to the `Table.razor.scss` file. The change adds an overflow property to the `.table-toolbar .dropdown-menu` class to improve the handling of content that exceeds the maximum height.

* [`src/BootstrapBlazor/Components/Table/Table.razor.scss`](diffhunk://#diff-2a3c54157e5330203856023676a9998e9daf2b2e98f6e89d0fba6f2aa27f5ec6R312): Added `overflow: auto;` to the `.table-toolbar .dropdown-menu` class to handle content overflow.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
