### PR TITLE
perf(TreeView): use Remove method improve performance

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.7.4-beta08</Version>
+    <Version>9.7.4-beta09</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Misc/ExpandableNodeCache.cs
+++ b/src/BootstrapBlazor/Misc/ExpandableNodeCache.cs
@@ -51,7 +51,7 @@ public class ExpandableNodeCache<TNode, TItem> where TNode : IExpandableNode<TIt
             ExpandedNodeCache.Add(node.Value);
 
             // 收缩节点缓存移除此节点
-            CollapsedNodeCache.RemoveWhere(x => EqualityComparer.Equals(x, node.Value));
+            CollapsedNodeCache.Remove(node.Value);
 
             // 无子项时通过回调方法延时加载
             if (node.HasChildren && !node.Items.Any())
@@ -67,7 +67,7 @@ public class ExpandableNodeCache<TNode, TItem> where TNode : IExpandableNode<TIt
         else
         {
             // 展开节点缓存移除此节点
-            ExpandedNodeCache.RemoveWhere(x => EqualityComparer.Equals(x, node.Value));
+            ExpandedNodeCache.Remove(node.Value);
 
             // 收缩节点缓存添加此节点
             CollapsedNodeCache.Add(node.Value);
@@ -85,7 +85,7 @@ public class ExpandableNodeCache<TNode, TItem> where TNode : IExpandableNode<TIt
         if (node.IsExpand)
         {
             // 已收缩
-            if (CollapsedNodeCache.Contains(node.Value, EqualityComparer))
+            if (CollapsedNodeCache.Contains(node.Value))
             {
                 node.IsExpand = false;
             }
@@ -96,7 +96,7 @@ public class ExpandableNodeCache<TNode, TItem> where TNode : IExpandableNode<TIt
         else
         {
             var needRemove = true;
-            if (ExpandedNodeCache.Contains(node.Value, EqualityComparer))
+            if (ExpandedNodeCache.Contains(node.Value))
             {
                 // 原来是展开状态，
                 if (node.HasChildren || node.Items.Any())
@@ -117,7 +117,7 @@ public class ExpandableNodeCache<TNode, TItem> where TNode : IExpandableNode<TIt
             }
             if (needRemove)
             {
-                ExpandedNodeCache.RemoveWhere(x => EqualityComparer.Equals(x, node.Value));
+                ExpandedNodeCache.Remove(node.Value);
             }
         }
     }


### PR DESCRIPTION
## Link issues
fixes #6257 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Optimize TreeView node caching by replacing predicate-based removals with direct Remove calls and streamlining Contains usage

Bug Fixes:
- Fix node cache removal to resolve issue #6257

Enhancements:
- Use HashSet.Remove instead of RemoveWhere and simplify Contains calls to boost cache removal performance