### PR TITLE
feat(BootstrapInputGroupLabel): add ChildContent parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor
@@ -4,10 +4,26 @@
 @if (IsInputGroupLabel)
 {
     <div @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString" required="@Required">
-        <span>@DisplayText</span>
+        @if (ChildContent != null)
+        {
+            @ChildContent
+        }
+        else
+        {
+            <span>@DisplayText</span>
+        }
     </div>
 }
 else
 {
-    <label @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString" required="@Required">@DisplayText</label>
+    <label @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString" required="@Required">
+        @if (ChildContent != null)
+        {
+            @ChildContent
+        }
+        else
+        {
+            @DisplayText
+        }
+    </label>
 }

--- a/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs
+++ b/src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs
@@ -41,6 +41,12 @@ public partial class BootstrapInputGroupLabel
     [Parameter]
     public bool ShowRequiredMark { get; set; }
 
+    /// <summary>
+    /// Gets or sets the child content. Default is null.
+    /// </summary>
+    [Parameter]
+    public RenderFragment? ChildContent { get; set; }
+
     private string? Required => ShowRequiredMark ? "true" : null;
 
     private bool IsInputGroupLabel => InputGroup != null;

--- a/test/UnitTest/Components/InputTest.cs
+++ b/test/UnitTest/Components/InputTest.cs
@@ -273,6 +273,13 @@ public class InputTest : BootstrapBlazorTestBase
         });
 
         Assert.Contains("DisplayText", cut.Markup);
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.ChildContent, builder => builder.AddContent(0, "test-child-content"));
+        });
+        cut.Contains("test-child-content");
+        cut.DoesNotContain("DisplayText");
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #5904 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces support for custom child content in the `BootstrapInputGroupLabel` component, allowing more flexibility in rendering its content. The key changes include updates to the Razor file, the component's parameters, and corresponding unit tests.

### Component Enhancements:

* [`src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor`](diffhunk://#diff-8612abd05bda9c0329ea9e4f1da70838addfcb73b0da0a0a05db906962d6884aR7-R28): Updated the rendering logic to check for `ChildContent`. If `ChildContent` is provided, it will be rendered; otherwise, the fallback `DisplayText` is displayed. This applies to both `<div>` and `<label>` elements.

* [`src/BootstrapBlazor/Components/Input/BootstrapInputGroupLabel.razor.cs`](diffhunk://#diff-61f3315d6e3a3f3fe530684df763c286b9dc34f6a752123119c373fd51973ec8R44-R49): Added a new `[Parameter]` property, `ChildContent`, of type `RenderFragment?`, enabling users to pass custom content to the component.

### Testing Enhancements:

* [`test/UnitTest/Components/InputTest.cs`](diffhunk://#diff-a974f944af6525d686090a811b00fc18a637609188ed638ce4f3ac81c0c7e947R276-R282): Enhanced the `GroupLabel_Ok` test to verify the behavior of the `ChildContent` parameter. The test ensures that when `ChildContent` is set, it is rendered instead of `DisplayText`.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Allow custom content within the `BootstrapInputGroupLabel` component.

New Features:
- Add a `ChildContent` parameter to `BootstrapInputGroupLabel` to enable rendering custom content instead of the default `DisplayText`.
- Update the component's rendering logic to prioritize `ChildContent` over `DisplayText` when provided.

Tests:
- Update unit tests to verify the rendering behavior when `ChildContent` is provided.