### PR TITLE
feat(Slider): update style compatible with row

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.3</Version>
+    <Version>9.5.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Slider/Slider.razor.scss
+++ b/src/BootstrapBlazor/Components/Slider/Slider.razor.scss
@@ -1,7 +1,7 @@
-.row {
+﻿.row {
     --bb-form-range-margin-top: #{$bb-form-range-margin-top};
 
-    .form-range {
+    > div[class^="col-"] > .form-range {
         margin-block-start: var(--bb-form-range-margin-top);
     }
 }


### PR DESCRIPTION
## Link issues
fixes #5796 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes a version update and a modification to the CSS styling in the `Slider` component.

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from `9.5.3` to `9.5.4`.

CSS styling modification:

* [`src/BootstrapBlazor/Components/Slider/Slider.razor.scss`](diffhunk://#diff-3ab2184a3478cb37c5ba84d366520fb714f7dfdba5c8e5f4c492d8f01281785bL1-R4): Changed the `.form-range` selector to apply styles only to direct children of `div` elements with class names starting with "col-".

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update Slider component styling to be more compatible with row layouts by refining CSS selector specificity

New Features:
- Modify Slider component's CSS to apply margin only to form range inputs within column-based row layouts

Enhancements:
- Improve CSS selector precision for Slider component's styling within grid systems