### PR TITLE
feat(ITcpSocketClient): use ReadOnlyMemory improve performance

### DIFF
--- a/src/BootstrapBlazor/Services/TcpSocket/DataPackage/DataPackageHandlerBase.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/DataPackage/DataPackageHandlerBase.cs
@@ -18,7 +18,7 @@ public abstract class DataPackageHandlerBase : IDataPackageHandler
     /// <summary>
     /// 当接收数据处理完成后，回调该函数执行接收
     /// </summary>
-    public Func<Memory<byte>, Task>? ReceivedCallBack { get; set; }
+    public Func<ReadOnlyMemory<byte>, ValueTask>? ReceivedCallBack { get; set; }
 
     /// <summary>
     /// Sends the specified data asynchronously to the target destination.
@@ -29,9 +29,9 @@ public abstract class DataPackageHandlerBase : IDataPackageHandler
     /// <param name="data">The data to be sent, represented as a block of memory.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a  <see cref="Memory{T}"/> of <see
     /// cref="byte"/> representing the response or acknowledgment  received from the target destination.</returns>
-    public virtual Task<Memory<byte>> SendAsync(Memory<byte> data)
+    public virtual ValueTask<ReadOnlyMemory<byte>> SendAsync(ReadOnlyMemory<byte> data)
     {
-        return Task.FromResult(data);
+        return ValueTask.FromResult(data);
     }
 
     /// <summary>
@@ -39,9 +39,9 @@ public abstract class DataPackageHandlerBase : IDataPackageHandler
     /// </summary>
     /// <param name="data">A memory buffer containing the data to be processed. The buffer must not be empty.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
