### PR TITLE
feat(Table): add NotSupportedColumnFilterMessage parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor
+++ b/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor
@@ -1,4 +1,4 @@
 ﻿@namespace BootstrapBlazor.Components
 @inherits FilterBase
 
-<div>@NotSupportedColumnFilterMessage</div>
+<div>@(new MarkupString(NotSupportedColumnFilterMessage))</div>

--- a/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor
+++ b/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor
@@ -1,4 +1,4 @@
 ﻿@namespace BootstrapBlazor.Components
 @inherits FilterBase
 
-<div>@NotSupportedMessage</div>
+<div>@NotSupportedColumnFilterMessage</div>

--- a/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor.cs
@@ -14,6 +14,7 @@ public partial class NotSupportFilter
     /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
     /// </summary>
     [Parameter]
+    [NotNull]
     public string? NotSupportedColumnFilterMessage { get; set; }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/NotSupportFilter.razor.cs
@@ -14,7 +14,7 @@ public partial class NotSupportFilter
     /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
     /// </summary>
     [Parameter]
-    public string? NotSupportedMessage { get; set; }
+    public string? NotSupportedColumnFilterMessage { get; set; }
 
     /// <summary>
     /// <inheritdoc/>
@@ -23,7 +23,7 @@ public partial class NotSupportFilter
     {
         base.OnParametersSet();
 
-        NotSupportedMessage ??= Localizer[nameof(NotSupportedMessage)];
+        NotSupportedColumnFilterMessage ??= Localizer[nameof(NotSupportedColumnFilterMessage)];
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Filters/TableColumnFilter.razor
+++ b/src/BootstrapBlazor/Components/Filters/TableColumnFilter.razor
@@ -89,7 +89,8 @@ else
                         break;
                     default:
                         <FilterProvider>
-                            <NotSupportFilter NotSupportedMessage="@NotSupportedMessage"></NotSupportFilter>
+                            <NotSupportFilter NotSupportedColumnFilterMessage="@NotSupportedColumnFilterMessage">
+                            </NotSupportFilter>
                         </FilterProvider>
                         break;
                 }

--- a/src/BootstrapBlazor/Components/Filters/TableColumnFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/TableColumnFilter.razor.cs
@@ -28,6 +28,7 @@ public partial class TableColumnFilter : IFilter
     /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
     /// </summary>
     [Parameter]
+    [ExcludeFromCodeCoverage]
     [Obsolete("已弃用，请使用 NotSupportedColumnFilterMessage 参数; Deprecated, please use NotSupportedColumnFilterMessage parameter")]
     public string? NotSupportedMessage { get => NotSupportedColumnFilterMessage; set => NotSupportedColumnFilterMessage = value; }
 

--- a/src/BootstrapBlazor/Components/Filters/TableColumnFilter.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/TableColumnFilter.razor.cs
@@ -28,7 +28,14 @@ public partial class TableColumnFilter : IFilter
     /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
     /// </summary>
     [Parameter]
-    public string? NotSupportedMessage { get; set; }
+    [Obsolete("已弃用，请使用 NotSupportedColumnFilterMessage 参数; Deprecated, please use NotSupportedColumnFilterMessage parameter")]
+    public string? NotSupportedMessage { get => NotSupportedColumnFilterMessage; set => NotSupportedColumnFilterMessage = value; }
+
+    /// <summary>
+    /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
+    /// </summary>
+    [Parameter]
+    public string? NotSupportedColumnFilterMessage { get; set; }
 
     /// <summary>
     /// 获得 相关联 ITableColumn 实例

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -586,8 +586,9 @@
                             }
                             @if (col.GetFilterable() && !ShowFilterHeader)
                             {
-                                <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this" IsActive="@Filters.ContainsKey(fieldName)"
-                                                   NotSupportedMessage="@NotSupportedMessage"
+                                <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this"
+                                                   IsActive="@Filters.ContainsKey(fieldName)"
+                                                   NotSupportedColumnFilterMessage="@NotSupportedColumnFilterMessage"
                                                    @onclick:stopPropagation>
                                 </TableColumnFilter>
                             }
