### PR TITLE
refactor(Table): update logic for IgnoreWhenExport parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.2-beta04</Version>
+    <Version>9.6.2-beta05</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -1184,19 +1184,19 @@ public partial class Table<TItem>
 
     private Task ExportAsync() => ExecuteExportAsync(() => OnExportAsync != null
         ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Unknown, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportAsync(Rows, GetVisibleColumns()));
+        : TableExport.ExportAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
 
     private Task ExportCsvAsync() => ExecuteExportAsync(() => OnExportAsync != null
         ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Csv, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportCsvAsync(Rows, GetVisibleColumns()));
+        : TableExport.ExportCsvAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
 
     private Task ExportPdfAsync() => ExecuteExportAsync(() => OnExportAsync != null
         ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Pdf, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportPdfAsync(Rows, GetVisibleColumns()));
+        : TableExport.ExportPdfAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
 
     private Task ExportExcelAsync() => ExecuteExportAsync(() => OnExportAsync != null
         ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Excel, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportExcelAsync(Rows, GetVisibleColumns()));
+        : TableExport.ExportExcelAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
 
     /// <summary>
     /// 获取当前 Table 选中的所有行数据

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -1202,7 +1202,7 @@ public partial class Table<TItem>
     /// Gets the export column collection.
     /// </summary>
     /// <returns></returns>
-    public List<ITableColumn> GetExportColumns() => [.. GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)];
+    public List<ITableColumn> GetExportColumns() => [.. GetVisibleColumns().Where(i => i.IgnoreWhenExport is not true)];
 
     /// <summary>
     /// 获取当前 Table 选中的所有行数据

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -470,7 +470,7 @@ public partial class Table<TItem>
     {
         // 不可见列
         var items = VisibleColumns.Where(i => i.Visible);
-        return Columns.Where(i => !i.GetIgnoreExport() && !i.GetIgnore() && items.Any(v => v.Name == i.GetFieldName()) && ScreenSize >= i.ShownWithBreakPoint);
+        return Columns.Where(i => !i.GetIgnore() && items.Any(v => v.Name == i.GetFieldName()) && ScreenSize >= i.ShownWithBreakPoint);
     }
 
     private bool GetColumnsListState(ColumnVisibleItem item) => VisibleColumns.Find(i => i.Name == item.Name) is { Visible: true } && VisibleColumns.Where(i => i.Visible).DistinctBy(i => i.Name).Count(i => i.Visible) == 1;

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -1183,20 +1183,26 @@ public partial class Table<TItem>
     }
 
     private Task ExportAsync() => ExecuteExportAsync(() => OnExportAsync != null
-        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Unknown, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
+        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Unknown, Rows, GetExportColumns(), BuildQueryPageOptions()))
+        : TableExport.ExportAsync(Rows, GetExportColumns()));
 
     private Task ExportCsvAsync() => ExecuteExportAsync(() => OnExportAsync != null
-        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Csv, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportCsvAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
+        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Csv, Rows, GetExportColumns(), BuildQueryPageOptions()))
+        : TableExport.ExportCsvAsync(Rows, GetExportColumns()));
 
     private Task ExportPdfAsync() => ExecuteExportAsync(() => OnExportAsync != null
-        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Pdf, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportPdfAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
+        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Pdf, Rows, GetExportColumns(), BuildQueryPageOptions()))
+        : TableExport.ExportPdfAsync(Rows, GetExportColumns()));
 
     private Task ExportExcelAsync() => ExecuteExportAsync(() => OnExportAsync != null
-        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Excel, Rows, GetVisibleColumns(), BuildQueryPageOptions()))
-        : TableExport.ExportExcelAsync(Rows, GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)));
+        ? OnExportAsync(new TableExportDataContext<TItem>(TableExportType.Excel, Rows, GetExportColumns(), BuildQueryPageOptions()))
+        : TableExport.ExportExcelAsync(Rows, GetExportColumns()));
+
+    /// <summary>
+    /// Gets the export column collection.
+    /// </summary>
+    /// <returns></returns>
+    public List<ITableColumn> GetExportColumns() => [.. GetVisibleColumns().Where(i => i.IgnoreWhenExport == false)];
 
     /// <summary>
     /// 获取当前 Table 选中的所有行数据