-    public virtual Task ReceiveAsync(Memory<byte> data)
+    public virtual ValueTask ReceiveAsync(ReadOnlyMemory<byte> data)
     {
-        return Task.CompletedTask;
+        return ValueTask.CompletedTask;
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public abstract class DataPackageHandlerBase : IDataPackageHandler
     /// for the specified <paramref name="length"/>.</remarks>
     /// <param name="buffer">The memory buffer containing the data to process.</param>
     /// <param name="length">The length of the valid data within the buffer.</param>
-    protected void SlicePackage(Memory<byte> buffer, int length)
+    protected void SlicePackage(ReadOnlyMemory<byte> buffer, int length)
     {
         _lastReceiveBuffer = buffer[length..].ToArray().AsMemory();
     }
@@ -66,7 +66,7 @@ public abstract class DataPackageHandlerBase : IDataPackageHandler
     /// <param name="buffer">The buffer to concatenate with the previously stored data. Must not be empty.</param>
     /// <returns>A <see cref="Memory{T}"/> instance containing the concatenated data.  If no previously stored data exists, the
     /// method returns the input <paramref name="buffer"/>.</returns>
-    protected Memory<byte> ConcatBuffer(Memory<byte> buffer)
+    protected ReadOnlyMemory<byte> ConcatBuffer(ReadOnlyMemory<byte> buffer)
     {
         if (_lastReceiveBuffer.IsEmpty)
         {

--- a/src/BootstrapBlazor/Services/TcpSocket/DataPackage/DelimiterDataPackageHandler.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/DataPackage/DelimiterDataPackageHandler.cs
@@ -51,7 +51,7 @@ public class DelimiterDataPackageHandler : DataPackageHandlerBase
     /// </summary>
     /// <param name="data"></param>
     /// <returns></returns>
-    public override async Task ReceiveAsync(Memory<byte> data)
+    public override async ValueTask ReceiveAsync(ReadOnlyMemory<byte> data)
     {
         data = ConcatBuffer(data);
 

--- a/src/BootstrapBlazor/Services/TcpSocket/DataPackage/FixLengthDataPackageHandler.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/DataPackage/FixLengthDataPackageHandler.cs
@@ -23,7 +23,7 @@ public class FixLengthDataPackageHandler(int length) : DataPackageHandlerBase
     /// </summary>
     /// <param name="data"></param>
     /// <returns></returns>
-    public override async Task ReceiveAsync(Memory<byte> data)
+    public override async ValueTask ReceiveAsync(ReadOnlyMemory<byte> data)
     {
         while (data.Length > 0)
         {

--- a/src/BootstrapBlazor/Services/TcpSocket/DataPackage/IDataPackageHandler.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/DataPackage/IDataPackageHandler.cs
@@ -16,7 +16,7 @@ public interface IDataPackageHandler
     /// <summary>
     /// Gets or sets the callback function to be invoked when data is received asynchronously.
     /// </summary>
-    Func<Memory<byte>, Task>? ReceivedCallBack { get; set; }
+    Func<ReadOnlyMemory<byte>, ValueTask>? ReceivedCallBack { get; set; }
 
     /// <summary>
     /// Sends the specified data asynchronously to the target destination.
@@ -27,7 +27,7 @@ public interface IDataPackageHandler
     /// <param name="data">The data to be sent, represented as a block of memory.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains a  <see cref="Memory{T}"/> of <see
     /// cref="byte"/> representing the response or acknowledgment  received from the target destination.</returns>
-    Task<Memory<byte>> SendAsync(Memory<byte> data);
+    ValueTask<ReadOnlyMemory<byte>> SendAsync(ReadOnlyMemory<byte> data);
 
     /// <summary>
     /// Asynchronously receives data from a source and writes it into the provided memory buffer.
@@ -37,5 +37,5 @@ public interface IDataPackageHandler
     /// <param name="data">The memory buffer to store the received data. The buffer must be writable and have sufficient capacity.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the number of bytes written to the
     /// buffer. Returns 0 if the end of the data stream is reached.</returns>
-    Task ReceiveAsync(Memory<byte> data);
+    ValueTask ReceiveAsync(ReadOnlyMemory<byte> data);
 }

--- a/src/BootstrapBlazor/Services/TcpSocket/DefaultTcpSocketClient.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/DefaultTcpSocketClient.cs
@@ -45,13 +45,13 @@ class DefaultTcpSocketClient : ITcpSocketClient
         _dataPackageHandler = handler;
     }
 
-    public Task<bool> ConnectAsync(string host, int port, CancellationToken token = default)
+    public ValueTask<bool> ConnectAsync(string host, int port, CancellationToken token = default)
     {
         var endPoint = new IPEndPoint(GetIPAddress(host), port);
         return ConnectAsync(endPoint, token);
     }
 
-    public async Task<bool> ConnectAsync(IPEndPoint endPoint, CancellationToken token = default)
+    public async ValueTask<bool> ConnectAsync(IPEndPoint endPoint, CancellationToken token = default)
     {
         var ret = false;
         try
@@ -81,7 +81,7 @@ class DefaultTcpSocketClient : ITcpSocketClient
         return ret;
     }
 
-    public async Task<bool> SendAsync(Memory<byte> data, CancellationToken token = default)
+    public async ValueTask<bool> SendAsync(ReadOnlyMemory<byte> data, CancellationToken token = default)
     {
         if (_client is not { Connected: true })
         {
@@ -110,7 +110,7 @@ class DefaultTcpSocketClient : ITcpSocketClient
         return ret;
     }
 
-    private async Task ReceiveAsync()
+    private async ValueTask ReceiveAsync()
     {
         _receiveCancellationTokenSource ??= new();
         while (_receiveCancellationTokenSource is { IsCancellationRequested: false })

--- a/src/BootstrapBlazor/Services/TcpSocket/ITcpSocketClient.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/ITcpSocketClient.cs
@@ -45,7 +45,7 @@ public interface ITcpSocketClient : IDisposable
     /// langword="default"/> if not provided.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is <see langword="true"/> if the connection
     /// is successfully established; otherwise, <see langword="false"/>.</returns>
-    Task<bool> ConnectAsync(string host, int port, CancellationToken token = default);
+    ValueTask<bool> ConnectAsync(string host, int port, CancellationToken token = default);
 
     /// <summary>
     /// Establishes an asynchronous connection to the specified endpoint.
@@ -57,7 +57,7 @@ public interface ITcpSocketClient : IDisposable
     /// langword="default"/> if not provided.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is <see langword="true"/> if the connection
     /// is successfully established; otherwise, <see langword="false"/>.</returns>
-    Task<bool> ConnectAsync(IPEndPoint endPoint, CancellationToken token = default);
+    ValueTask<bool> ConnectAsync(IPEndPoint endPoint, CancellationToken token = default);
 
     /// <summary>
     /// Sends the specified data asynchronously to the target endpoint.
@@ -69,7 +69,7 @@ public interface ITcpSocketClient : IDisposable
     /// <param name="token">An optional <see cref="CancellationToken"/> to observe while waiting for the operation to complete.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is <see langword="true"/> if the data was
     /// sent successfully; otherwise, <see langword="false"/>.</returns>
-    Task<bool> SendAsync(Memory<byte> data, CancellationToken token = default);
+    ValueTask<bool> SendAsync(ReadOnlyMemory<byte> data, CancellationToken token = default);
 
     /// <summary>
     /// Closes the current connection or resource, releasing any associated resources.


### PR DESCRIPTION
## Link issues
fixes #6263 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor TCP socket client and data package handler APIs to leverage ReadOnlyMemory<byte> and ValueTask, aiming to enhance performance and resource efficiency across the implementation and tests.

Enhancements:
- Refactor TcpSocket client and data package handler interfaces and implementations to use ReadOnlyMemory<byte> and ValueTask for improved performance and efficiency.

Tests:
- Update unit tests to use ReadOnlyMemory<byte> and ValueTask in accordance with the refactored interfaces.