@@ -659,7 +660,7 @@
                             @if(col.GetFilterable())
                             {
                                 <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this" IsHeaderRow="true"
-                                                   NotSupportedMessage="@NotSupportedMessage">
+                                                   NotSupportedColumnFilterMessage="@NotSupportedColumnFilterMessage">
                                 </TableColumnFilter>
                             }
                         </div>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -586,7 +586,10 @@
                             }
                             @if (col.GetFilterable() && !ShowFilterHeader)
                             {
-                                <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this" IsActive="@Filters.ContainsKey(fieldName)" @onclick:stopPropagation></TableColumnFilter>
+                                <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this" IsActive="@Filters.ContainsKey(fieldName)"
+                                                   NotSupportedMessage="@NotSupportedMessage"
+                                                   @onclick:stopPropagation>
+                                </TableColumnFilter>
                             }
                             @if (col.GetSortable())
                             {
@@ -655,7 +658,9 @@
                         <div class="table-cell">
                             @if(col.GetFilterable())
                             {
-                                <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this" IsHeaderRow="true"></TableColumnFilter>
+                                <TableColumnFilter Icon="@FilterIcon" Column="col" Table="this" IsHeaderRow="true"
+                                                   NotSupportedMessage="@NotSupportedMessage">
+                                </TableColumnFilter>
                             }
                         </div>
                     </th>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -17,6 +17,12 @@ namespace BootstrapBlazor.Components;
 public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where TItem : class
 {
     /// <summary>
+    /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
+    /// </summary>
+    [Parameter]
+    public string? NotSupportedMessage { get; set; }
+
+    /// <summary>
     /// 获得/设置 Loading 模板
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -20,7 +20,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     /// 获得/设置 不支持过滤类型提示信息 默认 null 读取资源文件内容
     /// </summary>
     [Parameter]
-    public string? NotSupportedMessage { get; set; }
+    public string? NotSupportedColumnFilterMessage { get; set; }
 
     /// <summary>
     /// 获得/设置 Loading 模板

--- a/src/BootstrapBlazor/Locales/en.json
+++ b/src/BootstrapBlazor/Locales/en.json
@@ -274,7 +274,7 @@
     "Contains": "Contains",
     "NotContains": "NotContains",
     "EnumFilter.AllText": "All",
-    "NotSupportedMessage": "Unsupported filter type, Please customize the filter use FilterTemplate, Please refer https://www.blazor.zone/table/filter#CustomFilter",
+    "NotSupportedColumnFilterMessage": "Unsupported filter type, Please customize the filter use FilterTemplate, Please refer https://www.blazor.zone/table/filter#CustomFilter",
     "MultiFilterSearchPlaceHolderText": "Please enter ...",
     "MultiFilterSelectAllText": "Select All"
   },

--- a/src/BootstrapBlazor/Locales/en.json
+++ b/src/BootstrapBlazor/Locales/en.json
@@ -274,7 +274,7 @@
     "Contains": "Contains",
     "NotContains": "NotContains",
     "EnumFilter.AllText": "All",
-    "NotSupportedMessage": "Unsupported filter type, Please customize the filter use FilterTemplate",
+    "NotSupportedMessage": "Unsupported filter type, Please customize the filter use FilterTemplate, Please refer https://www.blazor.zone/table/filter#CustomFilter",
     "MultiFilterSearchPlaceHolderText": "Please enter ...",
     "MultiFilterSelectAllText": "Select All"
   },

--- a/src/BootstrapBlazor/Locales/en.json
+++ b/src/BootstrapBlazor/Locales/en.json
@@ -274,7 +274,7 @@
     "Contains": "Contains",
     "NotContains": "NotContains",
     "EnumFilter.AllText": "All",
-    "NotSupportedColumnFilterMessage": "Unsupported filter type, Please customize the filter use FilterTemplate, Please refer https://www.blazor.zone/table/filter#CustomFilter",
+    "NotSupportedColumnFilterMessage": "<p>Unsupported filter type, Please customize the filter use <code>FilterTemplate</code></p><div>Please refer <a href=\"https://www.blazor.zone/table/filter#CustomFilter\" target=\"_blank\">CustomFilter</a></div>",
     "MultiFilterSearchPlaceHolderText": "Please enter ...",
     "MultiFilterSelectAllText": "Select All"
   },

--- a/src/BootstrapBlazor/Locales/zh.json
+++ b/src/BootstrapBlazor/Locales/zh.json
@@ -274,7 +274,7 @@
     "Contains": "包含",
     "NotContains": "不包含",
     "EnumFilter.AllText": "全选",
-    "NotSupportedMessage": "不支持的类型，请使用 FilterTemplate 自定义过滤组件，请参考文档 https://www.blazor.zone/table/filter#CustomFilter",
+    "NotSupportedColumnFilterMessage": "不支持的类型，请使用 FilterTemplate 自定义过滤组件，请参考文档 https://www.blazor.zone/table/filter#CustomFilter",
     "MultiFilterSearchPlaceHolderText": "请输入 ...",
     "MultiFilterSelectAllText": "全选"
   },

