### PR TITLE
refactor(AutoComplete): update blur logic

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -12,7 +12,7 @@
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
            data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString" data-bb-trigger-delete="true"
-           @bind="@CurrentValueAsString" @onblur="@OnBlur"
+           @bind="@CurrentValueAsString"
            placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement"/>
     <span class="form-select-append"><i class="@Icon"></i></span>
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -130,6 +130,11 @@ public partial class AutoComplete
         {
             await OnSelectedItemChanged(val);
         }
+
+        if (OnBlurAsync != null)
+        {
+            await OnBlurAsync(Value);
+        }
     }
 
     private List<string> Rows => _filterItems ?? [.. Items];

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -121,7 +121,7 @@ export function init(id, invoke) {
         }
     }
 
-    ac.blur = function() {
+    ac.blur = function () {
         const { input, invoke } = this;
         const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
         if (triggerBlur) {
@@ -195,7 +195,7 @@ export function dispose(id) {
     const { AutoComplete } = window.BootstrapBlazor;
     AutoComplete.dispose(id, () => {
         EventHandler.off(document, 'click', ac.closePopover);
-        EventHandler.off(document, 'keyup', ac.blur);
+        EventHandler.off(document, 'keyup', ac.keyup);
     });
 }
 

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -9,7 +9,7 @@ export function init(id, invoke) {
     const el = document.getElementById(id)
     const menu = el.querySelector('.dropdown-menu')
     const input = document.getElementById(`${id}_input`)
-    const ac = { el, invoke, menu }
+    const ac = { el, invoke, menu, input }
     Data.set(id, ac)
 
     const isPopover = input.getAttribute('data-bs-toggle') === 'bb.dropdown';
@@ -102,24 +102,36 @@ export function init(id, invoke) {
                 const d = Data.get(id);
                 if (d) {
                     d.close();
+                    d.blur();
                 }
             }
         });
     }
-    ac.blur = e => {
+
+    ac.keyup = e => {
         if (e.key === 'Tab') {
             [...document.querySelectorAll('.auto-complete.show')].forEach(a => {
                 const id = a.getAttribute('id');
                 const d = Data.get(id);
                 if (d) {
                     d.close();
+                    d.blur();
                 }
             });
         }
     }
+
+    ac.blur = function() {
+        const { input, invoke } = this;
+        const triggerBlur = input.getAttribute('data-bb-blur') === 'true';
+        if (triggerBlur) {
+            invoke.invokeMethodAsync('TriggerBlur');
+        }
+    }
+
     registerBootstrapBlazorModule('AutoComplete', id, () => {
         EventHandler.on(document, 'click', ac.closePopover);
-        EventHandler.on(document, 'keyup', ac.blur);
+        EventHandler.on(document, 'keyup', ac.keyup);
     });
 }
 

--- a/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
@@ -163,4 +163,16 @@ public abstract class PopoverCompleteBase<TValue> : BootstrapInputBase<TValue>, 
     /// </summary>
     /// <returns></returns>
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop);
+
+    /// <summary>
+    /// 触发 OnBlur 回调方法 由 Javascript 触发
+    /// </summary>
+    [JSInvokable]
+    public async Task TriggerBlur()
+    {
+        if (OnBlurAsync != null)
+        {
+            await OnBlurAsync(Value);
+        }
+    }
 }

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -227,6 +227,11 @@ public partial class AutoFill<TValue>
         {
             await OnSelectedItemChanged(val);
         }
+
+        if (OnBlurAsync != null)
+        {
+            await OnBlurAsync(Value);
+        }
     }
 
     private string? GetDisplayText(TValue item) => OnGetDisplayText?.Invoke(item) ?? item?.ToString();

--- a/src/BootstrapBlazor/Components/Search/Search.razor.cs
+++ b/src/BootstrapBlazor/Components/Search/Search.razor.cs
@@ -169,7 +169,8 @@ public partial class Search<TValue>
     [NotNull]
     private List<TValue>? _filterItems = null;
 
-    private SearchContext<TValue> _context = default!;
+    [NotNull]
+    private SearchContext<TValue>? _context = null;
 
     [NotNull]
     private RenderTemplate? _dropdown = null;
@@ -266,6 +267,11 @@ public partial class Search<TValue>
         if (OnSelectedItemChanged != null)
         {
             await OnSelectedItemChanged(val);
+        }
+
+        if (OnBlurAsync != null)
+        {
+            await OnBlurAsync(Value);
         }
     }
 

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -258,7 +258,7 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
         var cut = Context.RenderComponent<AutoComplete>(pb =>
         {
             pb.Add(a => a.Items, items);
-            pb.Add(a => a.Value, "test1");
+            pb.Add(a => a.Value, "test2");
             pb.Add(a => a.OnBlurAsync, v =>
             {
                 val = v;
@@ -266,7 +266,10 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
             });
         });
         await cut.InvokeAsync(() => cut.Instance.TriggerBlur());
