### PR TITLE
feat(IErrorLogger): support Release mode only show exception message

### DIFF
--- a/src/BootstrapBlazor/Components/ErrorLogger/BootstrapBlazorErrorBoundary.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/BootstrapBlazorErrorBoundary.cs
@@ -5,6 +5,7 @@
 
 using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System.Reflection;
 
@@ -31,6 +32,10 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
     [NotNull]
     private NavigationManager? NavigationManager { get; set; }
 
+    [Inject]
+    [NotNull]
+    private IHostEnvironment? IHostEnvironment { get; set; }
+
     /// <summary>
     /// 获得/设置 自定义错误处理回调方法
     /// </summary>
@@ -54,13 +59,10 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
     /// <inheritdoc/>
     /// </summary>
     /// <param name="exception"></param>
-    protected override async Task OnErrorAsync(Exception exception)
+    protected override Task OnErrorAsync(Exception exception)
     {
-        if (ShowToast)
-        {
-            await ToastService.Error(ToastTitle, exception.Message);
-        }
         Logger.LogError(exception, "{BootstrapBlazorErrorBoundary} {OnErrorAsync} log this error occurred at {Page}", nameof(BootstrapBlazorErrorBoundary), nameof(OnErrorAsync), NavigationManager.Uri);
+        return Task.CompletedTask;
     }
 
     /// <summary>
@@ -69,13 +71,13 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
     /// <param name="builder"></param>
     protected override void BuildRenderTree(RenderTreeBuilder builder)
     {
+        // 页面生命周期内异常直接调用这里
         var ex = CurrentException ?? _exception;
         if (ex != null)
         {
             // 处理自定义异常逻辑
             if (OnErrorHandleAsync != null)
             {
-                // 页面生命周期内异常直接调用这里
                 _ = OnErrorHandleAsync(Logger, ex);
                 return;
             }
@@ -132,7 +134,7 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
     }
 
     /// <summary>
-    /// 渲染异常信息方法
+    /// BootstrapBlazor 组件导致异常渲染方法
     /// </summary>
     /// <param name="exception"></param>
     /// <param name="handler"></param>
@@ -145,14 +147,35 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
             return;
         }
 
+        // 记录日志
+        await OnErrorAsync(exception);
+
         if (handler != null)
         {
-            await handler.HandlerException(exception, ExceptionContent);
+            if (IHostEnvironment.IsDevelopment())
+            {
+                // IHandlerException 处理异常逻辑
+                await handler.HandlerException(exception, ExceptionContent);
+            }
+            else
+            {
+                // 非开发模式下弹窗提示错误信息
+                await ToastService.Error(ToastTitle, exception.Message);
+            }
             return;
         }
 
-        await OnErrorAsync(exception);
+        // 显示异常信息
+        await ShowErrorToast(exception);
         _exception = exception;
         StateHasChanged();
+    }
+
+    private async Task ShowErrorToast(Exception exception)
+    {
+        if (ShowToast)
+        {
+            await ToastService.Error(ToastTitle, exception.Message);
+        }
     }
 }

--- a/src/BootstrapBlazor/Components/ErrorLogger/BootstrapBlazorErrorBoundary.cs
+++ b/src/BootstrapBlazor/Components/ErrorLogger/BootstrapBlazorErrorBoundary.cs
@@ -34,7 +34,7 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
 
     [Inject]
     [NotNull]
-    private IHostEnvironment? IHostEnvironment { get; set; }
+    private IHostEnvironment? HostEnvironment { get; set; }
 
     /// <summary>
     /// 获得/设置 自定义错误处理回调方法
