### PR TITLE
feat(Dialog): add Show<TComponent> extension method

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.1-beta02</Version>
+    <Version>9.6.1-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Extensions/DialogServiceExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/DialogServiceExtensions.cs
@@ -8,12 +8,12 @@ using Microsoft.AspNetCore.Components.Rendering;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// DialogService 扩展方法
+/// DialogService extensions method
 /// </summary>
 public static class DialogServiceExtensions
 {
     /// <summary>
-    /// 弹出带结果的对话框
+    /// Show dialog with generic type.
     /// </summary>
     /// <param name="service">DialogService 服务实例</param>
     /// <param name="title">对话框标题，优先级高于 <see cref="DialogOption.Title"/></param>

--- a/src/BootstrapBlazor/Extensions/DialogServiceExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/DialogServiceExtensions.cs
@@ -17,7 +17,7 @@ public static class DialogServiceExtensions
     /// </summary>
     /// <param name="service">DialogService 服务实例</param>
     /// <param name="title">对话框标题，优先级高于 <see cref="DialogOption.Title"/></param>
-    /// <param name="parameters">TCom 组件所需要的参数集合</param>
+    /// <param name="parameters">TComponent 组件所需要的参数集合</param>
     /// <param name="dialog">指定弹窗组件 默认为 null 使用 <see cref="BootstrapBlazorRoot"/> 组件内置弹窗组件</param>
     public static Task Show<TComponent>(this DialogService service, string title, IDictionary<string, object?>? parameters = null, Dialog? dialog = null) where TComponent : IComponent
     {

--- a/src/BootstrapBlazor/Extensions/DialogServiceExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/DialogServiceExtensions.cs
@@ -13,6 +13,25 @@ namespace BootstrapBlazor.Components;
 public static class DialogServiceExtensions
 {
     /// <summary>
+    /// 弹出带结果的对话框
+    /// </summary>
+    /// <param name="service">DialogService 服务实例</param>
+    /// <param name="title">对话框标题，优先级高于 <see cref="DialogOption.Title"/></param>
+    /// <param name="parameters">TCom 组件所需要的参数集合</param>
+    /// <param name="dialog">指定弹窗组件 默认为 null 使用 <see cref="BootstrapBlazorRoot"/> 组件内置弹窗组件</param>
+    public static Task Show<TComponent>(this DialogService service, string title, IDictionary<string, object?>? parameters = null, Dialog? dialog = null) where TComponent : IComponent
+    {
+        var option = new DialogOption();
+        if (!string.IsNullOrEmpty(title))
+        {
+            option.Title = title;
+        }
+        option.ShowFooter = false;
+        option.Component = BootstrapDynamicComponent.CreateComponent<TComponent>(parameters);
+        return service.Show(option, dialog);
+    }
+
+    /// <summary>
     /// 弹出搜索对话框
     /// </summary>
     /// <param name="service">DialogService 服务实例</param>

--- a/test/UnitTest/Components/DialogTest.cs
+++ b/test/UnitTest/Components/DialogTest.cs
@@ -573,6 +573,11 @@ public class DialogTest : BootstrapBlazorTestBase
         }));
         await cut.InvokeAsync(() => modal.Instance.CloseCallback());
         #endregion
+
+        #region Show Extensions Method
+        await cut.InvokeAsync(() => dialog.Show<MockValidateFormDialog>("Test Title"));
+        await cut.InvokeAsync(() => modal.Instance.CloseCallback());
+        #endregion
     }
 
     private class MockValidateFormDialog : ComponentBase


### PR DESCRIPTION
## Link issues
fixes #5982 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces a new extension method for the `DialogService` class to simplify showing dialogs with a specified component and title. Additionally, corresponding unit tests have been added to ensure the new functionality works as expected.

### New Feature: DialogService Extension Method

* Added a `Show<TComponent>` extension method to the `DialogService` class in `DialogServiceExtensions.cs`. This method allows displaying a dialog with a specified component (`TComponent`), title, and optional parameters, streamlining dialog creation.

### Unit Tests for New Method

* Added unit tests in `DialogTest.cs` to verify the functionality of the new `Show<TComponent>` method, including invoking the dialog with a title and ensuring correct behavior during dialog closure.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a new extension method to DialogService that simplifies showing dialogs with a generic component

New Features:
- Introduce `Show<TComponent>` extension method for DialogService to easily display dialogs with a specified component and title

Tests:
- Added unit test for the new `Show<TComponent>` extension method