### PR TITLE
feat(Select): add IsAutoClearSearchTextWhenCollapsed parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Selects.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Selects.razor.cs
@@ -322,6 +322,14 @@ public sealed partial class Selects
         },
         new()
         {
+            Name = "IsAutoClearSearchTextWhenCollapsed",
+            Description = Localizer["SelectsIsAutoClearSearchTextWhenCollapsed"],
+            Type = "bool",
+            ValueList = "true|false",
+            DefaultValue = "false"
+        },
+        new()
+        {
             Name = "DisplayText",
             Description = Localizer["SelectsDisplayText"],
             Type = "string",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3211,7 +3211,7 @@
     "SelectsCustomTemplateTitle": "Custom option templates",
     "SelectsCustomTemplateIntro": "By setting the <code>ItemTemplate</code> you can customize the option rendering style",
     "SelectsShowSearchTitle": "Drop-down box with search box",
-    "SelectsShowSearchIntro": "Controls whether the search box is displayed by setting the <code>ShowSearch</code> property, which is not displayed by default <b>false</b>. You can set the <code>IsAutoClearSearchTextWhenCollapsed</code> parameter to control whether the text in the search box is automatically cleared after the drop-down box is collapsed. The default value is false.",
+    "SelectsShowSearchIntro": "Controls whether the search box is displayed by setting the <code>ShowSearch</code> property, which is not displayed by default <b>false</b>. You can set the <code>IsAutoClearSearchTextWhenCollapsed</code> parameter to control whether the text in the search box is automatically cleared after the drop-down box is collapsed. The default value is <b>false</b>.",
     "SelectsConfirmSelectTitle": "Drop-down box with confirmation",
     "SelectsConfirmSelectIntro": "Block changes to the current value by setting the <code>OnBeforeSelectedItemChange</code> delegate.",
     "SelectsTimeZoneTitle": "Timezone",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3211,7 +3211,7 @@
     "SelectsCustomTemplateTitle": "Custom option templates",
     "SelectsCustomTemplateIntro": "By setting the <code>ItemTemplate</code> you can customize the option rendering style",
     "SelectsShowSearchTitle": "Drop-down box with search box",
-    "SelectsShowSearchIntro": "Controls whether the search box is displayed by setting the <code>ShowSearch</code> property, which is not displayed by default <b>false</b>",
+    "SelectsShowSearchIntro": "Controls whether the search box is displayed by setting the <code>ShowSearch</code> property, which is not displayed by default <b>false</b>. You can set the <code>IsAutoClearSearchTextWhenCollapsed</code> parameter to control whether the text in the search box is automatically cleared after the drop-down box is collapsed. The default value is false.",
     "SelectsConfirmSelectTitle": "Drop-down box with confirmation",
     "SelectsConfirmSelectIntro": "Block changes to the current value by setting the <code>OnBeforeSelectedItemChange</code> delegate.",
     "SelectsTimeZoneTitle": "Timezone",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3221,6 +3221,7 @@
     "SwalFooter": "Click Confirm to change the option value and select Cancel to leave the value unchanged",
     "SelectsShowLabel": "Whether to display the front label",
     "SelectsShowSearch": "Whether to display the search box",
+    "SelectsIsAutoClearSearchTextWhenCollapsed": "Whether to automatically clear the search bar when the drop-down box is collapsed",
     "SelectsDisplayText": "The front label displays text",
     "SelectsClass": "Style",
     "SelectsColor": "Color",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3211,7 +3211,7 @@
     "SelectsCustomTemplateTitle": "自定义选项模板",
     "SelectsCustomTemplateIntro": "通过设置 <code>ItemTemplate</code> 可以自定义选项渲染样式",
     "SelectsShowSearchTitle": "带搜索框的下拉框",
-    "SelectsShowSearchIntro": "通过设置 <code>ShowSearch</code> 属性控制是否显示搜索框，默认为 <b>false</b> 不显示搜索框",
+    "SelectsShowSearchIntro": "通过设置 <code>ShowSearch</code> 属性控制是否显示搜索框，默认为 <b>false</b> 不显示搜索框，可以通过设置 <code>IsAutoClearSearchTextWhenCollapsed</code> 参数控制下拉框收起后是否自动清空搜索框内文字，默认值为 false 不清空",
     "SelectsConfirmSelectTitle": "带确认的下拉框",
     "SelectsConfirmSelectIntro": "通过设置 <code>OnBeforeSelectedItemChange</code> 委托，阻止当前值的改变",
     "SelectsTimeZoneTitle": "时区下拉框",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3211,7 +3211,7 @@
     "SelectsCustomTemplateTitle": "自定义选项模板",
     "SelectsCustomTemplateIntro": "通过设置 <code>ItemTemplate</code> 可以自定义选项渲染样式",
     "SelectsShowSearchTitle": "带搜索框的下拉框",
-    "SelectsShowSearchIntro": "通过设置 <code>ShowSearch</code> 属性控制是否显示搜索框，默认为 <b>false</b> 不显示搜索框，可以通过设置 <code>IsAutoClearSearchTextWhenCollapsed</code> 参数控制下拉框收起后是否自动清空搜索框内文字，默认值为 false 不清空",
+    "SelectsShowSearchIntro": "通过设置 <code>ShowSearch</code> 属性控制是否显示搜索框，默认为 <b>false</b> 不显示搜索框，可以通过设置 <code>IsAutoClearSearchTextWhenCollapsed</code> 参数控制下拉框收起后是否自动清空搜索框内文字，默认值为 <b>false</b> 不清空",
     "SelectsConfirmSelectTitle": "带确认的下拉框",
     "SelectsConfirmSelectIntro": "通过设置 <code>OnBeforeSelectedItemChange</code> 委托，阻止当前值的改变",
     "SelectsTimeZoneTitle": "时区下拉框",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3221,6 +3221,7 @@
     "SwalFooter": "点击确认改变选项值，选择取消后值不变",
     "SelectsShowLabel": "是否显示前置标签",
     "SelectsShowSearch": "是否显示搜索框",
+    "SelectsIsAutoClearSearchTextWhenCollapsed": "下拉框收起时是否自动清空搜索栏",
     "SelectsDisplayText": "前置标签显示文本",
     "SelectsClass": "样式",
     "SelectsColor": "颜色",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.2-beta05</Version>
+    <Version>9.6.2-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -111,6 +111,12 @@ public partial class Select<TValue> : ISelect, ILookup
     [Parameter]
     public string? DefaultVirtualizeItemText { get; set; }
 
+    /// <summary>
+    /// Gets or sets whether auto clear the search text when dropdown closed.
+    /// </summary>
+    [Parameter]
+    public bool IsAutoClearSearchTextWhenCollapsed { get; set; }
+
     IEnumerable<SelectedItem>? ILookup.Lookup { get => Items; set => Items = value; }
 
     StringComparison ILookup.LookupStringComparison { get => StringComparison; set => StringComparison = value; }

--- a/src/BootstrapBlazor/Components/Select/Select.razor.js
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.js
@@ -10,7 +10,13 @@ export function init(id, invoke, options) {
     }
 
     const search = el.querySelector(".search-text")
-    const popover = Popover.init(el)
+    const popover = Popover.init(el, {
+        hideCallback: () => {
+            if (options.triggerCollapsed) {
+                invoke.invokeMethodAsync(options.triggerCollapsed);
+            }
+        }
+    });
     const input = el.querySelector(`#${id}_input`);
     const select = {
         el, invoke, options,

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -439,6 +439,23 @@ public class SelectTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Instance.TriggerCollapsed());
         Assert.True(collapsed);
     }
