### PR TITLE
refactor(Table): rename ProhibitEdit/Delete method name

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -545,7 +545,7 @@ public partial class Table<TItem>
         if (SelectedRows.Count == 1)
         {
             // 检查是否选中了不可编辑行（行内无编辑按钮），同时检查按钮禁用状态（禁用时不可编辑）
-            if (CanEdit())
+            if (ProhibitEdit())
             {
                 // 提示不可编辑
                 await ShowToastAsync(EditButtonToastTitle, EditButtonToastReadonlyContent);
@@ -992,7 +992,7 @@ public partial class Table<TItem>
         {
             await ShowDeleteToastAsync(DeleteButtonToastTitle, DeleteButtonToastContent);
         }
-        else if (CanDelete())
+        else if (ProhibitDelete())
         {
             await ShowDeleteToastAsync(DeleteButtonToastTitle, DeleteButtonToastCanNotDeleteContent);
         }
@@ -1003,12 +1003,12 @@ public partial class Table<TItem>
         return ret;
     }
 
-    private bool CanEdit() => (ShowExtendEditButtonCallback != null && !ShowExtendEditButtonCallback(SelectedRows[0]))
+    private bool ProhibitEdit() => (ShowExtendEditButtonCallback != null && !ShowExtendEditButtonCallback(SelectedRows[0]))
                 || !ShowExtendEditButton
                 || (DisableExtendEditButtonCallback != null && DisableExtendEditButtonCallback(SelectedRows[0]))
                 || DisableExtendEditButton;
 
-    private bool CanDelete() => (ShowExtendDeleteButtonCallback != null && SelectedRows.Any(i => !ShowExtendDeleteButtonCallback(i)))
+    private bool ProhibitDelete() => (ShowExtendDeleteButtonCallback != null && SelectedRows.Any(i => !ShowExtendDeleteButtonCallback(i)))
             || !ShowExtendDeleteButton
             || (DisableExtendDeleteButtonCallback != null && SelectedRows.Any(x => DisableExtendDeleteButtonCallback(x)))
             || DisableExtendDeleteButton;

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -8651,8 +8651,8 @@ public class TableTest : BootstrapBlazorTestBase
             pb.Add(a => a.ShowExtendEditButton, false);
             pb.Add(a => a.ShowExtendDeleteButton, false);
         });
-        Assert.True(CanEdit(cut.Instance));
-        Assert.True(CanDelete(cut.Instance));
+        Assert.True(ProhibitEdit(cut.Instance));
+        Assert.True(ProhibitDelete(cut.Instance));
 
         cut.SetParametersAndRender(pb =>
         {
@@ -8661,8 +8661,8 @@ public class TableTest : BootstrapBlazorTestBase
             pb.Add(a => a.DisableExtendEditButton, true);
             pb.Add(a => a.DisableExtendDeleteButton, true);
         });
-        Assert.True(CanEdit(cut.Instance));
-        Assert.True(CanDelete(cut.Instance));
+        Assert.True(ProhibitEdit(cut.Instance));
+        Assert.True(ProhibitDelete(cut.Instance));
 
         cut.SetParametersAndRender(pb =>
         {
@@ -8680,14 +8680,14 @@ public class TableTest : BootstrapBlazorTestBase
                 return true;
             });
         });
-        Assert.True(CanEdit(cut.Instance));
-        Assert.True(CanDelete(cut.Instance));
+        Assert.True(ProhibitEdit(cut.Instance));
+        Assert.True(ProhibitDelete(cut.Instance));
     }
 
-    static bool CanEdit(Table<Foo> @this)
+    static bool ProhibitEdit(Table<Foo> @this)
     {
         var ret = false;
-        var methodInfo = @this.GetType().GetMethod("CanEdit", BindingFlags.Instance | BindingFlags.NonPublic);
+        var methodInfo = @this.GetType().GetMethod("ProhibitEdit", BindingFlags.Instance | BindingFlags.NonPublic);
         if (methodInfo != null)
         {
             var result = methodInfo.Invoke(@this, null);
@@ -8699,10 +8699,10 @@ public class TableTest : BootstrapBlazorTestBase
         return ret;
     }
 
-    static bool CanDelete(Table<Foo> @this)
+    static bool ProhibitDelete(Table<Foo> @this)
     {
         var ret = false;
-        var methodInfo = @this.GetType().GetMethod("CanDelete", BindingFlags.Instance | BindingFlags.NonPublic);
+        var methodInfo = @this.GetType().GetMethod("ProhibitDelete", BindingFlags.Instance | BindingFlags.NonPublic);
         if (methodInfo != null)
         {
             var result = methodInfo.Invoke(@this, null);


### PR DESCRIPTION
## Link issues
fixes #5998 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request refactors the logic for determining edit and delete permissions in the `Table` component by replacing the `CanEdit` and `CanDelete` methods with `ProhibitEdit` and `ProhibitDelete`. Corresponding updates have been made to the unit tests to ensure consistency.

### Refactoring of permission logic in `Table` component:

* Replaced `CanEdit` with `ProhibitEdit` and `CanDelete` with `ProhibitDelete` in the `Table.razor.Toolbar.cs` file. This change inverts the logic to focus on prohibitions rather than permissions. (`[[1]](diffhunk://#diff-ca9e82d70b95de7204b56fbdace327d330eaef6777601f3d897b0e07c8c3eff8L548-R548)`, `[[2]](diffhunk://#diff-ca9e82d70b95de7204b56fbdace327d330eaef6777601f3d897b0e07c8c3eff8L995-R995)`, `[[3]](diffhunk://#diff-ca9e82d70b95de7204b56fbdace327d330eaef6777601f3d897b0e07c8c3eff8L1006-R1011)`)

### Updates to unit tests:

* Updated all references to `CanEdit` and `CanDelete` in the `TableTest.cs` file to use `ProhibitEdit` and `ProhibitDelete`, ensuring the tests align with the new logic. (`[[1]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160L8654-R8655)`, `[[2]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160L8664-R8665)`, `[[3]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160L8683-R8690)`, `[[4]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160L8702-R8705)`)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
