### PR TITLE
feat(DevUI): update btn-xs style

### DIFF
--- a/src/BootstrapBlazor.Server/wwwroot/css/devui.css
+++ b/src/BootstrapBlazor.Server/wwwroot/css/devui.css
@@ -54,6 +54,11 @@ pre code.hljs {
     --bs-btn-xxl-font-size: 1.5rem;
 }
 
+.btn-xs {
+    --bs-btn-padding-y: 0;
+    --bs-btn-padding-x: 0.45rem;
+}
+
 .btn-circle {
     --bb-button-circle-width: 35px;
     --bb-button-circle-height: 35px;


### PR DESCRIPTION
## Link issues
fixes #5750 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes a small change to the `src/BootstrapBlazor.Server/wwwroot/css/devui.css` file. The change introduces a new button size class `.btn-xs` with specific padding values.

Changes to button styles:

* [`src/BootstrapBlazor.Server/wwwroot/css/devui.css`](diffhunk://#diff-1c17070327417c9723d54e7ecdb371d453cd8f89416656cb16dc7310fbf706a3R57-R61): Added a new `.btn-xs` class with `--bs-btn-padding-y: 0` and `--bs-btn-padding-x: 0.45rem`.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add extra small (xs) button size style to DevUI CSS

New Features:
- Introduce a new `.btn-xs` CSS class with specific padding for extra small buttons

Enhancements:
- Extend button size variants in the DevUI stylesheet