@@ -152,7 +152,7 @@ class BootstrapBlazorErrorBoundary : ErrorBoundaryBase
 
         if (handler != null)
         {
-            if (IHostEnvironment.IsDevelopment())
+            if (HostEnvironment.IsDevelopment())
             {
                 // IHandlerException 处理异常逻辑
                 await handler.HandlerException(exception, ExceptionContent);

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -673,7 +673,7 @@ public partial class Layout : IHandlerException, ITabHeader
     private RenderFragment? _errorContent;
 
     /// <summary>
-    /// HandlerException 错误处理方法
+    /// <inheritdoc/>
     /// </summary>
     /// <param name="ex"></param>
     /// <param name="errorContent"></param>

--- a/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/ModalDialog.razor.cs
@@ -449,7 +449,7 @@ public partial class ModalDialog : IHandlerException
     protected RenderFragment? _errorContent;
 
     /// <summary>
-    /// HandlerException 错误处理方法
+    /// <inheritdoc/>
     /// </summary>
     /// <param name="ex"></param>
     /// <param name="errorContent"></param>

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -93,11 +93,14 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
     }
 
     /// <summary>
-    /// HandlerException 错误处理方法
+    /// <inheritdoc/>
     /// </summary>
     /// <param name="ex"></param>
     /// <param name="errorContent"></param>
-    public Task HandlerException(Exception ex, RenderFragment<Exception> errorContent) => DialogService.ShowErrorHandlerDialog(errorContent(ex));
+    public async Task HandlerException(Exception ex, RenderFragment<Exception> errorContent)
+    {
+        await DialogService.ShowErrorHandlerDialog(errorContent(ex));
+    }
 
     /// <summary>
     /// IDispose 方法用于释放资源

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -97,10 +97,7 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
     /// </summary>
     /// <param name="ex"></param>
     /// <param name="errorContent"></param>
-    public async Task HandlerException(Exception ex, RenderFragment<Exception> errorContent)
-    {
-        await DialogService.ShowErrorHandlerDialog(errorContent(ex));
-    }
+    public Task HandlerException(Exception ex, RenderFragment<Exception> errorContent) => DialogService.ShowErrorHandlerDialog(errorContent(ex));
 
     /// <summary>
     /// IDispose 方法用于释放资源

--- a/src/BootstrapBlazor/Directory.Build.props
+++ b/src/BootstrapBlazor/Directory.Build.props
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="$(NET6Version)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(NET8Version)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(NET8Version)" />
   </ItemGroup>
 
@@ -44,6 +45,7 @@
     <PackageReference Include="Microsoft.Extensions.Localization" Version="$(NET7Version)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(NET8Version)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="$(NET8Version)" />
   </ItemGroup>
 
@@ -53,6 +55,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(NET8Version)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(NET8Version)" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="$(NET8Version)" />
   </ItemGroup>
 
@@ -62,6 +65,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="$(NET9Version)" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="$(NET9Version)" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="$(NET9Version)" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="$(NET9Version)" />
     <PackageReference Include="Microsoft.Extensions.Localization" Version="$(NET9Version)" />
   </ItemGroup>
 

--- a/test/UnitTest/Components/BootstrapBlazorRootTest.cs
+++ b/test/UnitTest/Components/BootstrapBlazorRootTest.cs
@@ -5,6 +5,8 @@
 
 //using HarmonyLib;
 
+using Bunit.TestDoubles;
+
 namespace UnitTest.Components;
 
 public class BootstrapBlazorRootTest : TestBase
@@ -12,17 +14,10 @@ public class BootstrapBlazorRootTest : TestBase
     [Fact]
     public void Render_Ok()
     {
-        var context = new TestContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-
-        var sc = context.Services;
-        sc.AddBootstrapBlazor();
-        sc.ConfigureJsonLocalizationOptions(op =>
-        {
-            op.IgnoreLocalizerMissing = false;
-        });
-        sc.AddScoped<IRootComponentGenerator, MockGenerator>();
-        var cut = context.RenderComponent<BootstrapBlazorRoot>();
+        Context.Services.AddBootstrapBlazor();
+        Context.Services.AddScoped<IRootComponentGenerator, MockGenerator>();
+        Context.Services.GetRequiredService<ICacheManager>();
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>();
         cut.Contains("<div class=\"auto-generator\"></div>");
     }
 

--- a/test/UnitTest/Core/TestBase.cs
+++ b/test/UnitTest/Core/TestBase.cs
@@ -13,5 +13,7 @@ public class TestBase
     {
         Context = new TestContext();
         Context.JSInterop.Mode = JSRuntimeMode.Loose;
+
+        Context.Services.AddMockEnvironment();
     }
 }

