### PR TITLE
fix(Textarea): set UseShiftEnter to true not work

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.4-beta03</Version>
+    <Version>9.6.4-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Textarea/Textarea.razor.js
+++ b/src/BootstrapBlazor/Components/Textarea/Textarea.razor.js
@@ -3,7 +3,7 @@ import Data from "../../modules/data.js"
 import EventHandler from "../../modules/event-handler.js"
 
 export function init(id) {
-    var el = document.getElementById(id);
+    const el = document.getElementById(id);
     const text = {
         prevMethod: '',
         element: el
@@ -14,7 +14,7 @@ export function init(id) {
         if (e.key === "Enter" || e.key === "NumpadEnter") {
             const useShiftEnter = el.getAttribute('data-bb-shift-enter') === 'true';
             const shiftKey = e.shiftKey;
-            if (shiftKey && useShiftEnter) {
+            if (useShiftEnter && shiftKey === false) {
                 e.preventDefault();
             }
         }


### PR DESCRIPTION
## Link issues
fixes #6057 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix textarea Shift+Enter behavior and update variable declaration in Textarea.razor.js

Bug Fixes:
- Prevent default action on plain Enter when shift-enter mode is enabled

Enhancements:
- Use const instead of var for element reference