+
+    [Fact]
+    public async Task IsAutoClearSearchTextWhenCollapsed_Ok()
+    {
+        var cut = Context.RenderComponent<Select<string>>(pb =>
+        {
+            pb.Add(a => a.ShowSearch, true);
+            pb.Add(a => a.IsAutoClearSearchTextWhenCollapsed, true);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.TriggerOnSearch("123"));
+        cut.Contains("value=\"123\"");
+
+        await cut.InvokeAsync(() => cut.Instance.TriggerCollapsed());
+        cut.Contains("value=\"\"");
+    }
+
     [Fact]
     public void Validate_Ok()
     {

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -429,6 +429,17 @@ public class SelectTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task OnCollapsed_Ok()
+    {
+        var collapsed = false;
+        var cut = Context.RenderComponent<Select<string>>(pb =>
+        {
+            pb.Add(a => a.OnCollapsed, () => { collapsed = true; return Task.CompletedTask; });
+        });
+        await cut.InvokeAsync(() => cut.Instance.TriggerCollapsed());
+        Assert.True(collapsed);
+    }
+    [Fact]
     public void Validate_Ok()
     {
         var valid = false;


### PR DESCRIPTION
## Link issues
fixes #6019 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Implement automatic search text clearance and collapse event callback for the Select component by adding new parameters, wiring JS interop hide callback, and updating tests and samples.

New Features:
- Add IsAutoClearSearchTextWhenCollapsed parameter to Select component to automatically clear search text when collapsed
- Introduce OnCollapsed callback parameter to notify when dropdown is collapsed

Bug Fixes:
- Clear stale search text on collapse to address issue #6019

Enhancements:
- Hook into the JS popover hide callback to invoke the collapse logic
- Update sample attributes in Selects.razor.cs to include the new parameter

Documentation:
- Document the new IsAutoClearSearchTextWhenCollapsed parameter in component samples

Tests:
- Add unit tests verifying OnCollapsed invocation
- Add unit tests verifying search text is cleared when IsAutoClearSearchTextWhenCollapsed is enabled