### PR TITLE
feat(Table): add default css for Reset/Search button

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -990,13 +990,15 @@
                 }
                 @if (ShowResetButton)
                 {
-                    <Button Color="Color.Secondary" Icon="@ResetSearchButtonIcon" OnClickWithoutRender="ClearSearchClick">
+                    <Button Color="Color.Secondary" Icon="@ResetSearchButtonIcon" OnClickWithoutRender="ClearSearchClick"
+                            class="btn-table-reset">
                         <span class="d-none d-sm-inline-block">@ResetSearchButtonText</span>
                     </Button>
                 }
                 @if (ShowSearchButton)
                 {
-                    <Button Color="Color.Secondary" Icon="@SearchButtonIcon" OnClickWithoutRender="SearchClick">
+                    <Button Color="Color.Secondary" Icon="@SearchButtonIcon" OnClickWithoutRender="SearchClick"
+                            class="btn-table-search">
                         <span class="d-none d-sm-inline-block">@SearchButtonText</span>
                     </Button>
                 }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -3861,7 +3861,7 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var resetButton = cut.Find(".fa-trash-can");
+        var resetButton = cut.Find(".btn-table-reset");
         await cut.InvokeAsync(() => resetButton.Click());
         Assert.Null(searchModel.Name);
 
@@ -3935,7 +3935,7 @@ public class TableTest : BootstrapBlazorTestBase
         var table = cut.FindComponent<Table<Foo>>();
         table.Instance.SearchModel.Name = "Test";
 
-        var resetButton = cut.Find(".fa-trash-can");
+        var resetButton = cut.Find(".btn-table-reset");
         await cut.InvokeAsync(() => resetButton.Click());
         Assert.Null(table.Instance.SearchModel.Name);
     }
@@ -4119,7 +4119,7 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var resetButton = cut.Find(".fa-trash-can");
+        var resetButton = cut.Find(".btn-table-reset");
         await cut.InvokeAsync(() => resetButton.Click());
 
         Assert.True(reset);


### PR DESCRIPTION
## Link issues
fixes #6299 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add default CSS classes for Table component reset and search buttons and update unit tests to use these classes.

Bug Fixes:
- Fix #6299 by ensuring default styling hooks are available on reset and search buttons.

Enhancements:
- Introduce "btn-table-reset" and "btn-table-search" CSS classes on the Table component’s Reset and Search buttons for consistent default styling.

Tests:
- Update Table unit tests to locate reset and search buttons using the new CSS classes instead of icon-based selectors.