### PR TITLE
feat(Select): add IsUseActiveWhenValueIsNull parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -27,6 +27,12 @@ public partial class Select<TValue> : ISelect, ILookup
     private ILookupService? InjectLookupService { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the "active" state should be used when the associated value is null.
+    /// </summary>
+    [Parameter]
+    public bool IsUseActiveWhenValueIsNull { get; set; }
+
+    /// <summary>
     /// Gets or sets the display template. Default is null.
     /// </summary>
     [Parameter]
@@ -444,10 +450,18 @@ public partial class Select<TValue> : ISelect, ILookup
         {
             _lastSelectedValueString = "";
             _init = false;
-            return null;
+
+            return IsUseActiveWhenValueIsNull && !IsVirtualize
+                ? SetSelectedItemState(GetItemByRows())
+                : null;
         }
 
         var item = IsVirtualize ? GetItemByVirtualized() : GetItemByRows();
+        return SetSelectedItemState(item);
+    }
+
+    private SelectedItem? SetSelectedItemState(SelectedItem? item)
+    {
         if (item != null)
         {
             if (_init && DisableItemChangedWhenFirstRender)

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -13,6 +13,38 @@ namespace UnitTest.Components;
 public class SelectTest : BootstrapBlazorTestBase
 {
     [Fact]
+    public async Task IsUseActiveWhenValueNull_Ok()
+    {
+        var tcs = new TaskCompletionSource();
+        var selectedValue = "";
+        var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Select<string>>(pb =>
+            {
+                pb.Add(a => a.ShowSearch, true);
+                pb.Add(a => a.Items, new List<SelectedItem>()
+                {
+                    new("1", "Test1"),
+                    new("2", "Test2") { Active = true }
+                });
+                pb.Add(a => a.IsUseActiveWhenValueIsNull, true);
+                pb.Add(a => a.OnSelectedItemChanged, item =>
+                {
+                    selectedValue = item.Value;
+                    tcs.SetResult();
+                    return Task.CompletedTask;
+                });
+            });
+        });
+
+        await tcs.Task;
+
+        // 组件未设置 Value 参数，应该使用 Test2 作为初始选项，并且触发 SelectedItemChanged 回调
+        Assert.Equal("2", selectedValue);
+        cut.Contains("value=\"Test2\"");
+    }
+
+    [Fact]
     public async Task OnSearchTextChanged_Null()
     {
         var cut = Context.RenderComponent<BootstrapBlazorRoot>(pb =>


### PR DESCRIPTION
## Link issues
fixes #6303 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enable default selection of a pre-marked active item in the Select component when its Value is null by adding the IsUseActiveWhenValueIsNull parameter, updating the change handling logic, and validating the behavior with a new unit test.

New Features:
- Add IsUseActiveWhenValueIsNull parameter to Select component to allow using a pre-marked active item as the initial selection when no value is provided

Enhancements:
- Refactor selection logic by introducing SetSelectedItemState helper and updating OnChange to respect the new parameter

Tests:
- Add unit test to verify that the active item is used and the SelectedItemChanged callback is triggered when IsUseActiveWhenValueIsNull is enabled and no value is set