### PR TITLE
fix(Select): search icon not vertical center when use BI icon theme

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/PdfViewers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/PdfViewers.razor.cs
@@ -15,7 +15,7 @@ public partial class PdfViewers
     [Inject, NotNull]
     private ToastService? ToastService { get; set; }
 
-    private bool _useGoogleDocs = true;
+    private bool _useGoogleDocs = false;
 
     private Task OnLoaded() => ToastService.Success("Pdf Viewer", Localizer["PdfViewerToastSuccessfulContent"]);
 

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.7.1-beta05</Version>
+    <Version>9.7.1-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/Select.razor.scss
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.scss
@@ -1,4 +1,4 @@
-.select,
+﻿.select,
 .popover-dropdown {
     --bb-dropdown-link-pre-active-bg: #{$bb-dropdown-link-pre-active-bg};
 }
@@ -229,6 +229,11 @@
         right: var(--bb-select-search-icon-right);
         top: var(--bb-select-search-icon-top);
         color: var(--bb-select-search-icon-color);
+        width: 1rem;
+        height: 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
     }
 }
 

--- a/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
@@ -521,7 +521,7 @@ $bb-select-search-border-color: var(--bs-border-color);
 $bb-select-search-padding-right: 30px;
 $bb-select-search-icon-color: var(--bb-select-search-border-color);
 $bb-select-search-icon-right: 26px;
-$bb-select-search-icon-top: 19px;
+$bb-select-search-icon-top: 18px;
 $bb-select-search-height: 52px;
 $bb-select-append-width: 30px;
 $bb-select-append-color: #c0c4cc;


### PR DESCRIPTION
## Link issues
fixes #6171 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix search icon vertical alignment issues in the Select component under the BI icon theme and update the PdfViewers sample default to disable Google Docs

Bug Fixes:
- Center the search icon in the Select component when using the BI icon theme by adding flex-based centering and adjusting its vertical offset
- Adjust the global SCSS theme variable for the select search icon top offset

Chores:
- Change default Google Docs usage to false in PdfViewers sample