### PR TITLE
pef(Upload): add bufferSize parameter for improve save file performance

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/UploadButtons.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadButtons.razor.cs
@@ -61,7 +61,7 @@ public partial class UploadButtons : IDisposable
             _token ??= new CancellationTokenSource();
             try
             {
-                var ret = await file.SaveToFileAsync(fileName, MaxFileLength, _token.Token);
+                var ret = await file.SaveToFileAsync(fileName, MaxFileLength, token: _token.Token);
 
                 if (ret)
                 {

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor.cs
@@ -78,7 +78,7 @@ public partial class UploadCards : IDisposable
             _token ??= new CancellationTokenSource();
             try
             {
-                var ret = await file.SaveToFileAsync(fileName, MaxFileLength, _token.Token);
+                var ret = await file.SaveToFileAsync(fileName, MaxFileLength, token: _token.Token);
 
                 if (ret)
                 {

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.8.0-beta05</Version>
+    <Version>9.8.0-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
@@ -100,7 +100,7 @@ public static class UploadFileExtensions
                     while ((bytesRead = await stream.ReadAsync(buffer, token)) > 0)
                     {
                         totalRead += bytesRead;
-                        await uploadFile.WriteAsync(buffer.AsMemory(0, bytesRead), token);
+                        await uploadFile.WriteAsync(buffer, 0, bytesRead, token);
 
                         if (upload.UpdateCallback != null)
                         {

--- a/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
@@ -57,10 +57,11 @@ public static class UploadFileExtensions
     /// <param name="upload"></param>
     /// <param name="fileName"></param>
     /// <param name="maxAllowedSize"></param>
+    /// <param name="bufferSize"></param>
     /// <param name="token"></param>
     /// <returns></returns>
     [ExcludeFromCodeCoverage]
-    public static async Task<bool> SaveToFileAsync(this UploadFile upload, string fileName, long maxAllowedSize = 512000, CancellationToken token = default)
+    public static async Task<bool> SaveToFileAsync(this UploadFile upload, string fileName, long maxAllowedSize = 512000, int bufferSize = 64 * 1024, CancellationToken token = default)
     {
         var ret = false;
         if (upload.File != null)
@@ -92,7 +93,7 @@ public static class UploadFileExtensions
                 {
                     // 打开文件流
                     var stream = upload.File.OpenReadStream(maxAllowedSize, token);
-                    var buffer = new byte[4 * 1096];
+                    var buffer = new byte[bufferSize];
                     int bytesRead = 0;
                     double totalRead = 0;
 


### PR DESCRIPTION
## Link issues
fixes #6313 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add optional `bufferSize` parameter to `SaveToFileAsync` to optimize file write performance and adjust sample usage to accommodate the new parameter.

New Features:
- Add `bufferSize` parameter to `SaveToFileAsync` for configurable I/O buffer sizes.

Enhancements:
- Switch buffer allocation to use the new `bufferSize` and leverage explicit `WriteAsync` overload for improved file save performance.
- Update sample components to use a named `token` argument after inserting the `bufferSize` parameter.