### PR TITLE
feat(LayoutSpitBar): rename LayoutSplitBar component name

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor
@@ -10,7 +10,7 @@
             <span class="sidebar-text">Bootstrap Blazor</span>
         </div>
         <NavMenu />
-        <LayoutSplitebar Min="250" Max="380" ContainerSelector=".section"></LayoutSplitebar>
+        <LayoutSplitBar Min="250" Max="380" ContainerSelector=".section"></LayoutSplitBar>
     </aside>
 
     <section class="main">

--- a/src/BootstrapBlazor.Server/Components/Layout/TutorialsLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/TutorialsLayout.razor
@@ -9,7 +9,7 @@
         </div>
         <TutorialsNavMenu></TutorialsNavMenu>
         <Wwads IsVertical="true"></Wwads>
-        <LayoutSplitebar Min="220" Max="330" ContainerSelector=".section"></LayoutSplitebar>
+        <LayoutSplitBar Min="220" Max="330" ContainerSelector=".section"></LayoutSplitBar>
     </aside>
 
     <section class="main">

--- a/src/BootstrapBlazor.Server/Components/Samples/Layouts.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Layouts.razor.cs
@@ -141,8 +141,8 @@ public sealed partial class Layouts
         },
         new()
         {
-            Name = "ShowSplitebar",
-            Description =  Localizer["Layouts_ShowSplitebar_Description"],
+            Name = "ShowSplitBar",
+            Description =  Localizer["Layouts_ShowSplitBar_Description"],
             Type = "bool",
             ValueList = "true|false",
             DefaultValue = "false"

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -1424,7 +1424,7 @@
     "Layouts_IsFixedFooter_Description": "Whether to fix the Footer component",
     "Layouts_IsFixedHeader_Description": "Whether to fix the Header component",
     "Layouts_ShowCollapseBar_Description": "Whether to show contraction and expansion Bar",
-    "Layouts_ShowSplitebar_Description": "Whether to display the left and right split bar",
+    "Layouts_ShowSplitBar_Description": "Whether to display the left and right split bar",
     "Layouts_SidebarMinWidth_Description": "Minimum sidebar width",
     "Layouts_SidebarMaxWidth_Description": "Maximum sidebar width",
     "Layouts_ShowFooter_Description": "Whether to show Footer template",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -1424,7 +1424,7 @@
     "Layouts_IsFixedFooter_Description": "是否固定 Footer 组件",
     "Layouts_IsFixedHeader_Description": "是否固定 Header 组件",
     "Layouts_ShowCollapseBar_Description": "是否显示收缩展开 Bar",
-    "Layouts_ShowSplitebar_Description": "是否显示左右分割栏",
+    "Layouts_ShowSplitBar_Description": "是否显示左右分割栏",
     "Layouts_SidebarMinWidth_Description": "侧边栏最小宽度",
     "Layouts_SidebarMaxWidth_Description": "侧边栏最大宽度",
     "Layouts_ShowFooter_Description": "是否显示 Footer 模板",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.5.13-beta01</Version>
+    <Version>9.5.13-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor
@@ -96,7 +96,7 @@
         }
         @if (ShowSplitBar)
         {
-            <LayoutSplitebar Min="SidebarMinWidth" Max="SidebarMaxWidth"></LayoutSplitebar>
+            <LayoutSplitBar Min="SidebarMinWidth" Max="SidebarMaxWidth"></LayoutSplitBar>
         }
         @if (Menus != null)
         {

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor
@@ -94,7 +94,7 @@
         {
             @Side
         }
-        @if (ShowSplitebar)
+        @if (ShowSplitBar)
         {
             <LayoutSplitebar Min="SidebarMinWidth" Max="SidebarMaxWidth"></LayoutSplitebar>
         }

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -500,7 +500,7 @@ public partial class Layout : IHandlerException, ITabHeader
             // wasm 模式下 开启权限必须提供 AdditionalAssemblies 参数
             AdditionalAssemblies ??= [Assembly.GetEntryAssembly()!];
 
-            var uri= Navigation.ToAbsoluteUri(Navigation.Uri);
+            var uri = Navigation.ToAbsoluteUri(Navigation.Uri);
             var context = RouteTableFactory.Create(AdditionalAssemblies, uri.LocalPath);
             if (context.Handler != null)
             {

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -130,6 +130,15 @@ public partial class Layout : IHandlerException, ITabHeader
     /// 仅在 左右布局时有效
     /// </summary>
     [Parameter]
+    public bool ShowSplitBar { get; set; }
+
+    /// <summary>
+    /// 获得/设置 是否显示分割栏 默认 false 不显示
+    /// 仅在 左右布局时有效
+    /// </summary>
+    [Parameter]
+    [ExcludeFromCodeCoverage]
+    [Obsolete("已弃用，请使用 ShowSplitBar 单词拼写错误；Deprecated, please use ShowSplitBar The word is misspelled")]
     public bool ShowSplitebar { get; set; }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -138,7 +138,7 @@ public partial class Layout : IHandlerException, ITabHeader
     /// </summary>
     [Parameter]
     [ExcludeFromCodeCoverage]
-    [Obsolete("已弃用，请使用 ShowSplitBar 单词拼写错误；Deprecated, please use ShowSplitBar The word is misspelled")]
+    [Obsolete("已弃用，请使用 ShowSplitBar 单词拼写错误；Deprecated. Please use 'ShowSplitBar' instead. The word 'Splitebar' is misspelled.")]
     public bool ShowSplitebar { get; set; }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor
+++ b/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor
@@ -1,8 +1,8 @@
 ﻿@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
-@attribute [BootstrapModuleAutoLoader("Layout/LayoutSplitebar.razor.js")]
+@attribute [BootstrapModuleAutoLoader("Layout/LayoutSplitBar.razor.js")]
 
-<div id="@Id" class="layout-splitebar"
+<div id="@Id" class="layout-split-bar"
      data-bb-min="@_minWidthString" data-bb-max="@_maxWidthString" data-bb-selector="@ContainerSelector">
-    <div class="layout-splitebar-body"></div>
+    <div class="layout-split-bar-body"></div>
 </div>

--- a/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.cs
@@ -8,7 +8,7 @@ namespace BootstrapBlazor.Components;
 /// <summary>
 /// LayoutSidebar 组件
 /// </summary>
-public partial class LayoutSplitebar
+public partial class LayoutSplitBar
 {
     /// <summary>
     /// 获得/设置 容器选择器 默认 null 未设置

--- a/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.js
+++ b/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.js
@@ -11,11 +11,11 @@ export function init(id) {
     const selector = el.getAttribute("data-bb-selector") ?? ".layout";
     const section = document.querySelector(selector);
     if (section === null) {
-        log.warning(`LayoutSplitebar: selector ${selector} not found`);
+        log.warning(`LayoutSplitBar: selector ${selector} not found`);
         return;
     }
 
-    const bar = el.querySelector(".layout-splitebar-body");
+    const bar = el.querySelector(".layout-split-bar-body");
     let originX = 0;
     let width = 0;
     Drag.drag(bar,
@@ -50,7 +50,7 @@ export function init(id) {
 export function dispose(id) {
     const el = document.getElementById(id);
     if (el) {
-        const bar = el.querySelector(".layout-splitebar-body");
+        const bar = el.querySelector(".layout-split-bar-body");
         if (bar) {
             Drag.dispose(bar);
         }

--- a/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.scss
+++ b/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.scss
@@ -1,4 +1,4 @@
-.layout-splitebar {
+﻿.layout-split-bar {
     width: 1px;
     position: absolute;
     top: 0;
@@ -7,9 +7,9 @@
     background-color: var(--bs-border-color);
     display: none;
 
-    .layout-splitebar-body {
-        --bb-splitebar-body-hover-bg: #{$bb-splitebar-body-hover-bg};
-        --bb-splitebar-body-drag-hover-bg: #{$bb-splitebar-body-drag-hover-bg};
+    .layout-split-bar-body {
+        --bb-split-bar-body-hover-bg: #{$bb-split-bar-body-hover-bg};
+        --bb-split-bar-body-drag-hover-bg: #{$bb-split-bar-body-drag-hover-bg};
         position: absolute;
         inset: 0px -2px;
         cursor: col-resize;
@@ -18,27 +18,27 @@
         transition: background .3s linear;
 
         &:hover {
-            background-color: var(--bb-splitebar-body-hover-bg);
+            background-color: var(--bb-split-bar-body-hover-bg);
         }
     }
 }
 
 .drag {
-    .layout-splitebar {
-        .layout-splitebar-body:hover {
-            background-color: var(--bb-splitebar-body-drag-hover-bg);
+    .layout-split-bar {
+        .layout-split-bar-body:hover {
+            background-color: var(--bb-split-bar-body-drag-hover-bg);
         }
     }
 }
 
 .is-collapsed {
-    .layout-splitebar-body {
+    .layout-split-bar-body {
         display: none;
     }
 }
 
 @media(min-width: 768px) {
-    .layout-splitebar {
+    .layout-split-bar {
         display: block;
     }
 }

--- a/src/BootstrapBlazor/wwwroot/scss/components.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/components.scss
@@ -60,7 +60,7 @@
 @import "../../Components/Input/OtpInput.razor.scss";
 @import "../../Components/IpAddress/IpAddress.razor.scss";
 @import "../../Components/Layout/Layout.razor.scss";
-@import "../../Components/Layout/LayoutSplitebar.razor.scss";
+@import "../../Components/Layout/LayoutSplitBar.razor.scss";
 @import "../../Components/Light/Light.razor.scss";
 @import "../../Components/ListGroup/ListGroup.razor.scss";
 @import "../../Components/ListView/ListView.razor.scss";

--- a/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
@@ -347,9 +347,9 @@ $bb-layout-menu-item-hover-bg: #409eff;
 $bb-layout-logo-border-color: #d5d5d5;
 $bb-layout-logo-bg: #0e77e3;
 
-// LayoutSplitebar
-$bb-splitebar-body-hover-bg: rgba(175, 184, 193, 0.2);
-$bb-splitebar-body-drag-hover-bg: rgb(9, 105, 218);
+// LayoutSplitBar
+$bb-split-bar-body-hover-bg: rgba(175, 184, 193, 0.2);
+$bb-split-bar-body-drag-hover-bg: rgb(9, 105, 218);
 
 // Light
 $bb-light-bg: radial-gradient(circle, #fff, #aaa, #333);

--- a/test/UnitTest/Components/LayoutSplitebarTest.cs
+++ b/test/UnitTest/Components/LayoutSplitebarTest.cs
@@ -5,12 +5,12 @@
 
 namespace UnitTest.Components;
 
-public class LayoutSplitebarTest : BootstrapBlazorTestBase
+public class LayoutSplitBarTest : BootstrapBlazorTestBase
 {
     [Fact]
-    public void LayoutSplitebar_Ok()
+    public void LayoutSplitBar_Ok()
     {
-        var cut = Context.RenderComponent<LayoutSplitebar>(pb =>
+        var cut = Context.RenderComponent<LayoutSplitBar>(pb =>
         {
             pb.Add(a => a.ContainerSelector, ".layout");
         });

--- a/test/UnitTest/Components/LayoutTest.cs
+++ b/test/UnitTest/Components/LayoutTest.cs
@@ -344,14 +344,14 @@ public class LayoutTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void ShowLayouSidebar_Ok()
+    public void ShowLayoutSidebar_Ok()
     {
         var cut = Context.RenderComponent<Layout>(pb =>
         {
             pb.Add(a => a.UseTabSet, true);
             pb.Add(a => a.AdditionalAssemblies, new Assembly[] { GetType().Assembly });
             pb.Add(a => a.IsFullSide, true);
-            pb.Add(a => a.ShowSplitebar, true);
+            pb.Add(a => a.ShowSplitBar, true);
             pb.Add(a => a.SidebarMinWidth, 100);
             pb.Add(a => a.SidebarMaxWidth, 300);
             pb.Add(a => a.Side, new RenderFragment(builder =>

--- a/test/UnitTest/Components/LayoutTest.cs
+++ b/test/UnitTest/Components/LayoutTest.cs
@@ -359,7 +359,7 @@ public class LayoutTest : BootstrapBlazorTestBase
                 builder.AddContent(0, "test");
             }));
         });
-        cut.Contains("layout-splitebar");
+        cut.Contains("layout-split-bar");
         cut.Contains("data-bb-min=\"100\"");
         cut.Contains("data-bb-max=\"300\"");
     }


### PR DESCRIPTION
## Link issues
fixes #5914 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request focuses on renaming the `LayoutSplitebar` component to `LayoutSplitBar` across the codebase to correct a spelling error and improve consistency. It includes updates to component names, properties, CSS classes, localization keys, and test cases. Additionally, a deprecated property (`ShowSplitebar`) has been marked obsolete in favor of the corrected `ShowSplitBar`.

### Component Renaming and Updates:
* Renamed the `LayoutSplitebar` component to `LayoutSplitBar` in all related files, including `.razor`, `.razor.cs`, `.razor.js`, and `.razor.scss`. Updated associated CSS classes and JavaScript references [[1]](diffhunk://#diff-cf58ff5188d1121cb45bb0a2c10774845e8c1ec57a91cbec9b957e7b59c61004L3-R7) [[2]](diffhunk://#diff-051452bf126e275792f7fc57560db0ed24263e4ac8ef9bb06958730df36b3190L11-R11) [[3]](diffhunk://#diff-6714368611be728322b3b81cb51f084e32d08704eacbf341559b108c98ee560aL14-R18) [[4]](diffhunk://#diff-6714368611be728322b3b81cb51f084e32d08704eacbf341559b108c98ee560aL53-R53) [[5]](diffhunk://#diff-b92a10c1ba5bf558a796175ae480436315c12ce25f521d27633120a94e28c6e8L1-R1) [[6]](diffhunk://#diff-b92a10c1ba5bf558a796175ae480436315c12ce25f521d27633120a94e28c6e8L10-R12) [[7]](diffhunk://#diff-b92a10c1ba5bf558a796175ae480436315c12ce25f521d27633120a94e28c6e8L21-R41).
* Updated the SCSS theme file to reflect the new naming convention for hover and drag styles (`$bb-split-bar-body-hover-bg` and `$bb-split-bar-body-drag-hover-bg`).
* Adjusted imports in `components.scss` to reference the renamed SCSS file.

### Property and Localization Key Changes:
* Replaced the `ShowSplitebar` property with `ShowSplitBar` in the `Layout` component and marked `ShowSplitebar` as obsolete with a deprecation warning.
* Updated localization keys in `en-US.json` and `zh-CN.json` to use `ShowSplitBar` instead of `ShowSplitebar` [[1]](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L1427-R1427) [[2]](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL1427-R1427).

### Test Updates:
* Renamed test cases and updated assertions to reflect the new component and property names (`LayoutSplitBar` and `ShowSplitBar`) [[1]](diffhunk://#diff-0cec5f2dbf12b2f2c192c4943ee9a759189eb215d13e816b7bffdb54814162b4L8-R13) [[2]](diffhunk://#diff-76adc001aa3e8e5329f9b0a104240a09de106ddf2a6e8e430f3216eb71a61e45L347-R362).

### Codebase-Wide Usage Updates:
* Replaced all occurrences of `LayoutSplitebar` with `LayoutSplitBar` in Razor files, including `MainLayout.razor` and `TutorialsLayout.razor` [[1]](diffhunk://#diff-8b1b061268a838352d0caa2ce8bcfeda94327779577ad41e15e6070d994b2d9aL13-R13) [[2]](diffhunk://#diff-7cfb7bccce42d6057b1c26357ff7e7186711a4889767ce6db15ecfca0945e96dL12-R12).
* Updated attribute definitions in `Layouts.razor.cs` to reflect the corrected property name.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Rename the `LayoutSplitebar` component to `LayoutSplitBar` to correct a typo.

Enhancements:
- Update all references to the component, including class names, file names, CSS classes, SCSS variables, and JavaScript selectors.
- Mark the old `ShowSplitebar` property in the `Layout` component as obsolete and introduce the correctly spelled `ShowSplitBar` property.
- Update localization keys related to the renamed property description.