### PR TITLE
doc(ITcpSocketFactory): add DataAdapter documentation

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/SocketFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/SocketFactories.razor
@@ -72,3 +72,9 @@ private async Task CreateClient()
     <li><code>FixLengthDataPackageHandler</code> <b>固定长度数据处理器</b> 即每个通讯包都是固定长度</li>
     <li><code>DelimiterDataPackageHandler</code> <b>分隔符数据处理器</b> 即通讯包以特定一个或一组字节分割</li>
 </ul>
+
+<p class="code-label">5. 数据适配器（设计中）</p>
+
+<p>在我们实际应用中，接收到数据包后（已经过数据处理器）大多情况下是需要将电文转化为应用中的具体数据类型 <code>Class</code> 或 <code>Struct</code>。将原始数据包转化为类或者结构体的过程由我们的数据适配器来实现</p>
+
+<p>数据适配器设计思路如下</p>

--- a/src/BootstrapBlazor.Server/Extensions/MenusLocalizerExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/MenusLocalizerExtensions.cs
@@ -1578,6 +1578,7 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
+                    IsNew = true,
                     Text = Localizer["TcpSocketFactory"],
                     Url = "socket-factory"
                 },

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -4952,7 +4952,7 @@
     "CardUpload": "卡片上传组件 CardUpload",
     "DropUpload": "拖动上传组件 DropUpload",
     "Vditor": "富文本框 Vditor Markdown",
-    "TcpSocketFactory": "TCP Socket 套接字服务 ITcpSocketFactory"
+    "TcpSocketFactory": "套接字服务 ITcpSocketFactory"
   },
   "BootstrapBlazor.Server.Components.Samples.Table.TablesHeader": {
     "TablesHeaderTitle": "表头分组功能",


### PR DESCRIPTION
## Link issues
fixes #6274 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add documentation for the DataAdapter concept in the SocketFactories sample, highlight the TcpSocketFactory menu as new, and update Chinese localization accordingly

Enhancements:
- Mark the TcpSocketFactory demo menu item as new in the menu localizer

Documentation:
- Introduce a new section in SocketFactories.razor that explains the DataAdapter design for transforming raw data packages into application types
- Add corresponding Chinese localization entries for the DataAdapter section and TcpSocketFactory menu