### PR TITLE
feat(OtpInput ): support responsive layout

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/OtpInputs.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/OtpInputs.razor
@@ -10,6 +10,11 @@
         .otp-input-demo {
             text-align: center;
         }
+
+            .otp-input-demo .bb-otp-input {
+                --bb-otp-item-width: 32px;
+                --bb-otp-font-size: 1.2em;
+            }
     </style>
 </HeadContent>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/TwoFactorApp.razor.css
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/TwoFactorApp.razor.css
@@ -36,7 +36,7 @@
         font-weight: 400;
     }
 
-::deep .bb-opt-input .bb-opt-item {
-    --bb-opt-item-width: 50px;
-    --bb-opt-font-size: 2em;
+::deep .bb-otp-input .bb-otp-item {
+    --bb-otp-item-width: 50px;
+    --bb-otp-font-size: 2em;
 }

--- a/src/BootstrapBlazor/Components/Input/OtpInput.razor.cs
+++ b/src/BootstrapBlazor/Components/Input/OtpInput.razor.cs
@@ -35,11 +35,11 @@ public partial class OtpInput
     [Parameter]
     public string? PlaceHolder { get; set; }
 
-    private string? ClassString => CssBuilder.Default("bb-opt-input")
+    private string? ClassString => CssBuilder.Default("bb-otp-input")
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();
 
-    private string? InputClassString => CssBuilder.Default("bb-opt-item")
+    private string? InputClassString => CssBuilder.Default("bb-otp-item")
         .AddClass("input-number-fix", Type == OtpInputType.Number)
         .AddClass(ValidCss)
         .Build();

--- a/src/BootstrapBlazor/Components/Input/OtpInput.razor.js
+++ b/src/BootstrapBlazor/Components/Input/OtpInput.razor.js
@@ -3,14 +3,14 @@
 export function init(id, invoke, method) {
     const el = document.getElementById(id);
     const skipKeys = ['Enter', 'Tab', 'Shift', 'Control', 'Alt'];
-    EventHandler.on(el, 'input', '.bb-opt-item', e => {
+    EventHandler.on(el, 'input', '.bb-otp-item', e => {
         const isNumber = e.target.getAttribute('type') === 'number';
         if (isNumber && e.target.value.length > 1) {
             e.target.value = e.target.value.slice(1, 2);
         }
         setValue(el, invoke, method);
     });
-    EventHandler.on(el, 'keydown', '.bb-opt-item', e => {
+    EventHandler.on(el, 'keydown', '.bb-otp-item', e => {
         if (e.ctrlKey) {
             return;
         }
@@ -40,7 +40,7 @@ export function init(id, invoke, method) {
             e.preventDefault();
         }
     });
-    EventHandler.on(el, 'focus', '.bb-opt-item', e => {
+    EventHandler.on(el, 'focus', '.bb-otp-item', e => {
         if (e.target.select) {
             e.target.select();
         }
@@ -49,7 +49,7 @@ export function init(id, invoke, method) {
     EventHandler.on(el, 'paste', e => {
         if (e.clipboardData && e.clipboardData.getData) {
             const pastedText = e.clipboardData.getData('text/plain');
-            const inputs = [...el.querySelectorAll('.bb-opt-item')];
+            const inputs = [...el.querySelectorAll('.bb-otp-item')];
             if (inputs.find(i => i.getAttribute('disabled') || i.getAttribute('readonly'))) {
                 return;
             }
@@ -69,12 +69,12 @@ export function init(id, invoke, method) {
 }
 
 const setValue = (el, invoke, method) => {
-    const val = [...el.querySelectorAll('.bb-opt-item')].map(input => input.value).join('');
+    const val = [...el.querySelectorAll('.bb-otp-item')].map(input => input.value).join('');
     invoke.invokeMethodAsync(method, val);
 }
 
 const setPrevFocus = (el, target) => {
-    const inputs = [...el.querySelectorAll('.bb-opt-item')];
+    const inputs = [...el.querySelectorAll('.bb-otp-item')];
     let index = inputs.indexOf(target);
     if (index > 0) {
         setFocus(inputs[index - 1]);
@@ -82,7 +82,7 @@ const setPrevFocus = (el, target) => {
 }
 
 const setNextFocus = (el, target) => {
-    const inputs = [...el.querySelectorAll('.bb-opt-item')];
+    const inputs = [...el.querySelectorAll('.bb-otp-item')];
     let index = inputs.indexOf(target);
     if (index < inputs.length - 1) {
         setFocus(inputs[index + 1]);

--- a/src/BootstrapBlazor/Components/Input/OtpInput.razor.scss
+++ b/src/BootstrapBlazor/Components/Input/OtpInput.razor.scss
@@ -1,24 +1,24 @@
-﻿.bb-opt-input {
-    --bb-opt-item-width: 66px;
-    --bb-opt-item-disabled-color: #b8b8b8;
-    --bb-opt-item-padding: #{$bb-opt-item-padding};
-    --bb-opt-item-margin: #{$bb-opt-item-margin};
-    --bb-opt-font-size: #{$bb-opt-font-size};
-    --bb-opt-border-width: #{$bb-opt-border-width};
+﻿.bb-otp-input {
+    --bb-otp-item-width: #{$bb-otp-item-width};
+    --bb-otp-item-disabled-color: #{$bb-otp-item-disabled-color};
+    --bb-otp-item-padding: #{$bb-otp-item-padding};
+    --bb-otp-item-margin: #{$bb-otp-item-margin};
+    --bb-otp-font-size: #{$bb-otp-font-size};
+    --bb-otp-border-width: #{$bb-otp-border-width};
     white-space: nowrap;
     overflow: hidden;
 
-    .bb-opt-item {
+    .bb-otp-item {
         display: inline-block;
-        border: var(--bb-opt-border-width) solid var(--bs-border-color);
-        font-size: var(--bb-opt-font-size);
-        padding: var(--bb-opt-item-padding);
+        border: var(--bb-otp-border-width) solid var(--bs-border-color);
+        font-size: var(--bb-otp-font-size);
+        padding: var(--bb-otp-item-padding);
         border-radius: var(--bs-border-radius);
-        width: var(--bb-opt-item-width);
-        height: var(--bb-opt-item-width);
+        width: var(--bb-otp-item-width);
+        height: var(--bb-otp-item-width);
 
         &:not(:last-child) {
-            margin-right: var(--bb-opt-item-margin);
+            margin-right: var(--bb-otp-item-margin);
         }
 
         &[type] {
@@ -33,9 +33,16 @@
         &.is-invalid {
             --bs-border-color: var(--bs-danger);
         }
-    }
 
-    span.bb-opt-item {
-        color: var(--bb-opt-item-disabled-color);
+        &span {
+            color: var(--bb-otp-item-disabled-color);
+        }
+    }
+}
+
+@media (min-width: 768px) {
+    .bb-otp-input {
+        --bb-otp-item-width: 66px;
+        --bb-otp-font-size: 3em;
     }
 }

--- a/src/BootstrapBlazor/Components/Input/OtpInput.razor.scss
+++ b/src/BootstrapBlazor/Components/Input/OtpInput.razor.scss
@@ -1,14 +1,14 @@
 ﻿.bb-opt-input {
+    --bb-opt-item-width: 66px;
+    --bb-opt-item-disabled-color: #b8b8b8;
+    --bb-opt-item-padding: #{$bb-opt-item-padding};
+    --bb-opt-item-margin: #{$bb-opt-item-margin};
+    --bb-opt-font-size: #{$bb-opt-font-size};
+    --bb-opt-border-width: #{$bb-opt-border-width};
     white-space: nowrap;
     overflow: hidden;
 
     .bb-opt-item {
-        --bb-opt-item-width: 66px;
-        --bb-opt-item-disabled-color: #b8b8b8;
-        --bb-opt-item-padding: #{$bb-opt-item-padding};
-        --bb-opt-item-margin: #{$bb-opt-item-margin};
-        --bb-opt-font-size: #{$bb-opt-font-size};
-        --bb-opt-border-width: #{$bb-opt-border-width};
         display: inline-block;
         border: var(--bb-opt-border-width) solid var(--bs-border-color);
         font-size: var(--bb-opt-font-size);

--- a/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/theme/bootstrapblazor.scss
@@ -315,10 +315,12 @@ $bb-viewer-border-radius: 50%;
 $bb-ip-cell-max-width: 30px;
 
 // OptInput
-$bb-opt-item-padding: 0 .5em;
-$bb-opt-item-margin: .5rem;
-$bb-opt-font-size: 3em;
-$bb-opt-border-width: 1px;
+$bb-otp-item-width: 38px;
+$bb-otp-item-disabled-color: #b8b8b8;
+$bb-otp-item-padding: 0 .5em;
+$bb-otp-item-margin: .5rem;
+$bb-otp-font-size: 1.5em;
+$bb-otp-border-width: 1px;
 
 // Layout
 $bb-layout-header-height: 50px;

--- a/test/UnitTest/Components/OtpInputTest.cs
+++ b/test/UnitTest/Components/OtpInputTest.cs
@@ -19,7 +19,7 @@ public class OtpInputTest : BootstrapBlazorTestBase
             pb.Add(a => a.Digits, 6);
         });
 
-        var items = cut.FindAll(".bb-opt-item");
+        var items = cut.FindAll(".bb-otp-item");
         Assert.Equal(6, items.Count);
 
         var item = items[0];
@@ -36,21 +36,21 @@ public class OtpInputTest : BootstrapBlazorTestBase
             pb.Add(a => a.IsReadonly, true);
         });
 
-        var item = cut.Find(".bb-opt-item");
+        var item = cut.Find(".bb-otp-item");
         Assert.Contains("readonly=\"readonly\"", item.OuterHtml);
 
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.IsReadonly, false);
         });
-        item = cut.Find(".bb-opt-item");
-        Assert.Equal("<input type=\"number\" class=\"bb-opt-item input-number-fix\" inputmode=\"numeric\">", item.OuterHtml);
+        item = cut.Find(".bb-otp-item");
+        Assert.Equal("<input type=\"number\" class=\"bb-otp-item input-number-fix\" inputmode=\"numeric\">", item.OuterHtml);
 
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.IsDisabled, true);
         });
-        item = cut.Find(".bb-opt-item");
+        item = cut.Find(".bb-otp-item");
         Assert.Contains("disabled=\"disabled\"", item.OuterHtml);
     }
 
@@ -63,16 +63,16 @@ public class OtpInputTest : BootstrapBlazorTestBase
             pb.Add(a => a.PlaceHolder, "X");
         });
 
-        var item = cut.Find(".bb-opt-item");
-        Assert.Equal("<input type=\"text\" class=\"bb-opt-item\" maxlength=\"1\" placeholder=\"X\">", item.OuterHtml);
+        var item = cut.Find(".bb-otp-item");
+        Assert.Equal("<input type=\"text\" class=\"bb-otp-item\" maxlength=\"1\" placeholder=\"X\">", item.OuterHtml);
 
         cut.SetParametersAndRender(pb =>
         {
             pb.Add(a => a.Type, OtpInputType.Password);
             pb.Add(a => a.PlaceHolder, null);
         });
-        item = cut.Find(".bb-opt-item");
-        Assert.Equal("<input type=\"password\" class=\"bb-opt-item\" maxlength=\"1\">", item.OuterHtml);
+        item = cut.Find(".bb-otp-item");
+        Assert.Equal("<input type=\"password\" class=\"bb-otp-item\" maxlength=\"1\">", item.OuterHtml);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #6278 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Implement responsive styling for the OTP input component by renaming its classes to `bb-otp-*`, consolidating its styling into CSS custom properties, adding a media query for larger screens, and updating the related scss, JavaScript, C# logic, and tests accordingly.

New Features:
- Add responsive layout support for OtpInput using CSS custom properties and a media query

Enhancements:
- Rename CSS classes and scss variables from `bb-opt-*` to `bb-otp-*` across styles, JavaScript, and C# code
- Centralize OTP item styling into configurable CSS custom properties (width, padding, margin, font-size, border-width, disabled color)
- Update theme scss variables and sample component styles to align with the new CSS property names

Tests:
- Update unit tests to reference the renamed CSS classes