### PR TITLE
refactor(IVideoDevice): add bool result from open method

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -21,16 +21,6 @@ private IBluetooth? BluetoothService { get; set; }</Pre>
         <div class="col-12">
             <Select Items="@_items" @bind-Value="_deviceId" DisplayText="Devices" ShowLabel="true"></Select>
         </div>
-        @foreach (var device in _devices)
-        {
-            <div class="col-12">
-                <div>
-                    <div>DeviceId: @device.DeviceId</div>
-                    <div>DeviceId: @device.GroupId</div>
-                    <div>DeviceId: @device.Label</div>
-                </div>
-            </div>
-        }
     </div>
 
     <video class="bb-video" muted playsinline autoplay></video>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -22,12 +22,14 @@ private IBluetooth? BluetoothService { get; set; }</Pre>
         <div class="col-12">
             <Select Items="@_items" @bind-Value="_deviceId" DisplayText="Devices" ShowLabel="true"></Select>
         </div>
-        @foreach(var device in _devices)
+        @foreach (var device in _devices)
         {
             <div class="col-12">
-                <div>DeviceId: @device.DeviceId</div>
-                <div>DeviceId: @device.GroupId</div>
-                <div>DeviceId: @device.Label</div>
+                <div>
+                    <div>DeviceId: @device.DeviceId</div>
+                    <div>DeviceId: @device.GroupId</div>
+                    <div>DeviceId: @device.Label</div>
+                </div>
             </div>
         }
     </div>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -14,9 +14,9 @@ private IBluetooth? BluetoothService { get; set; }</Pre>
     <div class="row form-inline g-3">
         <div class="col-12">
             <Button Text="@Localizer["VideoDeviceRequestText"]" Icon="fa-solid fa-photo-film" OnClick="OnRequestDevice"></Button>
-            <Button Text="@Localizer["VideoDeviceOpenText"]" Icon="fa-solid fa-play" OnClick="OnOpenVideo" class="ms-2"></Button>
-            <Button Text="@Localizer["VideoDeviceCloseText"]" Icon="fa-solid fa-stop" OnClick="OnCloseVideo" class="ms-2"></Button>
-            <Button Text="@Localizer["VideoDeviceCaptureText"]" Icon="fa-solid fa-camera" OnClick="OnCapture" class="ms-2"></Button>
+            <Button Text="@Localizer["VideoDeviceOpenText"]" Icon="fa-solid fa-play" OnClick="OnOpenVideo" IsDisabled="_isOpen" class="ms-2"></Button>
+            <Button Text="@Localizer["VideoDeviceCloseText"]" Icon="fa-solid fa-stop" OnClick="OnCloseVideo" IsDisabled="!_isOpen" class="ms-2"></Button>
+            <Button Text="@Localizer["VideoDeviceCaptureText"]" Icon="fa-solid fa-camera" OnClick="OnCapture" IsDisabled="!_isOpen" class="ms-2"></Button>
         </div>
         <div class="col-12">
             <Select Items="@_items" @bind-Value="_deviceId" DisplayText="Devices" ShowLabel="true"></Select>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -17,7 +17,6 @@ private IBluetooth? BluetoothService { get; set; }</Pre>
             <Button Text="@Localizer["VideoDeviceOpenText"]" Icon="fa-solid fa-play" OnClick="OnOpenVideo" class="ms-2"></Button>
             <Button Text="@Localizer["VideoDeviceCloseText"]" Icon="fa-solid fa-stop" OnClick="OnCloseVideo" class="ms-2"></Button>
             <Button Text="@Localizer["VideoDeviceCaptureText"]" Icon="fa-solid fa-camera" OnClick="OnCapture" class="ms-2"></Button>
-            <Button Text="@Localizer["VideoDeviceFlipText"]" Icon="fa-solid fa-camera-rotate" OnClick="OnFlip" class="ms-2"></Button>
         </div>
         <div class="col-12">
             <Select Items="@_items" @bind-Value="_deviceId" DisplayText="Devices" ShowLabel="true"></Select>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -22,6 +22,14 @@ private IBluetooth? BluetoothService { get; set; }</Pre>
         <div class="col-12">
             <Select Items="@_items" @bind-Value="_deviceId" DisplayText="Devices" ShowLabel="true"></Select>
         </div>
+        @foreach(var device in _devices)
+        {
+            <div class="col-12">
+                <div>DeviceId: @device.DeviceId</div>
+                <div>DeviceId: @device.GroupId</div>
+                <div>DeviceId: @device.Label</div>
+            </div>
+        }
     </div>
 
     <video class="bb-video" muted playsinline autoplay></video>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -14,7 +14,7 @@ private IBluetooth? BluetoothService { get; set; }</Pre>
     <div class="row form-inline g-3">
         <div class="col-12">
             <Button Text="@Localizer["VideoDeviceRequestText"]" Icon="fa-solid fa-photo-film" OnClick="OnRequestDevice"></Button>
