### PR TITLE
feat(Light): rename class name light to bb-light

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.7.4-beta03</Version>
+    <Version>9.7.4-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Light/Light.razor.cs
+++ b/src/BootstrapBlazor/Components/Light/Light.razor.cs
@@ -13,7 +13,7 @@ public partial class Light
     /// <summary>
     /// 获得 组件样式
     /// </summary>
-    protected string? ClassString => CssBuilder.Default("light")
+    protected string? ClassString => CssBuilder.Default("bb-light")
         .AddClass("is-flat", IsFlat)
         .AddClass("flash", IsFlash && !IsFlat)
         .AddClass("is-flat-flash", IsFlash && IsFlat)

--- a/src/BootstrapBlazor/Components/Light/Light.razor.scss
+++ b/src/BootstrapBlazor/Components/Light/Light.razor.scss
@@ -1,4 +1,4 @@
-.light {
+﻿.bb-light {
     --bb-light-bg: #{$bb-light-bg};
     --bb-light-danger-start-color: #{$bb-light-danger-start-color};
     --bb-light-danger-end-color: #{$bb-light-danger-end-color};

--- a/test/UnitTest/Components/LightTest.cs
+++ b/test/UnitTest/Components/LightTest.cs
@@ -11,14 +11,14 @@ public class LightTest : BootstrapBlazorTestBase
     public void IsFlash_Ok()
     {
         var cut = Context.RenderComponent<Light>(builder => builder.Add(s => s.IsFlash, true));
-        Assert.Contains("light flash", cut.Markup);
+        Assert.Contains("bb-light flash", cut.Markup);
         Assert.DoesNotContain("is-flash-flat", cut.Markup);
 
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.IsFlat, true);
         });
-        Assert.DoesNotContain("light flash", cut.Markup);
+        Assert.DoesNotContain("bb-light flash", cut.Markup);
         Assert.Contains("is-flat", cut.Markup);
         Assert.Contains("is-flat-flash", cut.Markup);
     }


### PR DESCRIPTION
## Link issues
fixes #6231 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Rename the "light" CSS class to "bb-light" in the Light component to avoid naming conflicts, update corresponding SCSS styles and unit tests to reflect the new class name

Bug Fixes:
- Update unit tests in LightTest to assert against "bb-light" instead of "light"

Enhancements:
- Change Light component’s default CSS class from "light" to "bb-light" in its Razor code
- Rename the `.light` selector to `.bb-light` in Light component SCSS