### PR TITLE
feat(SpeechWave): remove Task.Run support wpf

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.11-beta05</Version>
+    <Version>9.5.11-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/UnitTest/Components/RecognizerTest.cs
+++ b/test/UnitTest/Components/RecognizerTest.cs
@@ -102,7 +102,7 @@ public class RecognizerTest : SpeechTestBase
         var shown = GetShow(cut.Instance);
         Assert.True(shown);
 
-        token.Cancel();
+        GetToken(cut.Instance) = null;
         shown = GetShow(cut.Instance);
         Assert.False(shown);
     }

--- a/test/UnitTest/Components/RecognizerTest.cs
+++ b/test/UnitTest/Components/RecognizerTest.cs
@@ -108,7 +108,7 @@ public class RecognizerTest : SpeechTestBase
     }
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_token")]
-    static extern ref CancellationTokenSource GetToken(SpeechWave @this);
+    static extern ref CancellationTokenSource? GetToken(SpeechWave @this);
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_IsShow")]
     static extern bool GetShow(SpeechWave @this);

--- a/test/UnitTest/Components/RecognizerTest.cs
+++ b/test/UnitTest/Components/RecognizerTest.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using System.Runtime.CompilerServices;
+
 namespace UnitTest.Components;
 
 public class RecognizerTest : SpeechTestBase
@@ -79,8 +81,10 @@ public class RecognizerTest : SpeechTestBase
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.Show, true);
+            pb.Add(a => a.ShowUsedTime, false);
         });
-        await Task.Delay(500);
+        await Task.Delay(1200);
+
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.Show, false);
@@ -88,20 +92,24 @@ public class RecognizerTest : SpeechTestBase
     }
 
     [Fact]
-    public void IsCancelled_Ok()
+    public void Token_Ok()
     {
-        var cut = Context.RenderComponent<SpeechWave>();
-        var pi = cut.Instance.GetType().GetProperty("IsShow", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        var tokenPi = cut.Instance.GetType().GetProperty("Token", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-
-        Assert.False((bool?)pi?.GetValue(cut.Instance));
-
-        var token = new CancellationTokenSource();
-        tokenPi?.SetValue(cut.Instance, token);
-        Assert.True((bool?)pi?.GetValue(cut.Instance));
+        var cut = Context.RenderComponent<SpeechWave>(pb =>
+        {
+            pb.Add(a => a.Show, true);
+        });
+        var token = GetToken(cut.Instance);
+        var shown = GetShow(cut.Instance);
+        Assert.True(shown);
 
         token.Cancel();
-        Assert.False((bool?)pi?.GetValue(cut.Instance));
-        Context.DisposeComponents();
+        shown = GetShow(cut.Instance);
+        Assert.False(shown);
     }
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_token")]
+    static extern ref CancellationTokenSource GetToken(SpeechWave @this);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "get_IsShow")]
+    static extern bool GetShow(SpeechWave @this);
 }


### PR DESCRIPTION
## Link issues
fixes #5893 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove Task.Run from the SpeechWave component.

Enhancements:
- Refactor `SpeechWave` component to run its timer logic asynchronously without `Task.Run`.
- Optimize rendering by calling `StateHasChanged` conditionally within the timer loop.
- Convert `OnParametersSet` to `OnParametersSetAsync`.

Tests:
- Update `SpeechWave` tests to align with asynchronous changes.
- Use `UnsafeAccessor` instead of reflection for accessing private members in tests.