--- a/src/BootstrapBlazor/Locales/zh.json
+++ b/src/BootstrapBlazor/Locales/zh.json
@@ -274,7 +274,7 @@
     "Contains": "包含",
     "NotContains": "不包含",
     "EnumFilter.AllText": "全选",
-    "NotSupportedColumnFilterMessage": "不支持的类型，请使用 FilterTemplate 自定义过滤组件，请参考文档 https://www.blazor.zone/table/filter#CustomFilter",
+    "NotSupportedColumnFilterMessage": "<p>不支持的类型，请使用 <code>FilterTemplate</code> 自定义过滤组件</p><div>请参考文档 <a href=\"https://www.blazor.zone/table/filter#CustomFilter\" target=\"_blank\">CustomFilter</a></div>",
     "MultiFilterSearchPlaceHolderText": "请输入 ...",
     "MultiFilterSelectAllText": "全选"
   },

--- a/src/BootstrapBlazor/Locales/zh.json
+++ b/src/BootstrapBlazor/Locales/zh.json
@@ -274,7 +274,7 @@
     "Contains": "包含",
     "NotContains": "不包含",
     "EnumFilter.AllText": "全选",
-    "NotSupportedMessage": "不支持的类型，请使用 FilterTemplate 自定义过滤组件",
+    "NotSupportedMessage": "不支持的类型，请使用 FilterTemplate 自定义过滤组件，请参考文档 https://www.blazor.zone/table/filter#CustomFilter",
     "MultiFilterSearchPlaceHolderText": "请输入 ...",
     "MultiFilterSelectAllText": "全选"
   },

--- a/test/UnitTest/Components/TableNotSupportFilterTest.cs
+++ b/test/UnitTest/Components/TableNotSupportFilterTest.cs
@@ -12,11 +12,12 @@ public class TableNotSupportFilterTest : BootstrapBlazorTestBase
     {
         var cut = Context.RenderComponent<TableColumnFilter>(pb =>
         {
+            pb.Add(a => a.NotSupportedMessage, "不支持的类型");
             pb.Add(a => a.Table, new MockTable());
             pb.Add(a => a.Column, new MockColumn());
         });
 
-        cut.Contains("不支持的类型，请使用 FilterTemplate 自定义过滤组件");
+        cut.Contains("不支持的类型");
 
         var filter = cut.FindComponent<NotSupportFilter>();
         var conditions = filter.Instance.GetFilterConditions();

--- a/test/UnitTest/Components/TableNotSupportFilterTest.cs
+++ b/test/UnitTest/Components/TableNotSupportFilterTest.cs
@@ -12,7 +12,7 @@ public class TableNotSupportFilterTest : BootstrapBlazorTestBase
     {
         var cut = Context.RenderComponent<TableColumnFilter>(pb =>
         {
-            pb.Add(a => a.NotSupportedMessage, "不支持的类型");
+            pb.Add(a => a.NotSupportedColumnFilterMessage, "不支持的类型");
             pb.Add(a => a.Table, new MockTable());
             pb.Add(a => a.Column, new MockColumn());
         });

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -451,6 +451,7 @@ public class TableTest : BootstrapBlazorTestBase
         {
             pb.AddChildContent<Table<Foo>>(pb =>
             {
+                pb.Add(a => a.NotSupportedMessage, "test-not-support");
                 pb.Add(a => a.SearchText, "张三");
                 pb.Add(a => a.TableColumns, foo => builder =>
                 {

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -451,7 +451,7 @@ public class TableTest : BootstrapBlazorTestBase
         {
             pb.AddChildContent<Table<Foo>>(pb =>
             {
-                pb.Add(a => a.NotSupportedMessage, "test-not-support");
+                pb.Add(a => a.NotSupportedColumnFilterMessage, "test-not-support");
                 pb.Add(a => a.SearchText, "张三");
                 pb.Add(a => a.TableColumns, foo => builder =>
                 {


### PR DESCRIPTION
## Link issues
fixes #6301 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a NotSupportedMessage parameter to Table to let consumers customize the message shown for unsupported column filters

New Features:
- Expose NotSupportedMessage parameter on Table to override default unsupported filter message

Enhancements:
- Pass the NotSupportedMessage through to TableColumnFilter components in both header and body cells

Tests:
- Update unit tests to set and verify the custom NotSupportedMessage value