### PR TITLE
feat(SelectGeneric): add reset logic when TextConvertToValueCallback return null

### DIFF
--- a/src/BootstrapBlazor/Components/Select/Select.razor.js
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.js
@@ -50,6 +50,13 @@ export function hide(id) {
     }
 }
 
+export function resetValue(id, value) {
+    const input = document.getElementById(id);
+    if (input) {
+        input.value = value;
+    }
+}
+
 export function dispose(id) {
     const select = Data.get(id)
     Data.remove(id)

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor
@@ -16,7 +16,7 @@
         <div class="dropdown-toggle" data-bs-toggle="@ToggleString" data-bs-placement="@PlacementString" data-bs-offset="@OffsetString" data-bs-custom-class="@CustomClassString">
             @if (DisplayTemplate != null)
             {
-                <div id="@InputId" class="@InputClassString" tabindex="0">
+                <div id="@InputId" class="@InputClassString">
                     @DisplayTemplate(SelectedRow)
                 </div>
             }

--- a/test/UnitTest/Components/SelectGenericTest.cs
+++ b/test/UnitTest/Components/SelectGenericTest.cs
@@ -868,12 +868,13 @@ public class SelectGenericTest : BootstrapBlazorTestBase
         // 覆盖返回 null 逻辑
         cut.SetParametersAndRender(pb =>
         {
-            pb.Add(a => a.TextConvertToValueCallback, v =>
+            pb.Add(a => a.TextConvertToValueCallback, async v =>
             {
-                return Task.FromResult((string?)null);
+                await Task.Yield();
+                return null;
             });
         });
-        Assert.Equal("Test4", cut.Instance.Value);
+        await cut.InvokeAsync(() => { input.Change("Test3"); });
     }
 
     [Fact]

--- a/test/UnitTest/Components/SelectGenericTest.cs
+++ b/test/UnitTest/Components/SelectGenericTest.cs
@@ -875,6 +875,12 @@ public class SelectGenericTest : BootstrapBlazorTestBase
             });
         });
         await cut.InvokeAsync(() => { input.Change("Test4"); });
+
+        cut.SetParametersAndRender(pb =>
+        {
+           pb.Add(a => a.Value, null);
+        });
+        await cut.InvokeAsync(() => { input.Change("Test5"); });
     }
 
     [Fact]

--- a/test/UnitTest/Components/SelectGenericTest.cs
+++ b/test/UnitTest/Components/SelectGenericTest.cs
@@ -874,7 +874,7 @@ public class SelectGenericTest : BootstrapBlazorTestBase
                 return null;
             });
         });
-        await cut.InvokeAsync(() => { input.Change("Test3"); });
+        await cut.InvokeAsync(() => { input.Change("Test4"); });
     }
 
     [Fact]

--- a/test/UnitTest/Components/SelectGenericTest.cs
+++ b/test/UnitTest/Components/SelectGenericTest.cs
@@ -873,6 +873,7 @@ public class SelectGenericTest : BootstrapBlazorTestBase
                 return Task.FromResult((string?)null);
             });
         });
+        Assert.Equal("Test4", cut.Instance.Value);
     }
 
     [Fact]
@@ -890,7 +891,7 @@ public class SelectGenericTest : BootstrapBlazorTestBase
             pb.Add(a => a.IsEditable, true);
             pb.Add(a => a.TextConvertToValueCallback, v =>
             {
-                return Task.FromResult(new Foo() { Id = 3, Address = "Foo3" });
+                return Task.FromResult(new Foo() { Id = 3, Address = "Foo3" })!;
             });
         });
 

--- a/test/UnitTest/Components/SelectGenericTest.cs
+++ b/test/UnitTest/Components/SelectGenericTest.cs
@@ -856,7 +856,7 @@ public class SelectGenericTest : BootstrapBlazorTestBase
             });
             pb.Add(a => a.TextConvertToValueCallback, v =>
             {
-                return Task.FromResult(v);
+                return Task.FromResult(v)!;
             });
         });
         Assert.False(input.IsReadOnly());
@@ -864,6 +864,15 @@ public class SelectGenericTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => { input.Change("Test3"); });
         Assert.Equal("Test3", cut.Instance.Value);
         Assert.True(updated);
+
+        // 覆盖返回 null 逻辑
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.TextConvertToValueCallback, v =>
+            {
+                return Task.FromResult((string?)null);
+            });
+        });
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #6120 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Implement fallback logic in SelectGeneric to discard invalid text conversions and reset the displayed input value when the conversion callback returns null

New Features:
- Reset the input display when TextConvertToValueCallback returns null

Enhancements:
- Allow TextConvertToValueCallback to return null by updating its signature to Task<TValue?>
- Add a JavaScript resetValue method and invoke it to restore the previous display on null conversions
- Remove tabindex attribute from the display template container

Tests:
- Add unit tests to cover scenarios where TextConvertToValueCallback returns null and ensure no state change