### PR TITLE
feat(IVideoDevice): add GetPreviewData method

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor
@@ -18,6 +18,7 @@ private IVideoDevice? VideoDeviceService { get; set; }</Pre>
                 <Button Text="@Localizer["VideoDeviceOpenText"]" Icon="fa-solid fa-play" OnClick="OnOpenVideo" IsDisabled="_isOpen || string.IsNullOrEmpty(_deviceId)"></Button>
                 <Button Text="@Localizer["VideoDeviceCloseText"]" Icon="fa-solid fa-stop" OnClick="OnCloseVideo" IsDisabled="!_isOpen"></Button>
                 <Button Text="@Localizer["VideoDeviceCaptureText"]" Icon="fa-solid fa-camera" OnClick="OnCapture" IsDisabled="!_isOpen"></Button>
+                <Button Text="@Localizer["VideoDeviceDownloadText"]" Icon="fa-solid fa-download" OnClick="OnDownload" IsDisabled="!_isOpen"></Button>
                 <Button Text="QVGA" IsDisabled="!_isOpen" OnClickWithoutRender="() => OnApply(320, 240)"></Button>
                 <Button Text="VGA" IsDisabled="!_isOpen" OnClickWithoutRender="() => OnApply(640, 480)"></Button>
                 <Button Text="HD" IsDisabled="!_isOpen" OnClickWithoutRender="() => OnApply(1280, 960)"></Button>

--- a/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs
@@ -13,6 +13,9 @@ public partial class VideoDevices : IAsyncDisposable
     [Inject, NotNull]
     private IVideoDevice? VideoDeviceService { get; set; }
 
+    [Inject, NotNull]
+    private DownloadService? DownloadService { get; set; }
+
     private readonly List<IMediaDeviceInfo> _devices = [];
 
     private List<SelectedItem> _items = [];
@@ -59,6 +62,15 @@ public partial class VideoDevices : IAsyncDisposable
     private async Task OnCapture()
     {
         _previewUrl = await VideoDeviceService.GetPreviewUrl();
+    }
+
+    private async Task OnDownload()
+    {
+        var stream = await VideoDeviceService.GetPreviewData();
+        if (stream != null)
+        {
+            await DownloadService.DownloadFromStreamAsync("preview.png", stream);
+        }
     }
 
     private async Task OnApply(int width, int height) => await VideoDeviceService.Apply(new MediaTrackConstraints() { Width = width, Height = height });

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -7128,7 +7128,7 @@
     "VideoDeviceOpenText": "Open",
     "VideoDeviceCloseText": "Close",
     "VideoDeviceCaptureText": "Capture",
-    "VideoDeviceFlipText": "Flip"
+    "VideoDeviceDownloadText": "Download"
   },
   "BootstrapBlazor.Server.Components.Samples.AudioDevices": {
     "AudioDeviceTitle": "IAudioDevice",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -7128,7 +7128,7 @@
     "VideoDeviceOpenText": "打开设备",
     "VideoDeviceCloseText": "关闭设备",
     "VideoDeviceCaptureText": "截图",
-    "VideoDeviceFlipText": "翻转镜头"
+    "VideoDeviceDownloadText": "下载"
   },
   "BootstrapBlazor.Server.Components.Samples.AudioDevices": {
     "AudioDeviceTitle": "IAudioDevice 音频设备服务",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.1-beta02</Version>
+    <Version>9.6.1-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs
@@ -45,6 +45,18 @@ class DefaultMediaDevices(IJSRuntime jsRuntime) : IMediaDevices
         return await module.InvokeAsync<string?>("getPreviewUrl");
     }
 
+    public async Task<Stream?> GetPreviewData()
+    {
+        Stream? ret = null;
+        var module = await LoadModule();
+        var stream = await module.InvokeAsync<IJSStreamReference?>("getPreviewData");
+        if (stream != null)
+        {
+            ret = await stream.OpenReadStreamAsync(stream.Length);
+        }
+        return ret;
+    }
+
     public async Task<bool> Apply(MediaTrackConstraints constraints)
     {
         var module = await LoadModule();

--- a/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/DefaultVideoDevice.cs
@@ -37,6 +37,11 @@ class DefaultVideoDevice(IMediaDevices deviceService) : IVideoDevice
         return deviceService.Capture();
     }
 
