### PR TITLE
feat(Upload): use local preview instead of base64 format

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor
@@ -55,13 +55,13 @@
 <DemoBlock Title="@Localizer["AvatarUploadAcceptTitle"]"
            Introduction="@Localizer["AvatarUploadAcceptIntro"]"
            Name="Accept">
-    <AvatarUpload TValue="string" Accept="image/*" OnChange="@OnChange"></AvatarUpload>
+    <AvatarUpload TValue="string" Accept="image/*"></AvatarUpload>
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["AvatarUploadValidateTitle"]"
            Introduction="@Localizer["AvatarUploadValidateIntro"]"
            Name="ValidateForm">
-    <ValidateForm Model="@_foo" OnValidSubmit="OnAvatarValidSubmit">
+    <ValidateForm Model="@_foo" OnValidSubmit="OnAvatarValidSubmit" OnInValidSubmit="OnAvatarInValidSubmit">
         <div class="row g-3">
             <div class="col-12">
                 <BootstrapInput @bind-Value="@_foo.Name"></BootstrapInput>

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor.cs
@@ -37,39 +37,14 @@ public partial class UploadAvatars : IDisposable
         ]);
     }
 
-    private async Task OnChange(UploadFile file)
-    {
-        // 示例代码，使用 base64 格式
-        if (file is { File: not null })
-        {
-            var format = file.File.ContentType;
-            if (file.IsImage())
-            {
-                _token ??= new CancellationTokenSource();
-                if (_token.IsCancellationRequested)
-                {
-                    _token.Dispose();
-                    _token = new CancellationTokenSource();
-                }
-
-                await file.RequestBase64ImageFileAsync(format, 640, 480, MaxFileLength, null, _token.Token);
-            }
-            else
-            {
-                file.Code = 1;
-                file.Error = Localizer["UploadsFormatError"];
-            }
-
-            if (file.Code != 0)
-            {
-                await ToastService.Error(Localizer["UploadsAvatarMsg"], $"{file.Error} {format}");
-            }
-        }
-    }
-
     private Task OnAvatarValidSubmit(EditContext context)
     {
-        return ToastService.Error(Localizer["UploadsValidateFormTitle"], Localizer["UploadsValidateFormValidContent"]);
+        return ToastService.Success(Localizer["UploadsValidateFormTitle"], Localizer["UploadsValidateFormValidContent"]);
+    }
+
+    private Task OnAvatarInValidSubmit(EditContext context)
+    {
+        return ToastService.Error(Localizer["UploadsValidateFormTitle"], Localizer["UploadsValidateFormInValidContent"]);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3481,6 +3481,7 @@
     "UploadsBorderRadius": "Border radius",
     "UploadsValidateFormTitle": "ValidateForm",
     "UploadsValidateFormValidContent": "Saved successfully",
+    "UploadsValidateFormInValidContent": "Please correct it and submit the form again",
     "UploadsFormatError": "The file format is incorrect",
     "UploadsAvatarMsg": "Avatar upload"
   },

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3481,6 +3481,7 @@
     "UploadsBorderRadius": "预览框圆角曲率",
     "UploadsValidateFormTitle": "表单应用",
     "UploadsValidateFormValidContent": "数据合规，保存成功",
+    "UploadsValidateFormInValidContent": "数据不合规，请更正后再提交表单",
     "UploadsFormatError": "文件格式不正确",
     "UploadsAvatarMsg": "头像上传"
   },

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.7.1-beta04</Version>
+    <Version>9.7.1-beta05</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
@@ -133,14 +133,9 @@ public partial class AvatarUpload<TValue>
     /// <returns></returns>
     protected override async Task TriggerOnChanged(UploadFile file)
     {
-        if (OnChange == null)
-        {
-            await file.RequestBase64ImageFileAsync(allowExtensions: AllowExtensions);
-        }
-        else
-        {
-            await OnChange(file);
-        }
+        // 从客户端获得预览地址不使用 base64 编码
+        file.PrevUrl = await InvokeAsync<string?>("getPreviewUrl", Id, file.OriginFileName);
+        await base.TriggerOnChanged(file);
     }
 
     private IReadOnlyCollection<ValidationResult> _results = [];

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
@@ -77,6 +77,12 @@ public partial class AvatarUpload<TValue>
     [Parameter]
     public bool IsUploadButtonAtFirst { get; set; }
 
+    /// <summary>
+    /// 获得/设置 是否允许预览回调方法 默认 null
+    /// </summary>
+    [Parameter]
+    public Func<UploadFile, bool>? CanPreviewCallback { get; set; }
+
     [Inject]
     [NotNull]
     private IIconTheme? IconTheme { get; set; }