--- a/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
@@ -344,8 +344,6 @@ public static class IEditItemExtensions
 
     internal static bool GetVisible(this ITableColumn col) => col.Visible ?? true;
 
-    internal static bool GetIgnoreExport(this ITableColumn col) => col.IgnoreWhenExport ?? false;
-
     internal static bool GetShowCopyColumn(this ITableColumn col) => col.ShowCopyColumn ?? false;
 
     internal static bool GetShowTips(this ITableColumn col) => col.ShowTips ?? false;


### PR DESCRIPTION
## Link issues
fixes #6009 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces changes to enhance table export functionality in the `BootstrapBlazor` library, including the addition of a new method to filter export columns, removal of unused code, and updates to unit tests. The changes focus on improving the handling of export-related logic and ensuring proper test coverage.

### Enhancements to Table Export Functionality:
* Added `GetExportColumns` method to filter columns for export by excluding those marked with `IgnoreWhenExport`. This ensures only relevant columns are included during export operations. (`[src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.csL1186-R1205](diffhunk://#diff-ca9e82d70b95de7204b56fbdace327d330eaef6777601f3d897b0e07c8c3eff8L1186-R1205)`)
* Updated export methods (`ExportAsync`, `ExportCsvAsync`, `ExportPdfAsync`, `ExportExcelAsync`) to use the new `GetExportColumns` method instead of `GetVisibleColumns`. (`[src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.csL1186-R1205](diffhunk://#diff-ca9e82d70b95de7204b56fbdace327d330eaef6777601f3d897b0e07c8c3eff8L1186-R1205)`)

### Code Simplification:
* Removed the unused `GetIgnoreExport` method from `ITableColumnExtensions`, as its functionality is now integrated into `GetExportColumns`. (`[src/BootstrapBlazor/Extensions/ITableColumnExtensions.csL347-L348](diffhunk://#diff-6bf3ad236565623debfb28c7c18a2a21bdd089aa294538b56491d5db7dd5a2f5L347-L348)`)

### Unit Test Updates:
* Enhanced the `ExportAsync_Ok` test to verify that columns marked with `IgnoreWhenExport` are excluded during export. Added assertions to validate the behavior of the `GetExportColumns` method. (`[[1]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160R6996-R7001)`, `[[2]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160R7016-R7029)`, `[[3]](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160R7040-R7042)`)
* Removed the redundant `IgnoreWhenExport_Ok` test, as its logic is now covered in the updated `ExportAsync_Ok` test. (`[test/UnitTest/Components/TableTest.csL8211-L8241](diffhunk://#diff-3546a7a8520a1cc0576ca6a1077d468561e7b825b061c3d1aac2daae7a62a160L8211-L8241)`)

### Version Update:
* Incremented the project version from `9.6.2-beta04` to `9.6.2-beta05` in the `BootstrapBlazor.csproj` file. (`[src/BootstrapBlazor/BootstrapBlazor.csprojL4-R4](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4)`)

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce IgnoreWhenExport-based filtering for table exports and refactor related logic

Enhancements:
- Add GetExportColumns method to exclude columns marked IgnoreWhenExport during export
- Update all export methods to use GetExportColumns instead of GetVisibleColumns
- Remove obsolete GetIgnoreExport extension method

Build:
- Bump project version to 9.6.2-beta05

Tests:
- Enhance ExportAsync_Ok test to assert ignored columns are excluded and consolidate IgnoreWhenExport_Ok logic
- Remove redundant standalone IgnoreWhenExport_Ok unit test