-            <Button Text="@Localizer["VideoDeviceOpenText"]" Icon="fa-solid fa-play" OnClick="OnOpenVideo" IsDisabled="_isOpen" class="ms-2"></Button>
+            <Button Text="@Localizer["VideoDeviceOpenText"]" Icon="fa-solid fa-play" OnClick="OnOpenVideo" IsDisabled="_isOpen || string.IsNullOrEmpty(_deviceId)" class="ms-2"></Button>
             <Button Text="@Localizer["VideoDeviceCloseText"]" Icon="fa-solid fa-stop" OnClick="OnCloseVideo" IsDisabled="!_isOpen" class="ms-2"></Button>
             <Button Text="@Localizer["VideoDeviceCaptureText"]" Icon="fa-solid fa-camera" OnClick="OnCapture" IsDisabled="!_isOpen" class="ms-2"></Button>
         </div>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -26,6 +26,7 @@ public partial class VideoDevices
         var devices = await VideoDeviceService.GetDevices();
         if (devices != null)
         {
+            _devices.Clear();
             _devices.AddRange(devices);
             _items = [.. _devices.Select(i => new SelectedItem(i.DeviceId, i.Label))];
         }

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -55,9 +55,4 @@ public partial class VideoDevices
     {
         _previewUrl = await VideoDeviceService.GetPreviewUrl();
     }
-
-    private async Task OnFlip()
-    {
-        await VideoDeviceService.Flip();
-    }
 }

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -43,12 +43,13 @@ public partial class VideoDevices
                 DeviceId = _deviceId,
                 VideoSelector = ".bb-video"
             };
-            _isOpen =  await VideoDeviceService.Open(constraints);
+            _isOpen = await VideoDeviceService.Open(constraints);
         }
     }
 
     private async Task OnCloseVideo()
     {
+        _isOpen = false;
         _previewUrl = "";
         await VideoDeviceService.Close(".bb-video");
     }

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -8,7 +8,7 @@ namespace BootstrapBlazor.Server.Components.Samples;
 /// <summary>
 /// VideoDevice Component
 /// </summary>
-public partial class VideoDevices
+public partial class VideoDevices : IAsyncDisposable
 {
     [Inject, NotNull]
     private IVideoDevice? VideoDeviceService { get; set; }
@@ -59,5 +59,24 @@ public partial class VideoDevices
     private async Task OnCapture()
     {
         _previewUrl = await VideoDeviceService.GetPreviewUrl();
+    }
+
+    private async Task DisposeAsync(bool disposing)
+    {
+        if (disposing)
+        {
+            await OnCloseVideo();
+        }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    /// <exception cref="NotImplementedException"></exception>
+    public async ValueTask DisposeAsync()
+    {
+        await DisposeAsync(true);
+        GC.SuppressFinalize(this);
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -31,6 +31,8 @@ public partial class VideoDevices
             _devices.Clear();
             _devices.AddRange(devices);
             _items = [.. _devices.Select(i => new SelectedItem(i.DeviceId, i.Label))];
+
+            _deviceId = _items.FirstOrDefault()?.Value;
         }
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -21,6 +21,8 @@ public partial class VideoDevices
 
     private string? _previewUrl;
 
+    private bool _isOpen = false;
+
     private async Task OnRequestDevice()
     {
         var devices = await VideoDeviceService.GetDevices();
@@ -41,7 +43,7 @@ public partial class VideoDevices
                 DeviceId = _deviceId,
                 VideoSelector = ".bb-video"
             };
-            await VideoDeviceService.Open(constraints);
+            _isOpen =  await VideoDeviceService.Open(constraints);
         }
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.css
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.css
@@ -2,7 +2,6 @@
     min-height: 240px;
     height: auto;
     width: auto;
-    transform: scaleX(-1);
     margin-top: 1rem;
     display: block;
 }
@@ -10,7 +9,6 @@
 .bb-image {
     border: 1px solid var(--bs-border-color);
     border-radius: var(--bs-border-radius);
-    transform: scaleX(-1);
     margin-top: 1rem;
     display: block;
 }

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.1-beta01</Version>
+    <Version>9.6.1-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
@@ -44,10 +44,4 @@ class DefaultMediaDevices(IJSRuntime jsRuntime) : IMediaDevices
         var module = await LoadModule();
         return await module.InvokeAsync<string?>("getPreviewUrl");
     }
-
-    public async Task Flip()
-    {
-        var module = await LoadModule();
-        await module.InvokeAsync<string?>("flip");
-    }
 }

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
@@ -21,10 +21,10 @@ class DefaultMediaDevices(IJSRuntime jsRuntime) : IMediaDevices
         return await module.InvokeAsync<List<MediaDeviceInfo>?>("enumerateDevices");
     }
 