+    public Task<Stream?> GetPreviewData()
+    {
+        return deviceService.GetPreviewData();
+    }
+
     public Task<string?> GetPreviewUrl()
     {
         return deviceService.GetPreviewUrl();

--- a/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs
@@ -44,6 +44,12 @@ public interface IMediaDevices
     Task<string?> GetPreviewUrl();
 
     /// <summary>
+    /// Gets the stream of the captured image.
+    /// </summary>
+    /// <returns></returns>
+    Task<Stream?> GetPreviewData();
+
+    /// <summary>
     /// Apply the media track constraints.
     /// </summary>
     /// <param name="constraints"></param>

--- a/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
+++ b/src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs
@@ -36,23 +36,17 @@ public interface IVideoDevice
     /// <returns></returns>
     Task Capture();
 
-    ///// <summary>
-    ///// Preview a still image from the video stream.
-    ///// </summary>
-    ///// <returns></returns>
-    //Task Preview();
-
-    ///// <summary>
-    ///// Gets the stream of the captured image.
-    ///// </summary>
-    ///// <returns></returns>
-    //Task<Stream?> GetPreviewImage();
-
     /// <summary>
     /// Gets the preview URL of the captured image.
     /// </summary>
     /// <returns></returns>
     Task<string?> GetPreviewUrl();
+
+    /// <summary>
+    /// Gets the stream of the captured image.
+    /// </summary>
+    /// <returns></returns>
+    Task<Stream?> GetPreviewData();
 
     /// <summary>
     /// Apply the media track constraints.

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -25,12 +25,12 @@ export async function open(type, options) {
 
 export async function close(selector) {
     const media = registerBootstrapBlazorModule("MediaDevices");
-    let ret = false;
+    let ret;
     if (media.stream) {
         ret = await closeVideoDevice(selector);
     }
     else {
-        ret = await stop(selector);
+        ret = stop(selector);
     }
     return ret;
 }
@@ -205,7 +205,7 @@ export async function record(options) {
     return ret;
 }
 
-export async function stop(selector) {
+export function stop(selector) {
     let ret = false;
     const media = registerBootstrapBlazorModule("MediaDevices");
     if (selector) {

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -154,7 +154,7 @@ export async function getPreviewUrl() {
     return url;
 }
 
-export async function getPreviewData() {
+export function getPreviewData() {
     const media = registerBootstrapBlazorModule("MediaDevices");
     return media.previewBlob;
 }

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -143,9 +143,15 @@ export async function getPreviewUrl() {
             const capture = new ImageCapture(track);
             const blob = await capture.takePhoto();
             url = URL.createObjectURL(blob);
+            media.previewBlob = blob;
         }
     }
     return url;
+}
+
+export async function getPreviewData() {
+    const media = registerBootstrapBlazorModule("MediaDevices");
+    return media.previewBlob;
 }
 
 const closeStream = stream => {

--- a/src/BootstrapBlazor/wwwroot/modules/media.js
+++ b/src/BootstrapBlazor/wwwroot/modules/media.js
@@ -6,8 +6,13 @@ export async function enumerateDevices() {
         console.log("enumerateDevices() not supported.");
     }
     else {
-        await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
-        ret = await navigator.mediaDevices.enumerateDevices();
+        try {
+            await navigator.mediaDevices.getUserMedia({ video: true, audio: true });
+            ret = await navigator.mediaDevices.enumerateDevices();
+        }
+        catch (e) {
+            console.warn(e);
+        }
     }
     return ret;
 }

--- a/test/UnitTest/Services/VideoDeviceTest.cs
+++ b/test/UnitTest/Services/VideoDeviceTest.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Microsoft.JSInterop;
+using UnitTest.Mock;
+
 namespace UnitTest.Services;
 
 public class VideoDeviceTest : BootstrapBlazorTestBase
@@ -27,7 +30,7 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
     public async Task Open_Ok()
     {
         Context.JSInterop.Setup<string?>("getPreviewUrl").SetResult("blob:https://test-preview");
-        Context.JSInterop.Setup<Stream?>("getPreviewData").SetResult(new MemoryStream([0x01, 0x02]));
+        Context.JSInterop.Setup<IJSStreamReference?>("getPreviewData").SetResult(new MockJSStreamReference());
         Context.JSInterop.Setup<bool>("open", _ => true).SetResult(true);
         Context.JSInterop.Setup<bool>("close", _ => true).SetResult(true);
         Context.JSInterop.Setup<bool>("apply", _ => true).SetResult(true);
@@ -62,6 +65,6 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
 
         var data = await service.GetPreviewData();
         Assert.NotNull(data);
-        Assert.Equal(2, data.Length);
+        Assert.Equal(4, data.Length);
     }
 }

--- a/test/UnitTest/Services/VideoDeviceTest.cs
+++ b/test/UnitTest/Services/VideoDeviceTest.cs
@@ -27,6 +27,7 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
     public async Task Open_Ok()
     {
         Context.JSInterop.Setup<string?>("getPreviewUrl").SetResult("blob:https://test-preview");
+        Context.JSInterop.Setup<Stream?>("getPreviewData").SetResult(new MemoryStream([0x01, 0x02]));
         Context.JSInterop.Setup<bool>("open", _ => true).SetResult(true);
         Context.JSInterop.Setup<bool>("close", _ => true).SetResult(true);
         Context.JSInterop.Setup<bool>("apply", _ => true).SetResult(true);
@@ -58,5 +59,9 @@ public class VideoDeviceTest : BootstrapBlazorTestBase
         await service.Capture();
         var url = await service.GetPreviewUrl();
         Assert.Equal("blob:https://test-preview", url);
+
+        var data = await service.GetPreviewData();
+        Assert.NotNull(data);
+        Assert.Equal(2, data.Length);
     }
 }


### PR DESCRIPTION
## Link issues
fixes #5964 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces functionality to download captured video frames as image files, along with related updates to services, interfaces, and tests. The most important changes include adding a download button to the UI, implementing a method to retrieve image data from the video stream, and updating the JavaScript module and unit tests to support this feature.

### UI Enhancements:
* Added a new "Download" button to the video controls in `VideoDevices.razor`, allowing users to download captured frames as images. The button is disabled when no video is active (`src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor`).

### Backend Service Updates:
* Injected a new `DownloadService` into the `VideoDevices` component to handle file downloads (`src/BootstrapBlazor.Server/Components/Samples/VideoDevices.razor.cs`).
* Added a `GetPreviewData` method in the `DefaultMediaDevices` service to retrieve the image data as a stream (`src/BootstrapBlazor/Services/MediaDevices/DefaultMediaDevices.cs`).
* Updated the `IVideoDevice` and `IMediaDevices` interfaces to include the new `GetPreviewData` method (`src/BootstrapBlazor/Services/MediaDevices/IVideoDevice.cs`, `src/BootstrapBlazor/Services/MediaDevices/IMediaDevices.cs`). [[1]](diffhunk://#diff-637f2ec193e62db8bac6720d25123e91a14268603f18bb0dac2be41d656b0df5L39-R50) [[2]](diffhunk://#diff-e6807d0450a960fd00bf9369b227e28700bdcfe0a67be50a80e315686aeffdb0R46-R51)

### JavaScript Module Enhancements:
* Added a `getPreviewData` function to the `media.js` module to retrieve the captured image blob for download (`src/BootstrapBlazor/wwwroot/modules/media.js`).
* Updated error handling and streamlined logic in other functions for better robustness (`src/BootstrapBlazor/wwwroot/modules/media.js`). [[1]](diffhunk://#diff-aa18f6d73a5b5d89a74281649166ae7c8109ca27695d099d1dabb4806fd0b074R9-R16) [[2]](diffhunk://#diff-aa18f6d73a5b5d89a74281649166ae7c8109ca27695d099d1dabb4806fd0b074L28-R38) [[3]](diffhunk://#diff-aa18f6d73a5b5d89a74281649166ae7c8109ca27695d099d1dabb4806fd0b074L208-R219)

### Unit Tests:
* Extended the `VideoDeviceTest` unit tests to verify the new `GetPreviewData` functionality, ensuring that the data stream is correctly retrieved and validated (`test/UnitTest/Services/VideoDeviceTest.cs`). [[1]](diffhunk://#diff-c3ea7e6f581934be63279561ddaf38337582f06b8f21ed3dc13f5a2fd21c7f79R30) [[2]](diffhunk://#diff-c3ea7e6f581934be63279561ddaf38337582f06b8f21ed3dc13f5a2fd21c7f79R62-R65)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add functionality to download captured video frames as image files in the video device component

New Features:
- Add GetPreviewData method to retrieve captured image data
- Implement download button for captured video frames

Enhancements:
- Improve error handling in device enumeration
- Streamline JavaScript module logic for media devices

Tests:
- Extend unit tests to verify new GetPreviewData functionality