### PR TITLE
fix(Table): remove ShowExtendEditButton/ShowExtendDeleteButton check condition

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.6.5-beta01</Version>
+    <Version>9.6.5-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -545,6 +545,7 @@ public partial class Table<TItem>
         if (SelectedRows.Count == 1)
         {
             // 检查是否选中了不可编辑行（行内无编辑按钮），同时检查按钮禁用状态（禁用时不可编辑）
+            // ShowExtendEditButton 不参与逻辑，不显示扩展编辑按钮时用户可能自定义按钮调用 EditAsync 方法
             if (ProhibitEdit())
             {
                 // 提示不可编辑
@@ -1004,12 +1005,10 @@ public partial class Table<TItem>
     }
 
     private bool ProhibitEdit() => (ShowExtendEditButtonCallback != null && !ShowExtendEditButtonCallback(SelectedRows[0]))
-                || !ShowExtendEditButton
-                || (DisableExtendEditButtonCallback != null && DisableExtendEditButtonCallback(SelectedRows[0]))
-                || DisableExtendEditButton;
+            || (DisableExtendEditButtonCallback != null && DisableExtendEditButtonCallback(SelectedRows[0]))
+            || DisableExtendEditButton;
 
     private bool ProhibitDelete() => (ShowExtendDeleteButtonCallback != null && SelectedRows.Any(i => !ShowExtendDeleteButtonCallback(i)))
-            || !ShowExtendDeleteButton
             || (DisableExtendDeleteButtonCallback != null && SelectedRows.Any(x => DisableExtendDeleteButtonCallback(x)))
             || DisableExtendDeleteButton;
 

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -8679,8 +8679,10 @@ public class TableTest : BootstrapBlazorTestBase
             pb.Add(a => a.ShowExtendEditButton, false);
             pb.Add(a => a.ShowExtendDeleteButton, false);
         });
-        Assert.True(ProhibitEdit(cut.Instance));
-        Assert.True(ProhibitDelete(cut.Instance));
+
+        // 不显示编辑删除按钮不参与是否可编辑删除判断，用户可能自定义按钮编辑或者删除当前行
+        Assert.False(ProhibitEdit(cut.Instance));
+        Assert.False(ProhibitDelete(cut.Instance));
 
         cut.SetParametersAndRender(pb =>
         {


### PR DESCRIPTION
## Link issues
fixes #6089 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove ShowExtendEditButton and ShowExtendDeleteButton flags from the internal edit/delete prohibition logic so that disabling those UI buttons no longer blocks programmatic calls, and update corresponding unit tests to reflect the new behavior.

Bug Fixes:
- Omit ShowExtendEditButton and ShowExtendDeleteButton checks from ProhibitEdit and ProhibitDelete logic to prevent unintended blocking of edit/delete methods
- Update ProhibitEditAsync and ConfirmDeleteAsync methods to only consider disable callbacks and flags, not show flags

Tests:
- Adjust Table unit tests to expect ProhibitEdit and ProhibitDelete return false when only show flags are false