### PR TITLE
feat(DateTimeRange): add AutoClose parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/DateTimeRanges.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/DateTimeRanges.razor
@@ -39,7 +39,7 @@
             <DateTimeRange @bind-Value="@BindValueDemoDateTimeRangeValue" OnValueChanged="v => BindValueDemoOnValueChanged(v, 1)"
                            ShowLunar="_showLunar" ShowSolarTerm="_showSolarTerm"
                            ShowFestivals="_showFestivals" ShowHolidays="_showHolidays"
-                           ShowSelectedValue="true"></DateTimeRange>
+                           ShowSelectedValue="true" AutoClose="true"></DateTimeRange>
         </div>
         <div class="col-12 col-sm-6">
             <BootstrapInputGroup>

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3987,7 +3987,7 @@
     "NormalTitle": "Basic skills",
     "NormalIntro": "Take 'day' as the basic unit, select a period of time",
     "BindValueTitle": "Data two-way binding",
-    "BindValueIntro": "Click the confirm button, the time selection box value is the same as the text box value",
+    "BindValueIntro": "Click the confirm button, the time selection box value is the same as the text box value. Enable auto-close by setting <code>AutoClose=\"true\"</code>. Directly display the selected value by setting <code>ShowSelectedValue=\"true\"</code>",
     "MaxMinValueTitle": "Max and Min",
     "MaxMinValueIntro": "set time range",
     "DisabledTitle": "Disabled",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3987,7 +3987,7 @@
     "NormalTitle": "基本功能",
     "NormalIntro": "以「日」为基本单位，选择一段时间",
     "BindValueTitle": "数据双向绑定",
-    "BindValueIntro": "点击确认按钮时间选择框值与文本框值一致",
+    "BindValueIntro": "点击确认按钮时间选择框值与文本框值一致，通过设置 <code>AutoClose=\"true\"</code> 实现自动关闭功能，通过设置 <code>ShowSelectedValue=\"true\"</code> 直接显示选中值",
     "MaxMinValueTitle": "最大值和最小值",
     "MaxMinValueIntro": "设置时间的取值范围",
     "DisabledTitle": "禁用",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.4</Version>
+    <Version>9.5.5</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
@@ -102,6 +102,12 @@ public partial class DateTimeRange
     public bool AutoCloseClickSideBar { get; set; }
 
     /// <summary>
+    /// Gets or sets whether to auto close the popup when the user selected range value. Default is false.
+    /// </summary>
+    [Parameter]
+    public bool AutoClose { get; set; }
+
+    /// <summary>
     /// Gets or sets whether show the selected value. Default is false.
     /// </summary>
     [Parameter]
@@ -509,7 +515,15 @@ public partial class DateTimeRange
         {
             await OnDateClick(d);
         }