-    public async Task Open(MediaTrackConstraints constraints)
+    public async Task<bool> Open(MediaTrackConstraints constraints)
     {
         var module = await LoadModule();
-        await module.InvokeVoidAsync("open", constraints);
+        return await module.InvokeAsync<bool>("open", constraints);
     }
 
     public async Task Close(string? videoSelector)

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
@@ -27,10 +27,10 @@ class DefaultMediaDevices(IJSRuntime jsRuntime) : IMediaDevices
         return await module.InvokeAsync<bool>("open", constraints);
     }
 
-    public async Task Close(string? videoSelector)
+    public async Task<bool> Close(string? videoSelector)
     {
         var module = await LoadModule();
-        await module.InvokeVoidAsync("close", videoSelector);
+        return await module.InvokeAsync<bool>("close", videoSelector);
     }
 
     public async Task Capture()

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
@@ -41,9 +41,4 @@ class DefaultVideoDevice(IMediaDevices deviceService) : IVideoDevice
     {
         return deviceService.GetPreviewUrl();
     }
-
-    public Task Flip()
-    {
-        return deviceService.Flip();
-    }
 }

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
@@ -27,7 +27,7 @@ class DefaultVideoDevice(IMediaDevices deviceService) : IVideoDevice
         return deviceService.Open(constraints);
     }
 
-    public Task Close(string? videoSelector)
+    public Task<bool> Close(string? videoSelector)
     {
         return deviceService.Close(videoSelector);
     }

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
@@ -22,7 +22,7 @@ class DefaultVideoDevice(IMediaDevices deviceService) : IVideoDevice
         return ret;
     }
 
-    public Task Open(MediaTrackConstraints constraints)
+    public Task<bool> Open(MediaTrackConstraints constraints)
     {
         return deviceService.Open(constraints);
     }

--- a/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
@@ -21,7 +21,7 @@ public interface IMediaDevices
     /// </summary>
     /// <param name="constraints"></param>
     /// <returns></returns>
-    Task Open(MediaTrackConstraints constraints);
+    Task<bool> Open(MediaTrackConstraints constraints);
 
     /// <summary>
     /// The close() method of the MediaDevices interface stops capturing media from the specified device and closes the MediaStream object.

--- a/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
@@ -41,10 +41,4 @@ public interface IMediaDevices
     /// </summary>
     /// <returns></returns>
     Task<string?> GetPreviewUrl();
-
-    /// <summary>
-    /// Flip the video device.
-    /// </summary>
-    /// <returns></returns>
-    Task Flip();
 }

--- a/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
@@ -28,7 +28,7 @@ public interface IMediaDevices
     /// </summary>
     /// <param name="videoSelector"></param>
     /// <returns></returns>
-    Task Close(string? videoSelector);
+    Task<bool> Close(string? videoSelector);
 
     /// <summary>
     /// The capture() method of the MediaDevices interface captures a still image from the specified video stream and saves it to the specified location.

--- a/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
@@ -21,7 +21,7 @@ public interface IVideoDevice
     /// </summary>
     /// <param name="constraints"></param>
     /// <returns></returns>
-    Task Open(MediaTrackConstraints constraints);
+    Task<bool> Open(MediaTrackConstraints constraints);
 
     /// <summary>
     /// Close the video device with the specified selector.

--- a/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
@@ -28,7 +28,7 @@ public interface IVideoDevice
     /// </summary>
     /// <param name="videoSelector"></param>
     /// <returns></returns>
-    Task Close(string? videoSelector);
+    Task<bool> Close(string? videoSelector);
 
     /// <summary>
     /// Capture a still image from the video stream.

--- a/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
@@ -53,10 +53,4 @@ public interface IVideoDevice
     /// </summary>
     /// <returns></returns>
     Task<string?> GetPreviewUrl();
-
-    /// <summary>
-    /// Flip the video device.
-    /// </summary>
-    /// <returns></returns>
-    Task Flip();
 }

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -75,31 +75,6 @@ export async function getPreviewUrl() {
     return url;
 }
 
