### PR TITLE
feat(Table): add col-line-no style on Line column

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -133,7 +133,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         .Build();
 
     private string? LineCellClassString => CssBuilder.Default("table-cell")
-        .AddClass("table-col-line-no", IsExcel)
+        .AddClass("col-line-no")
         .AddClass(LineNoColumnAlignment.ToDescriptionString())
         .Build();
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -133,6 +133,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         .Build();
 
     private string? LineCellClassString => CssBuilder.Default("table-cell")
+        .AddClass("table-col-line-no", IsExcel)
         .AddClass(LineNoColumnAlignment.ToDescriptionString())
         .Build();
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.scss
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.scss
@@ -1,4 +1,4 @@
-.table-container {
+﻿.table-container {
     --bb-table-td-padding-x: .5rem;
     --bb-table-td-padding-y: .5rem;
     --bb-table-cardview-label-width: 30%;
@@ -751,6 +751,10 @@ form .table .table-cell > textarea {
 
 .table-excel > tbody > tr > td > .table-cell > .form-check {
     padding: 6px 8px;
+}
+
+.table-excel > tbody > tr > td > .col-line-no {
+    padding: 7px 0;
 }
 
 .table-excel .active > td > .table-cell .form-control,


### PR DESCRIPTION
## Link issues
fixes #5850 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces styling and class updates to the `Table` component in the `BootstrapBlazor` library. The changes primarily focus on adding a new class for line number columns and updating related styles.

### Updates to the `Table` component:

* **Class Addition for Line Number Columns**:
  - Added the `col-line-no` class to the `LineCellClassString` property in `Table.razor.cs` to enable specific styling for line number columns.

* **Styling Adjustments**:
  - Modified the `.table-container` class in `Table.razor.scss` (though the change appears to be a minor text encoding or formatting update).
  - Added new styles for the `.col-line-no` class within `.table-excel` to adjust padding for line number cells.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add styling for line number columns in the Table component

New Features:
- Introduced a new CSS class 'col-line-no' for line number columns in the Table component

Enhancements:
- Updated styling to provide specific padding for line number cells in excel-style tables