--- a/test/UnitTest/Extensions/IServiceCollectionExtensions.cs
+++ b/test/UnitTest/Extensions/IServiceCollectionExtensions.cs
@@ -4,6 +4,8 @@
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 
 namespace Microsoft.Extensions.DependencyInjection;
 
@@ -23,5 +25,22 @@ internal static class IServiceCollectionExtensions
         var config = builder.Build();
         services.AddSingleton<IConfiguration>(config);
         return services;
+    }
+
+    public static IServiceCollection AddMockEnvironment(this IServiceCollection services)
+    {
+        services.AddSingleton<IHostEnvironment, MockEnvironment>();
+        return services;
+    }
+
+    class MockEnvironment : IHostEnvironment
+    {
+        public string EnvironmentName { get; set; } = "Development";
+
+        public string ApplicationName { get; set; } = "Test";
+
+        public string ContentRootPath { get; set; } = "UnitTest";
+
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
     }
 }

--- a/test/UnitTest/Services/MaskServiceTest.cs
+++ b/test/UnitTest/Services/MaskServiceTest.cs
@@ -8,17 +8,13 @@ namespace UnitTest.Services;
 /// <summary>
 /// MaskService 单元测试
 /// </summary>
-public class MaskServiceTest : TestBase
+public class MaskServiceTest : BootstrapBlazorTestBase
 {
     [Fact]
     public async Task Mask_Ok()
     {
-        var context = new TestContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        context.Services.AddBootstrapBlazor();
-
-        var maskService = context.Services.GetRequiredService<MaskService>();
-        var cut = context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        var maskService = Context.Services.GetRequiredService<MaskService>();
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
             pb.AddChildContent<Button>(pb =>
             {
@@ -49,12 +45,8 @@ public class MaskServiceTest : TestBase
     [Fact]
     public async Task Container_Ok()
     {
-        var context = new TestContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        context.Services.AddBootstrapBlazor();
-
-        var maskService = context.Services.GetRequiredService<MaskService>();
-        var cut = context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        var maskService = Context.Services.GetRequiredService<MaskService>();
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
             pb.AddChildContent<Button>(pb =>
             {
@@ -87,12 +79,8 @@ public class MaskServiceTest : TestBase
     [Fact]
     public async Task Show_Component()
     {
-        var context = new TestContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        context.Services.AddBootstrapBlazor();
-
-        var maskService = context.Services.GetRequiredService<MaskService>();
-        var cut = context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        var maskService = Context.Services.GetRequiredService<MaskService>();
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
             pb.AddChildContent<Button>(pb =>
             {
@@ -109,12 +97,8 @@ public class MaskServiceTest : TestBase
     [Fact]
     public async Task Show_Type()
     {
-        var context = new TestContext();
-        context.JSInterop.Mode = JSRuntimeMode.Loose;
-        context.Services.AddBootstrapBlazor();
-
-        var maskService = context.Services.GetRequiredService<MaskService>();
-        var cut = context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        var maskService = Context.Services.GetRequiredService<MaskService>();
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
         {
             pb.AddChildContent<Button>(pb =>
             {


### PR DESCRIPTION
## Link issues
fixes #6151 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Support showing only exception messages in release mode by injecting IHostEnvironment into the error boundary, refactoring the error-handling flow, and updating handler implementations to async for full details in development and minimal messaging in production

New Features:
- Support release-mode only showing exception message toast

Enhancements:
- Inject IHostEnvironment into error boundary to distinguish development and production behavior
- Refactor OnErrorAsync to always log errors and extract toast logic to a new ShowErrorToast method
- Modify RenderException to call OnErrorAsync then display full exception details in development via handler or show only toast message in non-development environments
- Convert HandlerException implementations in TabItemContent, Layout, and ModalDialog to async Task with await