### PR TITLE
fix(AutoComplete): tabbing off AutoComplete field does not close its drop down 

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.6-beta03</Version>
+    <Version>9.5.6-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -41,14 +41,14 @@ export function init(id, invoke) {
     if (duration > 0) {
         ac.debounce = true
         EventHandler.on(input, 'keydown', debounce(e => {
-            handlerKeydown(e);
+            handlerKeydown(ac, e);
         }, duration, e => {
             return ['ArrowUp', 'ArrowDown', 'Escape', 'Enter', 'NumpadEnter'].indexOf(e.key) > -1
         }))
     }
     else {
         EventHandler.on(input, 'keydown', e => {
-            handlerKeydown(e);
+            handlerKeydown(ac, e);
         })
     }
 
@@ -166,7 +166,7 @@ const handlerKeyup = (ac, e) => {
     }
 }
 
-const handlerKeydown = e => {
+const handlerKeydown = (ac, e) => {
     if (e.key === 'Tab') {
         ac.triggerBlur();
     }


### PR DESCRIPTION
## Link issues
fixes #5815 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes updates to the version number in the project file and modifications to the `AutoComplete` component's JavaScript file to improve event handling.

Version update:

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Updated the project version from `9.5.6-beta03` to `9.5.6-beta04`.

Event handling improvements in `AutoComplete` component:

* [`src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js`](diffhunk://#diff-6e1f08721d40e940db1bd318cba31cf6cb4ea87287c9d6e263b005912b473bb8L44-R51): Modified the `handlerKeydown` function to accept `ac` (AutoComplete instance) as a parameter and updated the event handler calls to pass `ac` along with the event object. [[1]](diffhunk://#diff-6e1f08721d40e940db1bd318cba31cf6cb4ea87287c9d6e263b005912b473bb8L44-R51) [[2]](diffhunk://#diff-6e1f08721d40e940db1bd318cba31cf6cb4ea87287c9d6e263b005912b473bb8L169-R169)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
