### PR TITLE
feat(Select): add ShowSwal parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Selects.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Selects.razor.cs
@@ -439,6 +439,14 @@ public sealed partial class Selects
             Type = "string",
             ValueList = " — ",
             DefaultValue = " — "
+        },
+        new()
+        {
+            Name = nameof(Select<string>.ShowSwal),
+            Description = Localizer["SelectsShowSwal"],
+            Type = "bool",
+            ValueList = "true|false",
+            DefaultValue = "true"
         }
     ];
 }

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3267,7 +3267,8 @@
     "TextConvertToValueCallback": "Callback method when input text changes in edit mode",
     "SelectsIsEditable": "Whether editable",
     "SelectsIsVirtualize": "Wether to enable virtualize",
-    "SelectsDefaultVirtualizeItemText": "The text string corresponding to the first load value when virtual scrolling is turned on is separated by commas"
+    "SelectsDefaultVirtualizeItemText": "The text string corresponding to the first load value when virtual scrolling is turned on is separated by commas",
+    "SelectsShowSwal": "Whether show the swal confirm popup"
   },
   "BootstrapBlazor.Server.Components.Samples.Sliders": {
     "SlidersTitle": "Slider",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3267,7 +3267,8 @@
     "TextConvertToValueCallback": "编辑模式下输入文本变化时回调方法",
     "SelectsIsEditable": "是否可编辑",
     "SelectsIsVirtualize": "是否开启虚拟滚动",
-    "SelectsDefaultVirtualizeItemText": "开启虚拟滚动时首次加载 Value 对应的文本字符串用逗号分割"
+    "SelectsDefaultVirtualizeItemText": "开启虚拟滚动时首次加载 Value 对应的文本字符串用逗号分割",
+    "SelectsShowSwal": "是否显示 Swal 确认弹窗"
   },
   "BootstrapBlazor.Server.Components.Samples.Sliders": {
     "SlidersTitle": "Slider 滑块",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.4-beta02</Version>
+    <Version>9.6.4-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -58,6 +58,12 @@ public partial class Select<TValue> : ISelect, ILookup
     public Func<SelectedItem, Task<bool>>? OnBeforeSelectedItemChange { get; set; }
 
     /// <summary>
+    /// Gets or sets whether show the swal popup when <see cref="OnBeforeSelectedItemChange"/> return true. Default is true.
+    /// </summary>
+    [Parameter]
+    public bool ShowSwal { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets the callback method when the selected item changes.
     /// </summary>
     [Parameter]
@@ -338,7 +344,7 @@ public partial class Select<TValue> : ISelect, ILookup
         if (OnBeforeSelectedItemChange != null)
         {
             ret = await OnBeforeSelectedItemChange(item);
-            if (ret)
+            if (ret && ShowSwal)
             {
                 // Return true to show modal
                 var option = new SwalOption()
@@ -353,10 +359,6 @@ public partial class Select<TValue> : ISelect, ILookup
                     option.FooterTemplate = builder => builder.AddContent(0, SwalFooter);
                 }
                 ret = await SwalService.ShowModal(option);
-            }
-            else
-            {
-                return;
             }
         }
         if (ret)

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -58,7 +58,7 @@ public partial class Select<TValue> : ISelect, ILookup
     public Func<SelectedItem, Task<bool>>? OnBeforeSelectedItemChange { get; set; }
 
     /// <summary>
-    /// Gets or sets whether show the swal popup when <see cref="OnBeforeSelectedItemChange"/> return true. Default is true.
+    /// Gets or sets whether to show the Swal confirmation popup when <see cref="OnBeforeSelectedItemChange"/> returns true. Default is true.
     /// 获得/设置 是否显示 Swal 确认弹窗
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -59,6 +59,7 @@ public partial class Select<TValue> : ISelect, ILookup
 
     /// <summary>
     /// Gets or sets whether show the swal popup when <see cref="OnBeforeSelectedItemChange"/> return true. Default is true.
+    /// 获得/设置 是否显示 Swal 确认弹窗
     /// </summary>
     [Parameter]
     public bool ShowSwal { get; set; } = true;


### PR DESCRIPTION
## Link issues
fixes #6035 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot
This pull request introduces a new `ShowSwal` parameter to the `Select<TValue>` component, allowing developers to control whether a Swal confirmation popup is displayed during item selection. Additionally, associated localization strings have been added, and the project version has been updated.

### Feature Addition: `ShowSwal` Parameter

* [`src/BootstrapBlazor/Components/Select/Select.razor.cs`](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bR60-R66): Added a new `[Parameter]` property `ShowSwal` to control whether the Swal confirmation popup is displayed when `OnBeforeSelectedItemChange` returns true. Default is set to `true`. Updated the `OnClickItem` method to respect this new parameter. [[1]](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bR60-R66) [[2]](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bL341-R348) [[3]](diffhunk://#diff-4b59afd1f94130ce8dd2845bcf0a02ebedded1184898d1478bc3023510010c2bL357-L360)

### Localization Updates

* [`src/BootstrapBlazor.Server/Locales/en-US.json`](diffhunk://#diff-790d42ebea731775f0fee88a92b20fadb044e53706fd6d3025dfa095df9b1b41L3270-R3271): Added a new localization string `SelectsShowSwal` for the `ShowSwal` parameter description.
* [`src/BootstrapBlazor.Server/Locales/zh-CN.json`](diffhunk://#diff-746b8cc3c80dd10d0a1bf77b8d6571652e15bcc7c33dcac0954d93b1a728cc7fL3270-R3271): Added a Chinese localization string for `SelectsShowSwal`.

### Code Example Updates

* [`src/BootstrapBlazor.Server/Components/Samples/Selects.razor.cs`](diffhunk://#diff-f9acebf8daf7961532146196175320f775b3539b8518fa39c101ad7d3e6bfe1dR442-R449): Updated the `GetAttributes` method to include the new `ShowSwal` property in the component's attribute list.

### Project Version Update

* [`src/BootstrapBlazor/BootstrapBlazor.csproj`](diffhunk://#diff-07918ce1b66955e76da5cd0ffa38512cce984fa2a09735a60e0db37b45235527L4-R4): Incremented the project version from `9.6.4-beta02` to `9.6.4-beta03`.

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a ShowSwal parameter to the Select component for optional display of confirmation popups, update related sample metadata and localization, and bump the project version.

New Features:
- Introduce ShowSwal parameter to Select component to toggle Swal confirmation popup

Enhancements:
- Update item click handler to respect ShowSwal setting
- Add ShowSwal attribute to sample component metadata

Build:
- Bump project version to 9.6.4-beta03

Documentation:
- Add localization strings for ShowSwal parameter in English and Chinese