### PR TITLE
perf(Table): use ReferenceEqualityComparer instance

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.7.4-beta05</Version>
+    <Version>9.7.4-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Sort.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Sort.cs
@@ -229,7 +229,7 @@ public partial class Table<TItem>
 
     private bool IsNotFixedColumn() => !(FixedExtendButtonsColumn && IsExtendButtonsInRowHeader) && !(GetVisibleColumns().FirstOrDefault()?.Fixed ?? false);
 
-    private ConcurrentDictionary<ITableColumn, bool> LastFixedColumnCache { get; } = new();
+    private ConcurrentDictionary<ITableColumn, bool> LastFixedColumnCache { get; } = new(ReferenceEqualityComparer.Instance);
 
     private bool IsLastColumn(ITableColumn col) => LastFixedColumnCache.GetOrAdd(col, col =>
     {
@@ -244,7 +244,7 @@ public partial class Table<TItem>
 
     private bool IsLastExtendButtonColumn() => IsExtendButtonsInRowHeader && !GetVisibleColumns().Any(i => i.Fixed);
 
-    private ConcurrentDictionary<ITableColumn, bool> FirstFixedColumnCache { get; } = new();
+    private ConcurrentDictionary<ITableColumn, bool> FirstFixedColumnCache { get; } = new(ReferenceEqualityComparer.Instance);
 
     private bool IsFirstColumn(ITableColumn col) => FirstFixedColumnCache.GetOrAdd(col, col =>
     {

--- a/src/BootstrapBlazor/Components/Table/TableToolbar.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/TableToolbar.razor.cs
@@ -20,7 +20,7 @@ public partial class TableToolbar<TItem> : ComponentBase
     /// </summary>
     private readonly List<IToolbarComponent> _buttons = [];
 
-    private readonly ConcurrentDictionary<ButtonBase, bool> _asyncButtonStateCache = new();
+    private readonly ConcurrentDictionary<ButtonBase, bool> _asyncButtonStateCache = new(ReferenceEqualityComparer.Instance);
 
     /// <summary>
     /// Specifies the content to be rendered inside this


### PR DESCRIPTION
## Issues
close #6239 

字典操作很频繁，增加一点点性能

## Summary by Sourcery

Use reference equality comparer for table column caches to reduce dictionary overhead and improve performance

Enhancements:
- Initialize LastFixedColumnCache with ReferenceEqualityComparer.Instance
- Initialize FirstFixedColumnCache with ReferenceEqualityComparer.Instance