-        StateHasChanged();
+
+        if (AutoClose && SelectedValue.Start != DateTime.MinValue && SelectedValue.End != DateTime.MinValue)
+        {
+            await ClickConfirmButton();
+        }
+        else
+        {
+            StateHasChanged();
+        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
@@ -102,7 +102,7 @@ public partial class DateTimeRange
     public bool AutoCloseClickSideBar { get; set; }
 
     /// <summary>
-    /// Gets or sets whether to auto close the popup when the user selected range value. Default is false.
+    /// Gets or sets whether to automatically close the popup after a date range is selected. Default is false.
     /// </summary>
     [Parameter]
     public bool AutoClose { get; set; }

--- a/test/UnitTest/Components/DateTimeRangeTest.cs
+++ b/test/UnitTest/Components/DateTimeRangeTest.cs
@@ -79,8 +79,15 @@ public class DateTimeRangeTest : BootstrapBlazorTestBase
     public async Task RangeValue_Ok()
     {
         var val = DateTime.Today;
+        var confirmValue = new DateTimeRangeValue();
         var cut = Context.RenderComponent<DateTimeRange>(pb =>
         {
+            pb.Add(a => a.OnConfirm, v =>
+            {
+                confirmValue = v;
+                return Task.CompletedTask;
+            });
+            pb.Add(a => a.AutoClose, true);
             pb.Add(a => a.ShowSelectedValue, true);
             pb.Add(a => a.OnDateClick, d =>
             {
@@ -113,12 +120,9 @@ public class DateTimeRangeTest : BootstrapBlazorTestBase
         input = inputs[1];
         Assert.Equal(start.ToString("yyyy-MM-dd"), input.GetAttribute("value"));
 
-        // confirm
-        var confirm = cut.FindAll(".is-confirm")[cut.FindAll(".is-confirm").Count - 1];
-        await cut.InvokeAsync(() =>
-        {
-            confirm.Click();
-        });
+        // 由于设置了 AutoClose 属性所以这里不需要点击确定按钮
+        Assert.Equal(val, confirmValue.Start);
+        Assert.Equal(start, confirmValue.End.Date);
 
         var value = cut.Instance.Value;
         var startDate = DateTime.Today.AddDays(1 - DateTime.Today.Day).AddMonths(-1);


### PR DESCRIPTION
## Link issues
fixes #5801 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces new functionality to the `DateTimeRange` component, including the ability to automatically close the popup when a date range is selected. It also updates the documentation and tests to reflect these changes.

Enhancements to `DateTimeRange` component:

* [`src/BootstrapBlazor.Server/Components/Samples/DateTimeRanges.razor`](diffhunk://#diff-8a9ddabfaec518d51b69ef44f288fe3cde986d640e467a820ba15c90c025fe28L42-R42): Added the `AutoClose` attribute to enable automatic closing of the popup when a date range is selected.
* [`src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs`](diffhunk://#diff-56650ea31e9c329be4965f4238a0c70896cf7cc399201fb5cf83b69929c48667R104-R109): Introduced the `AutoClose` parameter and updated the `UpdateValue` method to close the popup automatically if the `AutoClose` attribute is set to true and both start and end dates are selected. [[1]](diffhunk://#diff-56650ea31e9c329be4965f4238a0c70896cf7cc399201fb5cf83b69929c48667R104-R109) [[2]](diffhunk://#diff-56650ea31e9c329be4965f4238a0c70896cf7cc399201fb5cf83b69929c48667R518-R527)

Documentation updates:

* [`src/BootstrapBlazor.Server/Locales/en-US.json`](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L3990-R3990): Updated the `BindValueIntro` to include information about the new `AutoClose` attribute.
* [`src/BootstrapBlazor.Server/Locales/zh-CN.json`](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL3990-R3990): Updated the `BindValueIntro` to include information about the new `AutoClose` attribute.

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Incremented the version number from 9.5.4 to 9.5.5.

Test updates:

* [`test/UnitTest/Components/DateTimeRangeTest.cs`](diffhunk://#diff-7acd40333c50e11eb2b04d358025d1b6f83c4e0ebf00afcbd545e8b42c8eed06R82-R90): Added tests to verify the functionality of the `AutoClose` attribute, ensuring the popup closes automatically upon date selection. [[1]](diffhunk://#diff-7acd40333c50e11eb2b04d358025d1b6f83c4e0ebf00afcbd545e8b42c8eed06R82-R90) [[2]](diffhunk://#diff-7acd40333c50e11eb2b04d358025d1b6f83c4e0ebf00afcbd545e8b42c8eed06L116-R125)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add AutoClose parameter to DateTimeRange component to automatically close the popup when a date range is selected

New Features:
- Introduce an AutoClose parameter for DateTimeRange component that automatically closes the popup when both start and end dates are selected

Enhancements:
- Update UpdateValue method to support automatic popup closing based on AutoClose parameter

Documentation:
- Update documentation to include information about the new AutoClose attribute

Tests:
- Add test cases to verify the AutoClose functionality of the DateTimeRange component