### PR TITLE
fix(ValidateForm): compatible with custom validation classes not end with Attribute

### DIFF
--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -385,10 +385,6 @@ public partial class ValidateForm
             var result = rule.GetValidationResult(value, context);
             if (result != null && result != ValidationResult.Success)
             {
-                // 查找 resource 资源文件中的 ErrorMessage
-                var ruleNameSpan = rule.GetType().Name.AsSpan();
-                var index = ruleNameSpan.IndexOf(attributeSpan, StringComparison.OrdinalIgnoreCase);
-                var ruleName = ruleNameSpan[..index];
                 var find = false;
                 if (!string.IsNullOrEmpty(rule.ErrorMessage))
                 {
@@ -400,29 +396,36 @@ public partial class ValidateForm
                     }
                 }
 
-                // 通过设置 ErrorMessage 检索
-                if (!context.ObjectType.Assembly.IsDynamic && !find
-                    && !string.IsNullOrEmpty(rule.ErrorMessage)
-                    && LocalizerFactory.Create(context.ObjectType).TryGetLocalizerString(rule.ErrorMessage, out var msg))
+                if (!context.ObjectType.Assembly.IsDynamic)
                 {
-                    rule.ErrorMessage = msg;
-                    find = true;
-                }
+                    if (!find && !string.IsNullOrEmpty(rule.ErrorMessage)
+                        && LocalizerFactory.Create(context.ObjectType).TryGetLocalizerString(rule.ErrorMessage, out var msg))
+                    {
+                        // 通过设置 ErrorMessage 检索
+                        rule.ErrorMessage = msg;
+                        find = true;
+                    }
 
-                // 通过 Attribute 检索
-                if (!rule.GetType().Assembly.IsDynamic && !find
-                    && LocalizerFactory.Create(rule.GetType()).TryGetLocalizerString(nameof(rule.ErrorMessage), out msg))
-                {
-                    rule.ErrorMessage = msg;
-                    find = true;
-                }
+                    if (!find && LocalizerFactory.Create(rule.GetType()).TryGetLocalizerString(nameof(rule.ErrorMessage), out msg))
+                    {
+                        // 通过 Attribute 检索
+                        rule.ErrorMessage = msg;
+                        find = true;
+                    }
 
-                // 通过 字段.规则名称 检索
-                if (!context.ObjectType.Assembly.IsDynamic && !find
-                    && LocalizerFactory.Create(context.ObjectType).TryGetLocalizerString($"{memberName}.{ruleName.ToString()}", out msg))
-                {
-                    rule.ErrorMessage = msg;
-                    find = true;
+                    if (!find)
+                    {
+                        // 通过 字段.规则名称 检索
+                        // 查找 resource 资源文件中的 ErrorMessage
+                        var ruleNameSpan = rule.GetType().Name.AsSpan();
+                        var index = ruleNameSpan.IndexOf(attributeSpan, StringComparison.OrdinalIgnoreCase);
+                        var ruleName = ruleNameSpan[..index];
+                        if (LocalizerFactory.Create(context.ObjectType).TryGetLocalizerString($"{memberName}.{ruleName.ToString()}", out msg))
+                        {
+                            rule.ErrorMessage = msg;
+                            find = true;
+                        }
+                    }
                 }
 
                 if (!find)

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -419,7 +419,7 @@ public partial class ValidateForm
                         // 查找 resource 资源文件中的 ErrorMessage
                         var ruleNameSpan = rule.GetType().Name.AsSpan();
                         var index = ruleNameSpan.IndexOf(attributeSpan, StringComparison.OrdinalIgnoreCase);
-                        var ruleName = ruleNameSpan[..index];
+                        var ruleName = index == -1 ? ruleNameSpan[..] : ruleNameSpan[..index];
                         if (LocalizerFactory.Create(context.ObjectType).TryGetLocalizerString($"{memberName}.{ruleName.ToString()}", out msg))
                         {
                             rule.ErrorMessage = msg;


### PR DESCRIPTION
## Link issues
fixes #5745 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes changes to the `ValidateForm` component and its unit tests in order to improve validation logic and add new test coverage. The most important changes include refactoring the `ValidateDataAnnotations` method, adding a new test method, and introducing a custom validation rule.

Improvements to validation logic:

* [`src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs`](diffhunk://#diff-6233b9af9bc969209cff20f7ec9315ab3582586ca07f24a8c62558fe8c9a22f2L388-L391): Refactored the `ValidateDataAnnotations` method to streamline error message localization and improve readability. [[1]](diffhunk://#diff-6233b9af9bc969209cff20f7ec9315ab3582586ca07f24a8c62558fe8c9a22f2L388-L391) [[2]](diffhunk://#diff-6233b9af9bc969209cff20f7ec9315ab3582586ca07f24a8c62558fe8c9a22f2L403-R429)

Enhancements to unit tests:

* [`test/UnitTest/Components/ValidateFormTest.cs`](diffhunk://#diff-30d3a333b0ddf85222d1c7783b1aaa3a76ed02d18a2cf4956cc562d233db89a7R570-R590): Added a new test method `TestService_Ok` to verify custom validation rules without using the conventional `Attribute` suffix.
* [`test/UnitTest/Components/ValidateFormTest.cs`](diffhunk://#diff-30d3a333b0ddf85222d1c7783b1aaa3a76ed02d18a2cf4956cc562d233db89a7R762-R776): Introduced a new private class `TestValidateRule` for custom validation logic and updated the `HasService` class to include a property using this new rule.

Code cleanup:

* [`test/UnitTest/Components/ValidateFormTest.cs`](diffhunk://#diff-30d3a333b0ddf85222d1c7783b1aaa3a76ed02d18a2cf4956cc562d233db89a7L729-R750): Changed the visibility of the `Error` constant in the `HasServiceAttribute` class from `public` to `private`.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve validation logic in ValidateForm to support custom validation classes that do not end with 'Attribute'

Bug Fixes:
- Fixed localization logic for validation error messages to handle custom validation classes without the 'Attribute' suffix

Enhancements:
- Refactored validation error message retrieval to be more flexible with custom validation rule naming
- Improved support for localization of validation error messages

Tests:
- Added test case to verify custom validation rules without using the conventional 'Attribute' suffix
- Introduced a new test validation rule to demonstrate custom validation support

Chores:
- Changed visibility of an error constant in a test attribute class from public to private