### PR TITLE
feat(ImageCorpper): update AspectRatio type to float

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="BootstrapBlazor.Html2Image" Version="9.0.2" />
     <PackageReference Include="BootstrapBlazor.Html2Pdf" Version="9.0.2" />
     <PackageReference Include="BootstrapBlazor.IconPark" Version="9.0.3" />
-    <PackageReference Include="BootstrapBlazor.ImageCropper" Version="9.0.0" />
+    <PackageReference Include="BootstrapBlazor.ImageCropper" Version="9.0.1" />
     <PackageReference Include="BootstrapBlazor.IP2Region" Version="9.0.1" />
     <PackageReference Include="BootstrapBlazor.JitsiMeet" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.JuHeIpLocatorProvider" Version="9.0.0" />

--- a/src/BootstrapBlazor.Server/Components/Samples/ImageCroppers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ImageCroppers.razor.cs
@@ -22,7 +22,7 @@ public partial class ImageCroppers
 
     private string? _base64String2;
 
-    private readonly ImageCropperOption _roundOptions = new() { IsRound = true, Radius = "50%" };
+    private readonly ImageCropperOption _roundOptions = new() { IsRound = true, Radius = "50%", AspectRatio = 3/4f };
 
     /// <summary>
     /// <inheritdoc/>


### PR DESCRIPTION
## Link issues
fixes #6174 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Allow specifying AspectRatio as a float in ImageCropperOption and update sample usage accordingly

New Features:
- Enable float-based AspectRatio values for image croppers

Enhancements:
- Update ImageCroppers sample to set AspectRatio to 0.75 (3/4f) for round mode