### PR TITLE
feat(FlipClock): add ShowMonth parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/FlipClocks.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/FlipClocks.razor
@@ -9,6 +9,10 @@
     <FlipClock></FlipClock>
 </DemoBlock>
 
+<DemoBlock Title="@Localizer["ShowMonthText"]" Introduction="@Localizer["ShowMonthIntro"]" Name="ShowDay">
+    <FlipClock ShowMonth="true" ShowDay="true"></FlipClock>
+</DemoBlock>
+
 <DemoBlock Title="@Localizer["ShowDayText"]" Introduction="@Localizer["ShowDayIntro"]" Name="ShowDay">
     <FlipClock ShowDay="true"></FlipClock>
 </DemoBlock>

--- a/src/BootstrapBlazor.Server/Components/Samples/FlipClocks.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/FlipClocks.razor.cs
@@ -52,6 +52,14 @@ public partial class FlipClocks
     [
         new()
         {
+            Name = nameof(FlipClock.ShowMonth),
+            Description = Localizer["ShowMonth_Description"],
+            Type = "boolean",
+            ValueList = "true|false",
+            DefaultValue = "false"
+        },
+        new()
+        {
             Name = nameof(FlipClock.ShowDay),
             Description = Localizer["ShowDay_Description"],
             Type = "boolean",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -6802,6 +6802,8 @@
     "FlipClocksDescription": "Used for website timing or countdown",
     "BaseUsageText": "Basic usage",
     "BaseUsageIntro": "Synchronize display of current time",
+    "ShowMonthText": "Show Month",
+    "ShowMonthIntro": "Display month information by setting <code>ShowMonth=\"true\"</code>",
     "ShowDayText": "Show Day",
     "ShowDayIntro": "Display day information by setting <code>ShowDay=\"true\"</code>",
     "ShowMinuteText": "not display hours and minutes",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -6804,6 +6804,8 @@
     "BaseUsageIntro": "同步显示当前时间",
     "ShowDayText": "显示日",
     "ShowDayIntro": "通过设置 <code>ShowDay=\"true\"</code> 显示日信息",
+    "ShowMonthText": "显示月",
+    "ShowMonthIntro": "通过设置 <code>ShowMonth=\"true\"</code> 显示月信息",
     "ShowMinuteText": "不显示时、分",
     "ShowMinuteIntro": "通过设置 <code>ShowHour=\"false\"</code> <code>ShowMinute=\"false\"</code> 不显示小时、分钟信息",
     "ShowSecondText": "不显示秒",

--- a/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor
+++ b/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor
@@ -5,6 +5,14 @@
 <div @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString" id="@Id">
     @if (ShowDay)
     {
+        <div class="bb-flip-clock-list month">
+            @RenderItem(3)
+            @RenderItem(10)
+        </div>
+    }
+
+    @if (ShowDay)
+    {
         <div class="bb-flip-clock-list day">
             @RenderItem(10)
             @RenderItem(10)

--- a/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor
+++ b/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor
@@ -3,7 +3,7 @@
 @attribute [BootstrapModuleAutoLoader(JSObjectReference = true)]
 
 <div @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString" id="@Id">
-    @if (ShowDay)
+    @if (ShowMonth)
     {
         <div class="bb-flip-clock-list month">
             @RenderItem(3)

--- a/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor.cs
+++ b/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor.cs
@@ -12,6 +12,12 @@ namespace BootstrapBlazor.Components;
 public partial class FlipClock
 {
     /// <summary>
+    /// 获得/设置 是否显示 Month 默认 false
+    /// </summary>
+    [Parameter]
+    public bool ShowMonth { get; set; }
+
+    /// <summary>
     /// 获得/设置 是否显示 Day 默认 false
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor.js
+++ b/src/BootstrapBlazor/Components/FlipClock/FlipClock.razor.js
@@ -14,6 +14,7 @@ export function init(id, options) {
         return;
     }
 
+    const listMonth = el.querySelector('.bb-flip-clock-list.month');
     const listDay = el.querySelector('.bb-flip-clock-list.day');
     const listHour = el.querySelector('.bb-flip-clock-list.hour');
     const listMinute = el.querySelector('.bb-flip-clock-list.minute');
@@ -37,6 +38,7 @@ export function init(id, options) {
         else {
             now = new Date();
             return {
+                months: now.getMonth() + 1,
                 days: now.getDate(),
                 hours: now.getHours(),
                 minutes: now.getMinutes(),
@@ -48,15 +50,16 @@ export function init(id, options) {
         const minutes = Math.floor(totalMilliseconds / (1000 * 60)) % 60;
         const hours = Math.floor(totalMilliseconds / (1000 * 60 * 60)) % 24;
         const days = Math.floor(totalMilliseconds / (1000 * 60 * 60 * 24));
-        return { days, hours, minutes, seconds };
+        return { months, days, hours, minutes, seconds };
     }
 
+    let lastMonth;
     let lastDay;
     let lastHour;
     let lastMinute;
     let lastSecond;
     const go = () => {
-        const { days, hours, minutes, seconds } = getDate();
+        const { months, days, hours, minutes, seconds } = getDate();
 
         if (lastSecond !== seconds) {
             lastSecond = seconds;
@@ -74,7 +77,11 @@ export function init(id, options) {
             lastDay = days;
             setTime(listDay, days, countDown);
         }
-        return { days, hours, minutes, seconds }
+        if (lastMonth !== months) {
+            lastDay = days;
+            setTime(listMonth, months, countDown);
+        }
+        return { months, days, hours, minutes, seconds }
     }
 
     let start = void 0

--- a/test/UnitTest/Components/FlipClockTest.cs
+++ b/test/UnitTest/Components/FlipClockTest.cs
@@ -60,6 +60,19 @@ public class FlipClockTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void ShowMonth_Ok()
+    {
+        var cut = Context.RenderComponent<FlipClock>();
+        cut.DoesNotContain("bb-flip-clock-list month");
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.ShowMonth, true);
+        });
+        cut.Contains("bb-flip-clock-list month");
+    }
+
+    [Fact]
     public async Task ViewMode_Ok()
     {
         var completed = false;


### PR DESCRIPTION
## Link issues
fixes #6221 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a new ShowMonth option to the FlipClock component to optionally display the month, including support in the Razor markup, underlying JavaScript logic, unit tests, samples, and documentation.

New Features:
- Introduce ShowMonth parameter to FlipClock to enable month display.

Enhancements:
- Extend FlipClock’s JavaScript initialization and update logic to include months.
- Update component markup to conditionally render the month list when ShowMonth is true.

Documentation:
- Add ShowMonth attribute entry and default value in the component’s documentation.
- Include a demo block in the sample page showcasing the ShowMonth option.

Tests:
- Add unit test to verify month list appears only when ShowMonth is enabled.