### PR TITLE
refactor(ImageViewer): image element is not closed

### DIFF
--- a/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor
+++ b/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor
@@ -5,7 +5,7 @@
 <div tabindex="-1" class="bb-previewer collapse active" id="@Id" style="z-index: @ZIndex;">
     <div class="bb-viewer-mask"></div>
     <div class="bb-viewer-canvas">
-        <img src="@GetFirstImageUrl()" class="bb-viewer-img" style="transform: scale(1) rotate(0deg); margin: 0;">
+        <img src="@GetFirstImageUrl()" class="bb-viewer-img" style="transform: scale(1) rotate(0deg); margin: 0;"/>
     </div>
     <span class="bb-viewer-btn bb-viewer-close">
         <span></span>

--- a/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor
+++ b/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor
@@ -5,7 +5,7 @@
 <div tabindex="-1" class="bb-previewer collapse active" id="@Id" style="z-index: @ZIndex;">
     <div class="bb-viewer-mask"></div>
     <div class="bb-viewer-canvas">
-        <img src="@GetFirstImageUrl()" class="bb-viewer-img" style="transform: scale(1) rotate(0deg); margin: 0;"/>
+        <img src="@GetFirstImageUrl()" class="bb-viewer-img" style="transform: scale(1) rotate(0deg); margin: 0;" />
     </div>
     <span class="bb-viewer-btn bb-viewer-close">
         <span></span>


### PR DESCRIPTION
## Link issues
fixes #6288

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Add missing self-closing slash to img tag in ImagePreviewer.razor to correct HTML markup.