### PR TITLE
feat(BootstrapBlazorOptions): add ShowErrorLoggerToast parameter

### DIFF
--- a/src/BootstrapBlazor/Components/BaseComponents/BootstrapBlazorRoot.razor
+++ b/src/BootstrapBlazor/Components/BaseComponents/BootstrapBlazorRoot.razor
@@ -2,7 +2,7 @@
 @namespace BootstrapBlazor.Components
 
 <CascadingValue Value="this" IsFixed="true">
-    <ErrorLogger EnableErrorLogger="EnableErrorLoggerValue" ShowToast="ShowToast" ToastTitle="@ToastTitle" OnErrorHandleAsync="OnErrorHandleAsync!">
+    <ErrorLogger EnableErrorLogger="_enableErrorLoggerValue" ShowToast="_showToast" ToastTitle="@ToastTitle" OnErrorHandleAsync="OnErrorHandleAsync!">
         @ChildContent
 
         <Dialog></Dialog>

--- a/src/BootstrapBlazor/Components/BaseComponents/BootstrapBlazorRoot.razor.cs
+++ b/src/BootstrapBlazor/Components/BaseComponents/BootstrapBlazorRoot.razor.cs
@@ -48,10 +48,10 @@ public partial class BootstrapBlazorRoot
     public Func<ILogger, Exception, Task>? OnErrorHandleAsync { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示 Error 提示弹窗 默认 true 显示
+    /// 获得/设置 是否显示 Error 提示弹窗 默认 null 使用 <see cref="BootstrapBlazorOptions.ShowErrorLoggerToast"/> 设置值
     /// </summary>
     [Parameter]
-    public bool ShowToast { get; set; } = true;
+    public bool? ShowToast { get; set; }
 
     /// <summary>
     /// 获得/设置 Error Toast 弹窗标题
@@ -65,7 +65,9 @@ public partial class BootstrapBlazorRoot
     [Parameter]
     public bool? EnableErrorLogger { get; set; }
 
-    private bool EnableErrorLoggerValue => EnableErrorLogger ?? Options.CurrentValue.EnableErrorLogger;
+    private bool _enableErrorLoggerValue => EnableErrorLogger ?? Options.CurrentValue.EnableErrorLogger;
+
+    private bool _showToast => ShowToast ?? Options.CurrentValue.ShowErrorLoggerToast;
 
     /// <summary>
     /// SetParametersAsync 方法

--- a/src/BootstrapBlazor/Options/BootstrapBlazorOptions.cs
+++ b/src/BootstrapBlazor/Options/BootstrapBlazorOptions.cs
@@ -49,6 +49,11 @@ public class BootstrapBlazorOptions : IOptions<BootstrapBlazorOptions>
     public bool EnableErrorLogger { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets whether to enable show toast popup when global exception capture, default is true
+    /// </summary>
+    public bool ShowErrorLoggerToast { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets whether to fall back to the fallback culture, default is true
     /// </summary>
     public bool EnableFallbackCulture { get; set; } = true;

--- a/test/UnitTest/Options/BootstrapBlazorOptionsTest.cs
+++ b/test/UnitTest/Options/BootstrapBlazorOptionsTest.cs
@@ -13,6 +13,7 @@ public class BootstrapBlazorOptionsTest
         var options = new BootstrapBlazorOptions()
         {
             EnableErrorLogger = true,
+            ShowErrorLoggerToast = true,
             EnableFallbackCulture = true,
             JSModuleVersion = "1.0",
             TableSettings = new()


### PR DESCRIPTION
## Link issues
fixes #6116 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce a ShowErrorLoggerToast option to configure the display of error logger toasts, update the ShowToast parameter to be nullable and fallback to this new option, and adjust the root component and tests accordingly.

New Features:
- Add ShowErrorLoggerToast property to BootstrapBlazorOptions for controlling error toast display

Enhancements:
- Make ShowToast parameter nullable and default its value from the new ShowErrorLoggerToast option
- Update BootstrapBlazorRoot component to use the new configuration fallback for error logger toasts

Tests:
- Include ShowErrorLoggerToast in the BootstrapBlazorOptions unit test