### PR TITLE
refactor(AutoComplete): auto close dropdown box after press tab

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -106,8 +106,20 @@ export function init(id, invoke) {
             }
         });
     }
+    ac.blur = e => {
+        if (e.key === 'Tab') {
+            [...document.querySelectorAll('.auto-complete.show')].forEach(a => {
+                const id = a.getAttribute('id');
+                const d = Data.get(id);
+                if (d) {
+                    d.close();
+                }
+            });
+        }
+    }
     registerBootstrapBlazorModule('AutoComplete', id, () => {
         EventHandler.on(document, 'click', ac.closePopover);
+        EventHandler.on(document, 'keyup', ac.blur);
     });
 }
 
@@ -131,7 +143,7 @@ const handlerKeyup = (ac, e) => {
         }
     }
     else if (key === 'ArrowUp' || key === 'ArrowDown') {
-        el.classList.add('show');
+        ac.show();
         const items = [...menu.querySelectorAll('.dropdown-item')];
         let current = menu.querySelector('.active');
         if (current !== null) {
@@ -171,6 +183,7 @@ export function dispose(id) {
     const { AutoComplete } = window.BootstrapBlazor;
     AutoComplete.dispose(id, () => {
         EventHandler.off(document, 'click', ac.closePopover);
+        EventHandler.off(document, 'keyup', ac.blur);
     });
 }
 


### PR DESCRIPTION
## Link issues
fixes #5832 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request includes changes to the `AutoComplete` component in the `src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js` file to improve its behavior and functionality. The most important changes include adding a new blur event handler to close the auto-complete suggestions on tab key press, and updating the keyup event handler to use a method for showing suggestions.

Improvements to AutoComplete behavior:

* Added a new `blur` event handler to close the auto-complete suggestions when the tab key is pressed.
* Updated the keyup event handler to use the `ac.show()` method instead of directly adding the 'show' class.
* Modified the `dispose` function to remove the `keyup` event listener for the `blur` handler.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
