### PR TITLE
revert(IErrorLogger): revert update bool to nullable bool

### DIFF
--- a/src/BootstrapBlazor/Components/ErrorLogger/ErrorLogger.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/ErrorLogger.cs
@@ -22,13 +22,13 @@ public class ErrorLogger : ComponentBase, IErrorLogger
     /// <inheritdoc/>
     /// </summary>
     [Parameter]
-    public bool? EnableErrorLogger { get; set; }
+    public bool EnableErrorLogger { get; set; } = true;
 
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
     [Parameter]
-    public bool? ShowToast { get; set; }
+    public bool ShowToast { get; set; } = true;
 
     /// <summary>
     /// <inheritdoc/>
@@ -62,10 +62,6 @@ public class ErrorLogger : ComponentBase, IErrorLogger
     [Parameter]
     public Func<ErrorLogger, Task>? OnInitializedCallback { get; set; }
 
-    [Inject]
-    [NotNull]
-    private IOptionsMonitor<BootstrapBlazorOptions>? Options { get; set; }
-
     [NotNull]
     private BootstrapBlazorErrorBoundary? _errorBoundary = default;
 
@@ -77,8 +73,6 @@ public class ErrorLogger : ComponentBase, IErrorLogger
         base.OnInitialized();
 
         ToastTitle ??= Localizer[nameof(ToastTitle)];
-        EnableErrorLogger ??= Options.CurrentValue.EnableErrorLogger;
-        ShowToast ??= Options.CurrentValue.ShowErrorLoggerToast;
     }
 
     /// <summary>
@@ -108,7 +102,7 @@ public class ErrorLogger : ComponentBase, IErrorLogger
         builder.CloseComponent();
     }
 
-    private RenderFragment? RenderContent => (EnableErrorLogger ?? false) ? RenderError : ChildContent;
+    private RenderFragment? RenderContent => EnableErrorLogger ? RenderError : ChildContent;
 
     private RenderFragment RenderError => builder =>
     {

--- a/src/BootstrapBlazor/Components/ErrorLogger/IErrorLogger.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/IErrorLogger.cs
@@ -11,9 +11,9 @@ namespace BootstrapBlazor.Components;
 public interface IErrorLogger
 {
     /// <summary>
-    /// 获得/设置 是否开启全局异常捕获 默认 null 使用全局配置 <see cref="BootstrapBlazorOptions.EnableErrorLogger"/> 值
+    /// 获得/设置 是否开启全局异常捕获 默认 true
     /// </summary>
-    bool? EnableErrorLogger { get; set; }
+    bool EnableErrorLogger { get; set; }
 
     /// <summary>
     /// 获得/设置 自定义 Error 处理方法 默认 null
@@ -23,9 +23,9 @@ public interface IErrorLogger
     Task HandlerExceptionAsync(Exception ex);
 
     /// <summary>
-    /// 获得 是否显示 Error 提示弹窗 默认 null 使用全局配置 <see cref="BootstrapBlazorOptions.ShowErrorLoggerToast"/> 值
+    /// 获得 是否显示 Error 提示弹窗 默认 true
     /// </summary>
-    bool? ShowToast { get; }
+    bool ShowToast { get; }
 
     /// <summary>
     /// 获得 Error Toast 弹窗标题 默认读取资源文件内容


### PR DESCRIPTION
## Link issues
fixes #6140 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Revert the change that made error logger flags nullable by restoring EnableErrorLogger and ShowToast as non-nullable booleans with default values, remove options-based fallback, and simplify rendering logic.

Bug Fixes:
- Restore EnableErrorLogger and ShowToast as non-nullable bools with default true to prevent unintended null handling.

Enhancements:
- Remove IOptionsMonitor injection and config-based initialization for error logger options.