### PR TITLE
fix(Select): make sure show the right display text

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.5</Version>
+    <Version>9.5.6-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -156,6 +156,8 @@ public partial class Select<TValue> : ISelect, ILookup
 
     private ItemsProviderResult<SelectedItem> _result;
 
+    private string _defaultVirtualizedItemText = "";
+
     private SelectedItem? SelectedItem { get; set; }
 
     private SelectedItem? SelectedRow
@@ -175,7 +177,7 @@ public partial class Select<TValue> : ISelect, ILookup
             return null;
         }
 
-        var item = IsVirtualize ? GetItemByVirtulized() : GetItemByRows();
+        var item = IsVirtualize ? GetItemByVirtualized() : GetItemByRows();
         if (item != null)
         {
             if (_init && DisableItemChangedWhenFirstRender)
@@ -193,7 +195,7 @@ public partial class Select<TValue> : ISelect, ILookup
 
     private SelectedItem? GetItemWithEnumValue() => ValueType.IsEnum ? Rows.Find(i => i.Value == Convert.ToInt32(Value).ToString()) : null;
 
-    private SelectedItem GetItemByVirtulized() => new(CurrentValueAsString, DefaultVirtualizeItemText ?? CurrentValueAsString);
+    private SelectedItem GetItemByVirtualized() => new(CurrentValueAsString, _defaultVirtualizedItemText);
 
     private SelectedItem? GetItemByRows()
     {
@@ -202,6 +204,16 @@ public partial class Select<TValue> : ISelect, ILookup
             ?? Rows.Find(i => i.Active)
             ?? Rows.FirstOrDefault(i => !i.IsDisabled);
         return item;
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        _defaultVirtualizedItemText = DefaultVirtualizeItemText ?? CurrentValueAsString;
     }
 
     /// <summary>
@@ -363,6 +375,7 @@ public partial class Select<TValue> : ISelect, ILookup
         }
         if (ret)
         {
+            _defaultVirtualizedItemText = item.Text;
             await SelectedItemChanged(item);
         }
     }

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -761,7 +761,7 @@ public class SelectTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void DefaultVirtualizeItemText_Ok()
+    public void DefaultVirtualizeItemText_Null()
     {
         var cut = Context.RenderComponent<Select<string>>(pb =>
         {
@@ -776,12 +776,33 @@ public class SelectTest : BootstrapBlazorTestBase
 
         var input = cut.Find(".form-select");
         Assert.Contains("value=\"3\"", input.OuterHtml);
+    }
 
-        cut.SetParametersAndRender(pb =>
+    [Fact]
+    public async Task DefaultVirtualizeItemText_Ok()
+    {
+        var cut = Context.RenderComponent<Select<string>>(pb =>
         {
+            pb.Add(a => a.Items, new SelectedItem[]
+            {
+                new("1", "Test1"),
+                new("2", "Test2")
+            });
+            pb.Add(a => a.Value, "3");
+            pb.Add(a => a.IsVirtualize, true);
             pb.Add(a => a.DefaultVirtualizeItemText, "Test3");
         });
+
+        var input = cut.Find(".form-select");
         Assert.Contains("value=\"Test3\"", input.OuterHtml);
+
+        var items = cut.FindAll(".dropdown-item");
+        Assert.Equal(2, items.Count);
+
+        var item = items[1];
+        await cut.InvokeAsync(() => item.Click());
+        input = cut.Find(".form-select");
+        Assert.Contains("value=\"Test2\"", input.OuterHtml);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #5805 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes several updates to the `Select` component in the `BootstrapBlazor` library, as well as corresponding unit tests. The most important changes involve fixing a typo in method names, adding a new private field, and updating the logic for handling virtualized items.

### Updates to `Select` component:

* [`src/BootstrapBlazor/Components/Select/Select.razor.cs`](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bR159-R160): Added a new private field `_defaultVirtualizedItemText` to store the default text for virtualized items.
* [`src/BootstrapBlazor/Components/Select/Select.razor.cs`](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bL178-R180): Fixed a typo in the method name `GetItemByVirtulized` to `GetItemByVirtualized`. [[1]](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bL178-R180) [[2]](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bL196-R198)
* [`src/BootstrapBlazor/Components/Select/Select.razor.cs`](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bR209-R218): Updated the `OnInitialized` method to set `_defaultVirtualizedItemText` based on `DefaultVirtualizeItemText` or `CurrentValueAsString`.
* [`src/BootstrapBlazor/Components/Select/Select.razor.cs`](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bR378): Modified the `OnClickItem` method to update `_defaultVirtualizedItemText` when an item is clicked.

### Unit tests:

* [`test/UnitTest/Components/SelectTest.cs`](diffhunk://#diff-2a7e710fa9625ec63c6ad1977036da3e8312516ee2654426f683ec39ea33ae22L764-R764): Renamed the test method `DefaultVirtualizeItemText_Ok` to `DefaultVirtualizeItemText_Null` and added a new test method `DefaultVirtualizeItemText_Ok` to verify the behavior of virtualized items. [[1]](diffhunk://#diff-2a7e710fa9625ec63c6ad1977036da3e8312516ee2654426f683ec39ea33ae22L764-R764) [[2]](diffhunk://#diff-2a7e710fa9625ec63c6ad1977036da3e8312516ee2654426f683ec39ea33ae22R779-R805)

### Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the version from `9.5.5` to `9.5.6-beta01`.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve the Select component's handling of virtualized items by fixing display text logic and method naming

New Features:
- Implement more robust handling of default text for virtualized Select items

Bug Fixes:
- Correct the display text for virtualized Select items when no default text is provided
- Fix a typo in the method name from 'GetItemByVirtulized' to 'GetItemByVirtualized'

Enhancements:
- Add a new private field to manage default virtualized item text
- Update item selection logic for virtualized Select components

Tests:
- Add comprehensive test cases for DefaultVirtualizeItemText behavior
- Verify virtualized item selection and display logic