### PR TITLE
feat(cherry-markdown): add IsSupportMath parameter

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="BootstrapBlazor.BootstrapIcon" Version="9.0.2" />
     <PackageReference Include="BootstrapBlazor.Chart" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.ChatBot" Version="9.0.0" />
-    <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="9.0.0" />
+    <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="9.0.1" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="9.0.0" />
     <PackageReference Include="BootstrapBlazor.DockView" Version="9.1.13" />
     <PackageReference Include="BootstrapBlazor.DriverJs" Version="9.0.3" />

--- a/src/BootstrapBlazor.Server/Components/Samples/CherryMarkdowns.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/CherryMarkdowns.razor
@@ -11,7 +11,7 @@
 <Pre class="no-highlight">builder.Services.Configure&lt;HubOptions&gt;(option => option.MaximumReceiveMessageSize = null);</Pre>
 
 <DemoBlock Title="@Localizer["NormalTitle"]" Introduction="@Localizer["NormalIntro"]" Name="Normal">
-    <CherryMarkdown @bind-Value="MarkdownString" @bind-Html="HtmlString" style="height: 400px" />
+    <CherryMarkdown @bind-Value="MarkdownString" @bind-Html="HtmlString" IsSupportMath="true" style="height: 400px" />
     <div class="mt-3">
         <textarea class="form-control" rows="6" disabled="disabled">@MarkdownString</textarea>
     </div>


### PR DESCRIPTION
## Link issues
fixes #6236 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a new IsSupportMath flag to the CherryMarkdown component for optional math support and reflect this change in the demo sample.

New Features:
- Introduce an IsSupportMath parameter to CherryMarkdown to enable math rendering

Documentation:
- Update the CherryMarkdown sample to demonstrate IsSupportMath usage