@@ -134,7 +140,10 @@ public partial class AvatarUpload<TValue>
     protected override async Task TriggerOnChanged(UploadFile file)
     {
         // 从客户端获得预览地址不使用 base64 编码
-        file.PrevUrl = await InvokeAsync<string?>("getPreviewUrl", Id, file.OriginFileName);
+        if (file.IsImage(AllowExtensions, CanPreviewCallback))
+        {
+            file.PrevUrl = await InvokeAsync<string?>("getPreviewUrl", Id, file.OriginFileName);
+        }
         await base.TriggerOnChanged(file);
     }
 

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
@@ -133,6 +133,21 @@ public partial class CardUpload<TValue>
         RemoveIcon ??= IconTheme.GetIconByKey(ComponentIcons.CardUploadRemoveIcon);
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="file"></param>
+    /// <returns></returns>
+    protected override async Task TriggerOnChanged(UploadFile file)
+    {
+        // 从客户端获得预览地址不使用 base64 编码
+        if (file.IsImage(AllowExtensions, CanPreviewCallback))
+        {
+            file.PrevUrl = await InvokeAsync<string?>("getPreviewUrl", Id, file.OriginFileName);
+        }
+        await base.TriggerOnChanged(file);
+    }
+
     private async Task OnCardFileDelete(UploadFile item)
     {
         await OnFileDelete(item);

--- a/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
@@ -194,14 +194,14 @@ public static class UploadFileExtensions
     /// </summary>
     /// <param name="item"></param>
     /// <param name="allowExtensions"></param>
-    /// <param name="_callback"></param>
+    /// <param name="callback"></param>
     /// <returns></returns>
-    public static bool IsImage(this UploadFile item, List<string>? allowExtensions = null, Func<UploadFile, bool>? _callback = null)
+    public static bool IsImage(this UploadFile item, List<string>? allowExtensions = null, Func<UploadFile, bool>? callback = null)
     {
         bool ret;
-        if (_callback != null)
+        if (callback != null)
         {
-            ret = _callback(item);
+            ret = callback(item);
         }
         else if (item.File != null)
         {

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -886,6 +886,23 @@ export function drawImage(canvas, image, offsetWidth, offsetHeight) {
     context.drawImage(image, 0, 0, offsetWidth, offsetHeight);
 }
 
+export function readFileToBlobAsync(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+
+        reader.onload = () => {
+            const blob = new Blob([reader.result], { type: file.type });
+            resolve(blob);
+        };
+
+        reader.onerror = (error) => {
+            reject(error);
+        };
+
+        reader.readAsArrayBuffer(file);
+    });
+}
+
 export {
     autoAdd,
     autoRemove,

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -886,6 +886,10 @@ export function drawImage(canvas, image, offsetWidth, offsetHeight) {
     context.drawImage(image, 0, 0, offsetWidth, offsetHeight);
 }
 
+/**
+ *  @param {File} file
+ *  @returns {Blob}
+ */
 export function readFileAsync(file) {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -886,7 +886,7 @@ export function drawImage(canvas, image, offsetWidth, offsetHeight) {
     context.drawImage(image, 0, 0, offsetWidth, offsetHeight);
 }
 
-export function readFileToBlobAsync(file) {
+export function readFileAsync(file) {
     return new Promise((resolve, reject) => {
         const reader = new FileReader();
 

--- a/test/UnitTest/Components/UploadAvatarTest.cs
+++ b/test/UnitTest/Components/UploadAvatarTest.cs
@@ -17,6 +17,7 @@ public class UploadAvatarTest : BootstrapBlazorTestBase
         UploadFile? uploadFile = null;
         var cut = Context.RenderComponent<AvatarUpload<string>>(pb =>
         {
+            pb.Add(a => a.CanPreviewCallback, null);
             pb.Add(a => a.IsMultiple, true);
             pb.Add(a => a.OnChange, file =>
             {


### PR DESCRIPTION
## Link issues
fixes #6156

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Implement local preview for image uploads by replacing base64 image requests with Blob URL previews via a new JavaScript API, update upload components and samples to use the new mechanism, and adjust tests accordingly.

New Features:
- Add client-side image preview using Blob URLs instead of base64 encoding
- Introduce getPreviewUrl JS function and readFileAsync utility for file reading
- Expose CanPreviewCallback parameter to allow custom preview logic

Enhancements:
- Update AvatarUpload and CardUpload components to fetch preview URLs via JS invocation rather than base64 processing
- Simplify sample code by removing base64 preview demo and adding OnValidSubmit/OnInValidSubmit handlers

Tests:
- Enhance unit tests for AvatarUpload to include CanPreviewCallback parameter