### PR TITLE
refactor(Tab): remove ShowErrorLoggerToast parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Layout/Layout.razor
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor
@@ -148,8 +148,7 @@
           RefreshToolbarTooltipText="@RefreshToolbarTooltipText" FullscreenToolbarTooltipText="@FullscreenToolbarTooltipText"
           OnToolbarRefreshCallback="OnToolbarRefreshCallback" TabHeader="TabHeader"
           Body="@Main" NotAuthorized="NotAuthorized!" NotFound="NotFound!" NotFoundTabText="@NotFoundTabText"
-          EnableErrorLogger="@_enableErrorLogger" ShowErrorLoggerToast="@_showToast"
-          ErrorLoggerToastTitle="@ErrorLoggerToastTitle">
+          EnableErrorLogger="@_enableErrorLogger" ErrorLoggerToastTitle="@ErrorLoggerToastTitle">
     </Tab>;
 
     RenderFragment RenderFooter =>

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor
@@ -21,7 +21,7 @@ else
             <CascadingValue Value="this" IsFixed="true">
                 @if (IsOnlyRenderActiveTab)
                 {
-                    var item = Items.FirstOrDefault(i => i.IsActive);
+                    var item = TabItems.Find(i => i.IsActive);
                     if (item != null)
                     {
                         @RenderTabItem(item)
@@ -29,7 +29,7 @@ else
                 }
                 else
                 {
-                    foreach (var item in Items)
+                    foreach (var item in TabItems)
                     {
                         @RenderTabItem(item)
                     }

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -438,12 +438,6 @@ public partial class Tab
     public bool? EnableErrorLogger { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否显示 Error 提示弹窗 默认 null 使用 <see cref="BootstrapBlazorOptions.ShowErrorLoggerToast"/> 设置值
-    /// </summary>
-    [Parameter]
-    public bool? ShowErrorLoggerToast { get; set; }
-
-    /// <summary>
     /// 获得/设置 错误日志 <see cref="Toast"/> 弹窗标题 默认 null
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -614,7 +614,7 @@ public partial class Tab
         if (!Excluded)
         {
             // 地址相同参数不同需要重新渲染 TabItem
-            var tab = Items.FirstOrDefault(tab => tab.Url.TrimStart('/').Equals(requestUrl, StringComparison.OrdinalIgnoreCase));
+            var tab = TabItems.Find(tab => tab.Url.TrimStart('/').Equals(requestUrl, StringComparison.OrdinalIgnoreCase));
             if (tab != null)
             {
                 ActiveTabItem(tab);
@@ -652,7 +652,7 @@ public partial class Tab
     /// </summary>
     public void ClickPrevTab()
     {
-        var item = Items.FirstOrDefault(i => i.IsActive);
+        var item = TabItems.FirstOrDefault(i => i.IsActive);
         if (item != null)
         {
             var index = TabItems.IndexOf(item);
@@ -1036,8 +1036,8 @@ public partial class Tab
     [JSInvokable]
     public async Task DragItemCallback(int originIndex, int currentIndex)
     {
-        var firstColumn = Items.ElementAtOrDefault(originIndex);
-        var targetColumn = Items.ElementAtOrDefault(currentIndex);
+        var firstColumn = TabItems.ElementAtOrDefault(originIndex);
+        var targetColumn = TabItems.ElementAtOrDefault(currentIndex);
         if (firstColumn != null && targetColumn != null)
         {
             if (_draggedItems.Count == 0)
@@ -1138,11 +1138,12 @@ public partial class Tab
 
     private RenderFragment RenderTabList() => builder =>
     {
-        if (!Items.Any() && !string.IsNullOrEmpty(DefaultUrl))
+        if (TabItems.Count == 0 && !string.IsNullOrEmpty(DefaultUrl))
         {
             if (ClickTabToNavigation)
             {
                 Navigator.NavigateTo(DefaultUrl);
+                return;
             }
             else
             {
@@ -1152,9 +1153,13 @@ public partial class Tab
 
         if (FirstRender)
         {
-            if (!Items.Any(t => t.IsActive))
+            if (TabItems.Find(t => t.IsActive) == null)
             {
-                Items.FirstOrDefault(i => i.IsDisabled == false)?.SetActive(true);
+                var item = TabItems.Find(i => i.IsDisabled == false);
+                if (item != null)
+                {
+                    item.SetActive(true);
+                }
             }
         }
 
@@ -1186,7 +1191,7 @@ public partial class Tab
 
     private RenderFragment RenderTabItems() => builder =>
     {
-        foreach (var item in Items)
+        foreach (var item in TabItems)
         {
             if (item.HeaderTemplate != null)
             {

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -68,8 +68,7 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
         builder.AddAttribute(2, nameof(ErrorLogger.EnableErrorLogger), enableErrorLogger);
 
         // TabItem 不需要 Toast 提示错误信息
-        var showToast = TabSet.ShowErrorLoggerToast ?? false;
-        builder.AddAttribute(3, nameof(ErrorLogger.ShowToast), showToast);
+        builder.AddAttribute(3, nameof(ErrorLogger.ShowToast), false);
         builder.AddAttribute(4, nameof(ErrorLogger.ToastTitle), TabSet.ErrorLoggerToastTitle);
         builder.AddAttribute(5, nameof(ErrorLogger.OnInitializedCallback), new Func<ErrorLogger, Task>(logger =>
         {

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -65,9 +65,10 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
         builder.AddAttribute(1, nameof(ErrorLogger.ChildContent), content);
 
         var enableErrorLogger = TabSet.EnableErrorLogger ?? Options.CurrentValue.EnableErrorLogger;
-        var showToast = TabSet.ShowErrorLoggerToast ?? Options.CurrentValue.ShowErrorLoggerToast;
         builder.AddAttribute(2, nameof(ErrorLogger.EnableErrorLogger), enableErrorLogger);
-        builder.AddAttribute(3, nameof(ErrorLogger.ShowToast), showToast);
+
+        // TabItem 不需要 Toast 提示错误信息
+        builder.AddAttribute(3, nameof(ErrorLogger.ShowToast), false);
         builder.AddAttribute(4, nameof(ErrorLogger.ToastTitle), TabSet.ErrorLoggerToastTitle);
         builder.AddAttribute(5, nameof(ErrorLogger.OnInitializedCallback), new Func<ErrorLogger, Task>(logger =>
         {

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -68,7 +68,8 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
         builder.AddAttribute(2, nameof(ErrorLogger.EnableErrorLogger), enableErrorLogger);
 
         // TabItem 不需要 Toast 提示错误信息
-        builder.AddAttribute(3, nameof(ErrorLogger.ShowToast), false);
+        var showToast = TabSet.ShowErrorLoggerToast ?? false;
+        builder.AddAttribute(3, nameof(ErrorLogger.ShowToast), showToast);
         builder.AddAttribute(4, nameof(ErrorLogger.ToastTitle), TabSet.ErrorLoggerToastTitle);
         builder.AddAttribute(5, nameof(ErrorLogger.OnInitializedCallback), new Func<ErrorLogger, Task>(logger =>
         {


### PR DESCRIPTION
## Link issues
fixes #6149

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove the ShowErrorLoggerToast parameter from the Tab component and layout, disable toast display for error logging in tab items, and consolidate tab item handling to use the TabItems collection.

Enhancements:
- Remove the ShowErrorLoggerToast parameter and related layout attribute from the Tab component
- Always disable error-toast display in TabItemContent by setting ShowToast to false
- Replace all usages of the Items collection with the TabItems property in tab rendering, activation, navigation, and drag operations
- Simplify default-tab rendering logic and ensure consistent TabItems-based traversal