-        Assert.Equal("test1", val);
+        Assert.Equal("test2", val);
+
+        var item = cut.Find(".dropdown-item");
+        await cut.InvokeAsync(() => item.Click());
     }
 
     [Fact]

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -265,8 +265,7 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
                 return Task.CompletedTask;
             });
         });
-        var input = cut.Find(".form-control");
-        await cut.InvokeAsync(() => input.Blur());
+        await cut.InvokeAsync(() => cut.Instance.TriggerBlur());
         Assert.Equal("test1", val);
     }
 

--- a/test/UnitTest/Components/AutoFillTest.cs
+++ b/test/UnitTest/Components/AutoFillTest.cs
@@ -70,6 +70,27 @@ public class AutoFillTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task OnBlurAsync_Ok()
+    {
+        Foo? val = null;
+        var items = new List<Foo>() { new() { Name = "test1" }, new() { Name = "test2" } };
+        var cut = Context.RenderComponent<AutoFill<Foo>>(pb =>
+        {
+            pb.Add(a => a.Items, items);
+            pb.Add(a => a.OnBlurAsync, v =>
+            {
+                val = v;
+                return Task.CompletedTask;
+            });
+        });
+
+        var item = cut.Find(".dropdown-item");
+        await cut.InvokeAsync(() => item.Click());
+        Assert.NotNull(val);
+        Assert.Equal("test1", val.Name);
+    }
+
+    [Fact]
     public async Task OnCustomFilter_Ok()
     {
         var filtered = false;

--- a/test/UnitTest/Components/SearchTest.cs
+++ b/test/UnitTest/Components/SearchTest.cs
@@ -8,6 +8,32 @@ namespace UnitTest.Components;
 public class SearchTest : BootstrapBlazorTestBase
 {
     [Fact]
+    public async Task OnBlurAsync_Ok()
+    {
+        string? val = null;
+        var items = new List<string>() { "test1", "test2" };
+        var cut = Context.RenderComponent<Search<string>>(pb =>
+        {
+            pb.Add(a => a.OnSearch, v =>
+            {
+                return Task.FromResult(items.AsEnumerable());
+            });
+            pb.Add(a => a.OnBlurAsync, v =>
+            {
+                val = v;
+                return Task.CompletedTask;
+            });
+        });
+        await cut.InvokeAsync(() => cut.Instance.TriggerFilter("t"));
+        await Task.Delay(20);
+
+        var item = cut.Find(".dropdown-item");
+        await cut.InvokeAsync(() => item.Click());
+        Assert.NotNull(val);
+        Assert.Equal("test1", val);
+    }
+
+    [Fact]
     public void Items_Ok()
     {
         var cut = Context.RenderComponent<Search<string>>();


### PR DESCRIPTION
## Link issues
fixes #5837 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request enhances the `AutoComplete` component in the `BootstrapBlazor` library by adding support for a new `OnBlurAsync` callback and improving the handling of blur events. Key changes include updates to the Razor, C#, and JavaScript files to implement this functionality.

### Enhancements to blur event handling:

* **Razor file update (`AutoComplete.razor`)**: Removed the `@onblur` attribute from the Razor markup to centralize blur event handling through JavaScript and the new `OnBlurAsync` callback.

* **C# backend logic (`AutoComplete.razor.cs`)**: Added a check in the `OnClickItem` method to invoke the `OnBlurAsync` callback if it is defined, ensuring that blur events are triggered programmatically as needed.

* **JavaScript enhancements (`AutoComplete.razor.js`)**:
  - Updated the `init` function to include the input element in the `ac` object for easier access.
  - Introduced a new `blur` method in the `ac` object to handle blur events and invoke the `TriggerBlur` method on the C# side when the `data-bb-blur` attribute is set to `true`.
  - Replaced the `keyup` handler with a more specific implementation to ensure proper handling of the `Tab` key and blur events.

* **C# component base class (`PopoverCompleteBase.cs`)**: Added a `TriggerBlur` method marked with `[JSInvokable]` to allow JavaScript to invoke the `OnBlurAsync` callback when triggered.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor the AutoComplete component to improve blur event handling and add support for an OnBlurAsync callback

New Features:
- Added OnBlurAsync callback to trigger blur events programmatically

Enhancements:
- Centralized blur event handling through JavaScript and a new OnBlurAsync callback
- Improved input element access and event management in the AutoComplete component

Chores:
- Removed direct @onblur attribute from Razor markup
- Updated JavaScript event handling to support more precise blur triggers