### PR TITLE
fix(Table): should show the Toast when not set BootstrapBlazorOption ToastDelay

### DIFF
--- a/src/BootstrapBlazor/Components/Message/MessageService.cs
+++ b/src/BootstrapBlazor/Components/Message/MessageService.cs
@@ -22,7 +22,7 @@ public class MessageService(IOptionsMonitor<BootstrapBlazorOptions> option) : Bo
     {
         if (!option.ForceDelay)
         {
-            if (Options.MessageDelay != 0)
+            if (Options.MessageDelay > 0)
             {
                 option.Delay = Options.MessageDelay;
             }

--- a/src/BootstrapBlazor/Components/SweetAlert/SwalService.cs
+++ b/src/BootstrapBlazor/Components/SweetAlert/SwalService.cs
@@ -17,7 +17,7 @@ public class SwalService(IOptionsMonitor<BootstrapBlazorOptions> options) : Boot
     /// <param name="swal">指定弹窗组件 默认为 null 使用 <see cref="BootstrapBlazorRoot"/> 组件内置弹窗组件</param>
     public async Task Show(SwalOption option, SweetAlert? swal = null)
     {
-        if (!option.ForceDelay && options.CurrentValue.SwalDelay != 0)
+        if (!option.ForceDelay && options.CurrentValue.SwalDelay > 0)
         {
             option.Delay = options.CurrentValue.SwalDelay;
         }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Localization.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Localization.cs
@@ -303,13 +303,6 @@ public partial class Table<TItem>
     public string? SaveButtonToastResultContent { get; set; }
 
     /// <summary>
-    /// Gets or sets the toast delay in milliseconds. Default is 4000ms.
-    /// </summary>
-    [Parameter]
-    [NotNull]
-    public int ToastDelay { get; set; } = 4000;
-
-    /// <summary>
     /// 获得/设置 保存成功文字
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Localization.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Localization.cs
@@ -303,6 +303,13 @@ public partial class Table<TItem>
     public string? SaveButtonToastResultContent { get; set; }
 
     /// <summary>
+    /// Gets or sets the toast delay in milliseconds. Default is 4000ms.
+    /// </summary>
+    [Parameter]
+    [NotNull]
+    public int ToastDelay { get; set; } = 4000;
+
+    /// <summary>
     /// 获得/设置 保存成功文字
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -1158,11 +1158,10 @@ public partial class Table<TItem>
         var option = new ToastOption()
         {
             Title = title,
-            Delay = Options.CurrentValue.ToastDelay
         };
-        if (option.Delay == 0)
+        if (Options.CurrentValue.ToastDelay > 0)
         {
-            option.Delay = Math.Max(1000, ToastDelay);
+            option.Delay = Options.CurrentValue.ToastDelay;
         }
         return option;
     }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -1153,11 +1153,19 @@ public partial class Table<TItem>
         }
     }
 
-    private ToastOption GetToastOption(string title) => new()
+    private ToastOption GetToastOption(string title)
     {
-        Title = title,
-        Delay = Options.CurrentValue.ToastDelay
-    };
+        var option = new ToastOption()
+        {
+            Title = title,
+            Delay = Options.CurrentValue.ToastDelay
+        };
+        if (option.Delay == 0)
+        {
+            option.Delay = Math.Max(1000, ToastDelay);
+        }
+        return option;
+    }
 
     private Task ExportAsync() => ExecuteExportAsync(() => OnExportAsync != null
         ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Unknown, Rows, GetVisibleColumns(), BuildQueryPageOptions()))

--- a/test/UnitTest/Components/TableDialogTest.cs
+++ b/test/UnitTest/Components/TableDialogTest.cs
@@ -24,7 +24,6 @@ public class TableDialogTest : TableDialogTestBase
         {
             pb.AddChildContent<Table<Foo>>(pb =>
             {
-                pb.Add(a => a.ToastDelay, 4000);
                 pb.Add(a => a.RenderMode, TableRenderMode.Table);
                 pb.Add(a => a.Items, items);
                 pb.Add(a => a.EditDialogIsDraggable, true);

--- a/test/UnitTest/Components/TableDialogTest.cs
+++ b/test/UnitTest/Components/TableDialogTest.cs
@@ -6,6 +6,7 @@
 using AngleSharp.Dom;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Localization;
+using Microsoft.Extensions.Options;
 using System.Reflection;
 
 namespace UnitTest.Components;
@@ -15,12 +16,15 @@ public class TableDialogTest : TableDialogTestBase
     [Fact]
     public async Task EditAsync_Ok()
     {
+        var options = Context.Services.GetRequiredService<IOptionsMonitor<BootstrapBlazorOptions>>();
+        options.CurrentValue.ToastDelay = 0;
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var items = Foo.GenerateFoo(localizer, 2);
         var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
             pb.AddChildContent<Table<Foo>>(pb =>
             {
+                pb.Add(a => a.ToastDelay, 4000);
                 pb.Add(a => a.RenderMode, TableRenderMode.Table);
                 pb.Add(a => a.Items, items);
                 pb.Add(a => a.EditDialogIsDraggable, true);


### PR DESCRIPTION
## Link issues
fixes #5809 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes several changes to improve the handling of delay options in various components and adds a necessary dependency in the unit tests. The most important changes include modifying the delay condition checks in `MessageService` and `SwalService`, updating the `GetToastOption` method in `Table.razor.Toolbar.cs`, and adding the `IOptionsMonitor` dependency in `TableDialogTest`.

Improvements to delay handling:

* [`src/BootstrapBlazor/Components/Message/MessageService.cs`](diffhunk://#diff-144e45c279edb84ee5e05da093e73b33d81dc3c3b0ffc62744164a508423f694L25-R25): Changed the condition to check if `Options.MessageDelay` is greater than 0 instead of not equal to 0.
* [`src/BootstrapBlazor/Components/SweetAlert/SwalService.cs`](diffhunk://#diff-600f3b97775937217ea50a929becc0c22c73692a1cb75612e82d6588d0678700L20-R20): Modified the condition to check if `options.CurrentValue.SwalDelay` is greater than 0 instead of not equal to 0.
* [`src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs`](diffhunk://#diff-ca9e82d70b95de7204b56fbdace327d330eaef6777601f3d897b0e07c8c3eff8L1156-R1167): Updated the `GetToastOption` method to include a check for `Options.CurrentValue.ToastDelay` being greater than 0 before setting the delay.

Unit test improvements:

* [`test/UnitTest/Components/TableDialogTest.cs`](diffhunk://#diff-2f3363e3322eab5ff3203f5221c29d6c892bdb252e70f18068c3d5f031fc7d88R9): Added `Microsoft.Extensions.Options` using directive and injected `IOptionsMonitor<BootstrapBlazorOptions>` to set `ToastDelay` to 0 in the `EditAsync_Ok` test method. [[1]](diffhunk://#diff-2f3363e3322eab5ff3203f5221c29d6c892bdb252e70f18068c3d5f031fc7d88R9) [[2]](diffhunk://#diff-2f3363e3322eab5ff3203f5221c29d6c892bdb252e70f18068c3d5f031fc7d88R19-R20)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