-export async function flip() {
-    const media = registerBootstrapBlazorModule("MediaDevices");
-    const { stream } = media;
-    if (stream && stream.active) {
-        const tracks = stream.getVideoTracks();
-        if (tracks) {
-            const track = tracks[0];
-            const constraints = track.getSettings();
-            const { facingMode } = constraints;
-            if (facingMode === void 0) {
-                console.log('facingMode is not supported');
-                return;
-            }
-
-            if (facingMode === "user" || facingMode.exact === "user" || facingMode.ideal === "user") {
-                constraints.facingMode = { ideal: "environment" }
-            }
-            else {
-                constraints.facingMode = { ideal: "user" }
-            }
-            await track.applyConstraints(constraints);
-        }
-    }
-}
-
 const closeStream = stream => {
     if (stream) {
         const tracks = stream.getTracks();

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -29,16 +29,25 @@ export async function open(options) {
     if (height) {
         constrains.video.height = { ideal: height };
     }
-    const stream = await navigator.mediaDevices.getUserMedia(constrains);
-    const media = registerBootstrapBlazorModule("MediaDevices");
-    media.stream = stream;
 
-    if (videoSelector) {
-        const video = document.querySelector(videoSelector);
-        if (video) {
-            video.srcObject = stream;
+    let ret = false;
+    try {
+        const stream = await navigator.mediaDevices.getUserMedia(constrains);
+        const media = registerBootstrapBlazorModule("MediaDevices");
+        media.stream = stream;
+
+        if (videoSelector) {
+            const video = document.querySelector(videoSelector);
+            if (video) {
+                video.srcObject = stream;
+            }
         }
+        ret = true;
     }
+    catch (err) {
+        console.error("Error accessing media devices.", err);
+    }
+    return ret;
 }
 
 export async function close(videoSelector) {

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -51,21 +51,30 @@ export async function open(options) {
 }
 
 export async function close(videoSelector) {
-    if (videoSelector) {
-        const video = document.querySelector(videoSelector);
-        if (video) {
-            video.pause();
-            const stream = video.srcObject;
-            closeStream(stream);
-            video.srcObject = null;
+    let ret = false;
+
+    try {
+        if (videoSelector) {
+            const video = document.querySelector(videoSelector);
+            if (video) {
+                video.pause();
+                const stream = video.srcObject;
+                closeStream(stream);
+                video.srcObject = null;
+            }
         }
+        const media = registerBootstrapBlazorModule("MediaDevices");
+        const { stream } = media;
+        if (stream && stream.active) {
+            closeStream(stream);
+        }
+        media.stream = null;
+        ret = true;
     }
-    const media = registerBootstrapBlazorModule("MediaDevices");
-    const { stream } = media;
-    if (stream && stream.active) {
-        closeStream(stream);
+    catch (err) {
+        console.error("Error closing media devices.", err);
     }
-    media.stream = null;
+    return ret;
 }
 
 export async function getPreviewUrl() {

--- a/test/UnitTest/Services/VideoDeviceTest.cs
+++ b/test/UnitTest/Services/VideoDeviceTest.cs
@@ -46,7 +46,6 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
         Assert.Equal(".bb-video", options.VideoSelector);
 
         await service.Capture();
-        await service.Flip();
         var url = await service.GetPreviewUrl();
         Assert.Equal("blob:https://test-preview", url);
     }

--- a/test/UnitTest/Services/VideoDeviceTest.cs
+++ b/test/UnitTest/Services/VideoDeviceTest.cs
@@ -27,6 +27,7 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
     {
         Context.JSInterop.Setup<string?>("getPreviewUrl").SetResult("blob:https://test-preview");
         Context.JSInterop.Setup<bool>("open", _ => true).SetResult(true);
+        Context.JSInterop.Setup<bool>("close", _ => true).SetResult(true);
 
         var service = Context.Services.GetRequiredService<IVideoDevice>();
         var options = new MediaTrackConstraints()
@@ -40,7 +41,8 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
         var open = await service.Open(options);
         Assert.True(open);
 
-        await service.Close(".bb-video");
+        var close = await service.Close(".bb-video");
+        Assert.True(close);
 
         Assert.Equal("test-device-id", options.DeviceId);
         Assert.Equal("user", options.FacingMode);

--- a/test/UnitTest/Services/VideoDeviceTest.cs
+++ b/test/UnitTest/Services/VideoDeviceTest.cs
@@ -26,6 +26,7 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
     public async Task Open_Ok()
     {
         Context.JSInterop.Setup<string?>("getPreviewUrl").SetResult("blob:https://test-preview");
+        Context.JSInterop.Setup<bool>("open", _ => true).SetResult(true);
 
         var service = Context.Services.GetRequiredService<IVideoDevice>();
         var options = new MediaTrackConstraints()
@@ -36,7 +37,9 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
             Width = 480,
             VideoSelector = ".bb-video"
         };
-        await service.Open(options);
+        var open = await service.Open(options);
+        Assert.True(open);
+
         await service.Close(".bb-video");
 
         Assert.Equal("test-device-id", options.DeviceId);


### PR DESCRIPTION
## Link issues
fixes #5944 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor the video device open method to return a boolean result indicating success or failure of opening the media device

Bug Fixes:
- Prevent multiple attempts to open the same video device

Enhancements:
- Modify the Open method to return a boolean indicating device access status
- Add error handling for media device access
- Update UI to disable/enable buttons based on device open state

Chores:
- Remove unused Flip method from video device interfaces and implementations