### PR TITLE
fix(Select): trigger OnSelectedItemsChanged after clear

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.7.4-beta04</Version>
+    <Version>9.7.4-beta05</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -286,6 +286,7 @@ public partial class MultiSelect<TValue>
         await base.OnClearValue();
 
         SelectedItems.Clear();
+        await SetValue();
     }
 
     /// <summary>
@@ -459,7 +460,7 @@ public partial class MultiSelect<TValue>
 
         if (OnSelectedItemsChanged != null)
         {
-            await OnSelectedItemsChanged.Invoke(SelectedItems);
+            await OnSelectedItemsChanged(SelectedItems);
         }
 
         _lastSelectedValueString = CurrentValueAsString;

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -406,7 +406,10 @@ public partial class Select<TValue> : ISelect, ILookup
         await base.OnClearValue();
 
         SelectedItem = null;
-        _lastSelectedValueString = "";
+        if (OnSelectedItemChanged != null)
+        {
+            await OnSelectedItemChanged(new SelectedItem("", ""));
+        }
     }
 
     private string? ReadonlyString => IsEditable ? null : "readonly";

--- a/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor.cs
@@ -328,6 +328,7 @@ public partial class MultiSelectGeneric<TValue>
         await base.OnClearValue();
 
         SelectedItems.Clear();
+        await SetValue();
     }
 
     private bool _isToggle;
@@ -435,7 +436,7 @@ public partial class MultiSelectGeneric<TValue>
 
         if (OnSelectedItemsChanged != null)
         {
-            await OnSelectedItemsChanged.Invoke(SelectedItems);
+            await OnSelectedItemsChanged(SelectedItems);
         }
 
         CurrentValue = [.. SelectedItems.Select(i => i.Value)];

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
@@ -474,6 +474,10 @@ public partial class SelectGeneric<TValue> : ISelectGeneric<TValue>, IModelEqual
             await VirtualizeElement.RefreshDataAsync();
         }
         SelectedItem = new SelectedItem<TValue>(default!, "");
+        if (OnSelectedItemChanged != null)
+        {
+            await OnSelectedItemChanged(SelectedItem);
+        }
     }
 
     private string? ReadonlyString => IsEditable ? null : "readonly";

--- a/test/UnitTest/Components/MultiSelectTest.cs
+++ b/test/UnitTest/Components/MultiSelectTest.cs
@@ -690,6 +690,7 @@ public class MultiSelectTest : BootstrapBlazorTestBase
     [Fact]
     public async Task IsVirtualize_Items_Clearable_Ok()
     {
+        IEnumerable<SelectedItem>? selectedItems = null;
         var cut = Context.RenderComponent<MultiSelect<string>>(pb =>
         {
             pb.Add(a => a.Items, new SelectedItem[]
@@ -703,6 +704,11 @@ public class MultiSelectTest : BootstrapBlazorTestBase
             pb.Add(a => a.OverscanCount, 4);
             pb.Add(a => a.IsClearable, true);
             pb.Add(a => a.ShowSearch, true);
+            pb.Add(a => a.OnSelectedItemsChanged, items =>
+            {
+                selectedItems = items;
+                return Task.CompletedTask;
+            });
         });
 
         // 覆盖有搜索条件时，点击清空按钮
@@ -718,6 +724,8 @@ public class MultiSelectTest : BootstrapBlazorTestBase
         // 点击 Clear 按钮
         var button = cut.Find(".clear-icon");
         await cut.InvokeAsync(() => button.Click());
+        Assert.NotNull(selectedItems);
+        Assert.Empty(selectedItems);
 
         // 下拉框显示所有选项
         items = cut.FindAll(".dropdown-item");

--- a/test/UnitTest/Components/SelectGenericTest.cs
+++ b/test/UnitTest/Components/SelectGenericTest.cs
@@ -132,9 +132,15 @@ public class SelectGenericTest : BootstrapBlazorTestBase
     public void IsClearable_Ok()
     {
         var val = "Test2";
+        string? selectedValue = "Test2";
         var cut = Context.RenderComponent<SelectGeneric<string>>(pb =>
         {
             pb.Add(a => a.IsClearable, true);
+            pb.Add(a => a.OnSelectedItemChanged, item =>
+            {
+                selectedValue = item.Value;
+                return Task.CompletedTask;
+            });
             pb.Add(a => a.Items, new List<SelectedItem<string>>()
             {
                 new("", "请选择"),
@@ -151,6 +157,7 @@ public class SelectGenericTest : BootstrapBlazorTestBase
         var clearButton = cut.Find(".clear-icon");
         cut.InvokeAsync(() => clearButton.Click());
         Assert.Null(val);
+        Assert.Null(selectedValue);
 
         // 提高代码覆盖率
         var select = cut;

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -135,10 +135,16 @@ public class SelectTest : BootstrapBlazorTestBase
     [Fact]
     public async Task IsClearable_Ok()
     {
+        var selectedValue = "Test2";
         var val = "Test2";
         var cut = Context.RenderComponent<Select<string>>(pb =>
         {
             pb.Add(a => a.IsClearable, true);
+            pb.Add(a => a.OnSelectedItemChanged, item =>
+            {
+                selectedValue = item.Value;
+                return Task.CompletedTask;
+            });
             pb.Add(a => a.Items, new List<SelectedItem>()
             {
                 new("", "请选择"),
@@ -155,6 +161,7 @@ public class SelectTest : BootstrapBlazorTestBase
         var clearButton = cut.Find(".clear-icon");
         await cut.InvokeAsync(() => clearButton.Click());
         Assert.Null(val);
+        Assert.Equal("", selectedValue);
 
         // 提高代码覆盖率
         var select = cut;


### PR DESCRIPTION
## Link issues
fixes #6233 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fire selected-item change callbacks on clearing selections in Select, SelectGeneric, MultiSelect, and MultiSelectGeneric components and extend tests to verify this behavior.

Bug Fixes:
- Invoke OnSelectedItemChanged when clearing the value in Select and SelectGeneric components.
- Invoke OnSelectedItemsChanged when clearing selections in MultiSelect and MultiSelectGeneric components.

Tests:
- Add assertions in MultiSelectTest to verify OnSelectedItemsChanged is triggered and returns an empty collection after clear.
- Add assertions in SelectGenericTest and SelectTest to verify OnSelectedItemChanged is triggered and yields the expected value after clear.