### PR TITLE
doc(ITcpSocketClient): add DataHandler sample code

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/SocketFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/SocketFactories.razor
@@ -15,7 +15,10 @@
 [NotNull]
 private ITcpSocketFactory? TcpSocketFactory { get; set; }</Pre>
 
-<Pre>var client = factory.GetOrCreate("192.168.1.100", 0);</Pre>
+<Pre>var client = TcpSocketFactory.GetOrCreate("bb", options =>
+{
+    options.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+});</Pre>
 
 <p class="code-label">3. 使用方法</p>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/Adapters.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/Adapters.razor
@@ -1,0 +1,40 @@
+﻿@page "/socket/adapter"
+@inject IStringLocalizer<Adapters> Localizer
+
+<h3>@Localizer["AdaptersTitle"]</h3>
+<h4>@Localizer["AdaptersDescription"]</h4>
+
+<Notice></Notice>
+
+<DemoBlock Title="@Localizer["NormalTitle"]"
+           Introduction="@Localizer["NormalIntro"]"
+           Name="Normal" ShowCode="false">
+    <p>本例中连接一个模拟自定义协议服务，每次接收到客户端发来的特定数据后，返回业务数据。这类应用在我们实际应用中非常常见</p>
+    <p>通过 <code>SocketClientOptions</code> 配置类关闭自动接收数据功能 <code>IsAutoReceive="false"</code></p>
+    <Pre>_client = TcpSocketFactory.GetOrCreate("demo-adapter", options =>
+{
+    options.IsAutoReceive = false;
+    options.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+});</Pre>
+    <ul class="ul-demo">
+        <li>点击 <b>连接</b> 按钮后通过 <code>ITcpSocketFactory</code> 服务实例创建的 <code>ITcpSocketClient</code> 对象连接到网站模拟 <code>TcpServer</code></li>
+        <li>点击 <b>断开</b> 按钮调用 <code>CloseAsync</code> 方法断开 Socket 连接</li>
+        <li>点击 <b>发送</b> 按钮调用 <code>SendAsync</code> 方法发送请求数据</li>
+    </ul>
+    <p>本例中已关闭自动接收功能，调用 <code>ReceivedAsync</code> 方法主动接收服务端返回数据</p>
+
+    <div class="row form-inline g-3">
+        <div class="col-12 col-sm-6">
+            <Button Text="连接" Icon="fa-solid fa-play"
+                    OnClick="OnConnectAsync" IsDisabled="@_client.IsConnected"></Button>
+            <Button Text="断开" Icon="fa-solid fa-stop" class="ms-2"
+                    OnClick="OnCloseAsync" IsDisabled="@(!_client.IsConnected)"></Button>
+            <Button Text="发送" Icon="fa-solid fa-paper-plane" class="ms-2" IsAsync="true"
+                    OnClick="OnSendAsync" IsDisabled="@(!_client.IsConnected)"></Button>
+        </div>
+        <div class="col-12">
+            <Console Items="@_items" Height="496" HeaderText="接收数据（间隔 10 秒）"
+                     ShowAutoScroll="true" OnClear="@OnClear"></Console>
+        </div>
+    </div>
+</DemoBlock>

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/Adapters.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/Adapters.razor
@@ -21,7 +21,16 @@
         <li>点击 <b>断开</b> 按钮调用 <code>CloseAsync</code> 方法断开 Socket 连接</li>
         <li>点击 <b>发送</b> 按钮调用 <code>SendAsync</code> 方法发送请求数据</li>
     </ul>
-    <p>本例中已关闭自动接收功能，调用 <code>ReceivedAsync</code> 方法主动接收服务端返回数据</p>
+    <p class="code-label">通讯协议讲解：</p>
+    <p>在实际应用开发中，通讯数据协议很多时候是双方约定的。我们假设本示例通讯协议规约为定长格式具体如下：</p>
+    <ul class="ul-demo">
+        <li>发送数据包格式为 <code>请求头（Header）+ 请求体（Body）</code> 长度总和为 12 个字节</li>
+        <li>请求头为 4 字节定长，请求体为 8 个字节定长</li>
+        <li>请求体为字符串类型数据</li>
+        <li>返回数据包格式为 <code>响应头（Header）+ 响应体（Body）</code> 长度总和为 12 个字节</li>
+        <li>响应头为 4 字节定长，响应体为 8 个字节定长</li>
+        <li>响应体为字符串类型数据</li>
+    </ul>
 
     <div class="row form-inline g-3">
         <div class="col-12 col-sm-6">
@@ -33,7 +42,7 @@
                     OnClick="OnSendAsync" IsDisabled="@(!_client.IsConnected)"></Button>
         </div>
         <div class="col-12">
-            <Console Items="@_items" Height="496" HeaderText="接收数据（间隔 10 秒）"
+            <Console Items="@_items" Height="496" HeaderText="模拟通讯示例"
                      ShowAutoScroll="true" OnClear="@OnClear"></Console>
         </div>
     </div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/Adapters.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/Adapters.razor.cs
@@ -1,0 +1,110 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using System.Net;
+
+namespace BootstrapBlazor.Server.Components.Samples.Sockets;
+
+/// <summary>
+/// 数据适配器示例
+/// </summary>
+public partial class Adapters : IDisposable
+{
+    [Inject, NotNull]
+    private ITcpSocketFactory? TcpSocketFactory { get; set; }
+
+    private ITcpSocketClient _client = null!;
+
+    private List<ConsoleMessageItem> _items = [];
+
+    private readonly IPEndPoint _serverEndPoint = new(IPAddress.Loopback, 8900);
+
+    private CancellationTokenSource _connectTokenSource = new();
+    private CancellationTokenSource _sendTokenSource = new();
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnInitialized()
+    {
+        base.OnInitialized();
+
+        // 从服务中获取 Socket 实例
+        _client = TcpSocketFactory.GetOrCreate("demo-adapter", options =>
+        {
+            options.IsAutoReceive = false;
+            options.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+        });
+    }
+
+    private async Task OnConnectAsync()
+    {
+        if (_client is { IsConnected: false })
+        {
+            await _client.ConnectAsync(_serverEndPoint, _connectTokenSource.Token);
+        }
+    }
+
+    private async Task SendAsync()
+    {
+        if (_client is { IsConnected: false })
+        {
+            // 准备通讯数据
+            var data = new byte[1024];
+            await _client.SendAsync(data, _sendTokenSource.Token);
+        }
+    }
+
+    private async Task OnCloseAsync()
+    {
+        if (_client is { IsConnected: true })
+        {
+            await _client.CloseAsync();
+        }
+    }
+
+    private Task OnClear()
+    {
+        _items = [];
+        return Task.CompletedTask;
+    }
+
+    private async ValueTask OnReceivedAsync(ReadOnlyMemory<byte> data)
+    {
+        // 将数据显示为十六进制字符串
+        var payload = System.Text.Encoding.UTF8.GetString(data.Span);
+        _items.Add(new ConsoleMessageItem
+        {
+            Message = $"接收到来自站点的数据为 {payload}"
+        });
+
+        // 保持队列中最大数量为 50
+        if (_items.Count > 50)
+        {
+            _items.RemoveAt(0);
+        }
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (_client is { IsConnected: true })
+            {
+
+            }
+        }
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/Receives.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/Receives.razor.cs
@@ -8,7 +8,7 @@ using System.Net;
 namespace BootstrapBlazor.Server.Components.Samples.Sockets;
 
 /// <summary>
-/// 
+/// 接收电文示例
 /// </summary>
 public partial class Receives : ComponentBase, IDisposable
 {
@@ -27,7 +27,10 @@ public partial class Receives : ComponentBase, IDisposable
         base.OnInitialized();
 
         // 从服务中获取 Socket 实例
-        _client = TcpSocketFactory.GetOrCreate("bb", key => new IPEndPoint(IPAddress.Loopback, 0));
+        _client = TcpSocketFactory.GetOrCreate("bb", options =>
+        {
+            options.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
+        });
         _client.ReceivedCallBack += OnReceivedAsync;
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/Receives.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/Receives.razor.cs
@@ -10,7 +10,7 @@ namespace BootstrapBlazor.Server.Components.Samples.Sockets;
 /// <summary>
 /// 接收电文示例
 /// </summary>
-public partial class Receives : ComponentBase, IDisposable
+public partial class Receives : IDisposable
 {
     [Inject, NotNull]
     private ITcpSocketFactory? TcpSocketFactory { get; set; }
@@ -18,6 +18,8 @@ public partial class Receives : ComponentBase, IDisposable
     private ITcpSocketClient _client = null!;
 
     private List<ConsoleMessageItem> _items = [];
+
+    private readonly IPEndPoint _serverEndPoint = new(IPAddress.Loopback, 8800);
 
     /// <summary>
     /// <inheritdoc/>
@@ -27,7 +29,7 @@ public partial class Receives : ComponentBase, IDisposable
         base.OnInitialized();
 
         // 从服务中获取 Socket 实例
-        _client = TcpSocketFactory.GetOrCreate("bb", options =>
+        _client = TcpSocketFactory.GetOrCreate("demo-receive", options =>
         {
             options.LocalEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
         });
@@ -38,7 +40,7 @@ public partial class Receives : ComponentBase, IDisposable
     {
         if (_client is { IsConnected: false })
         {
-            await _client.ConnectAsync("127.0.0.1", 8800, CancellationToken.None);
+            await _client.ConnectAsync(_serverEndPoint, CancellationToken.None);
         }
     }
 

--- a/src/BootstrapBlazor.Server/Extensions/MenusLocalizerExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/MenusLocalizerExtensions.cs
@@ -218,8 +218,15 @@ internal static class MenusLocalizerExtensions
             {
                 new()
                 {
+                    IsNew = true,
                     Text = Localizer["SocketReceive"],
                     Url = "socket/receive"
+                },
+                new()
+                {
+                    IsNew = true,
+                    Text = Localizer["SocketDataAdapter"],
+                    Url = "socket/adapter"
                 }
             };
             AddBadge(item, count: 1);
@@ -257,7 +264,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsUpdate = true,
                     Text = Localizer["Labels"],
                     Url = "label"
                 },
@@ -430,7 +436,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["OtpInput"],
                     Url = "otp-input"
                 },
@@ -467,13 +472,11 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsUpdate = true,
                     Text = Localizer["SelectTable"],
                     Url = "select-table"
                 },
                 new()
                 {
-                    IsUpdate = true,
                     Text = Localizer["SelectTree"],
                     Url = "select-tree"
                 },
@@ -539,7 +542,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["Vditor"],
                     Url = "vditor"
                 }
@@ -830,13 +832,11 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["Typed"],
                     Url = "typed"
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["UniverSheet"],
                     Url = "univer-sheet"
                 },
@@ -1241,7 +1241,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["FullScreenButton"],
                     Url = "fullscreen-button"
                 },
@@ -1267,7 +1266,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["Meet"],
                     Url = "meet"
                 },
@@ -1568,7 +1566,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["Html2Image"],
                     Url = "html2image"
                 },
@@ -1615,7 +1612,6 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["TotpService"],
                     Url = "otp-service"
                 },
@@ -1626,13 +1622,11 @@ internal static class MenusLocalizerExtensions
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["AudioDevice"],
                     Url = "audio-device"
                 },
                 new()
                 {
-                    IsNew = true,
                     Text = Localizer["VideoDevice"],
                     Url = "video-device"
                 },

--- a/src/BootstrapBlazor.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/ServiceCollectionExtensions.cs
@@ -45,7 +45,8 @@ static class ServiceCollectionExtensions
         services.AddTaskServices();
         services.AddHostedService<ClearTempFilesService>();
         services.AddHostedService<MockOnlineContributor>();
-        services.AddHostedService<MockSocketServerService>();
+        services.AddHostedService<MockReceiveSocketServerService>();
+        services.AddHostedService<MockCustomProtocolSocketServerService>();
 
         // 增加通用服务
         services.AddBootstrapBlazorServices();

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -7210,5 +7210,11 @@
     "OfficeViewerNormalTitle": "Basic Usage",
     "OfficeViewerNormalIntro": "Set the document URL for preview by configuring the <code>Url</code> value",
     "OfficeViewerToastSuccessfulContent": "Office document loaded successfully"
+  },
+  "BootstrapBlazor.Server.Components.Samples.Sockets.Receives": {
+    "ReceivesTitle": "Socket Receive",
+    "ReceivesDescription": "Receive data through Socket and display it",
+    "NormalTitle": "Basic usage",
+    "NormalIntro": "After connecting, the timestamp data sent by the server is automatically received through the <code>ReceivedCallBack</code> callback method"
   }
 }

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -7210,5 +7210,11 @@
     "OfficeViewerNormalTitle": "基本用法",
     "OfficeViewerNormalIntro": "通过设置 <code>Url</code> 值设置预览文档地址",
     "OfficeViewerToastSuccessfulContent": "Office 文档加载成功"
+  },
+  "BootstrapBlazor.Server.Components.Samples.Sockets.Receives": {
+    "ReceivesTitle": "Socket 接收示例",
+    "ReceivesDescription": "通过 Socket 接收数据并且显示",
+    "NormalTitle": "基本用法",
+    "NormalIntro": "连接后通过 <code>ReceivedCallBack</code> 回调方法自动接收服务端发送来的时间戳数据"
   }
 }

--- a/src/BootstrapBlazor.Server/Services/MockCustomProtocalSocketServerService.cs
+++ b/src/BootstrapBlazor.Server/Services/MockCustomProtocalSocketServerService.cs
@@ -1,0 +1,74 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using System.Net;
+using System.Net.Sockets;
+
+namespace Longbow.Tasks.Services;
+
+/// <summary>
+/// 模拟 Socket 服务端服务类
+/// </summary>
+internal class MockCustomProtocolSocketServerService(ILogger<MockCustomProtocolSocketServerService> logger) : BackgroundService
+{
+    /// <summary>
+    /// 运行任务
+    /// </summary>
+    /// <param name="stoppingToken"></param>
+    /// <returns></returns>
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        var server = new TcpListener(IPAddress.Loopback, 8900);
+        server.Start();
+        while (stoppingToken is { IsCancellationRequested: false })
+        {
+            try
+            {
+                var client = await server.AcceptTcpClientAsync(stoppingToken);
+                _ = Task.Run(() => OnDataHandlerAsync(client, stoppingToken), stoppingToken);
+            }
+            catch { }
+        }
+    }
+
+    private async Task OnDataHandlerAsync(TcpClient client, CancellationToken stoppingToken)
+    {
+        // 方法目的:
+        // 收到消息后发送自定义通讯协议的响应数据
+        // 响应头 + 响应体
+        await using var stream = client.GetStream();
+        while (stoppingToken is { IsCancellationRequested: false })
+        {
+            try
+            {
+                // 接收数据
+                var len = await stream.ReadAsync(new byte[1024], stoppingToken);
+                if (len == 0)
+                {
+                    // 断开连接
+                    break;
+                }
+
+                // 实际应用中需要解析接收到的数据进行处理，本示例中仅模拟接收数据后发送响应数据
+
+                // 发送响应数据
+                // 响应头: 4 字节表示响应体长度 [0x32, 0x30, 0x32, 0x35]
+                // 响应体: 8 字节当前时间戳字符串 
+                var data = new byte[12];
+                "2025"u8.ToArray().CopyTo(data, 0);
+                System.Text.Encoding.UTF8.GetBytes(DateTime.Now.ToString("ddHHmmss")).CopyTo(data, 4);
+                await stream.WriteAsync(data, stoppingToken);
+            }
+            catch (OperationCanceledException) { break; }
+            catch (IOException) { break; }
+            catch (SocketException) { break; }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "MockCustomProtocolSocketServerService encountered an error while sending data.");
+                break;
+            }
+        }
+    }
+}

--- a/src/BootstrapBlazor.Server/Services/MockReceiveSocketServerService.cs
+++ b/src/BootstrapBlazor.Server/Services/MockReceiveSocketServerService.cs
@@ -11,7 +11,7 @@ namespace Longbow.Tasks.Services;
 /// <summary>
 /// 模拟 Socket 服务端服务类
 /// </summary>
-internal class MockSocketServerService(ILogger<MockSocketServerService> logger) : BackgroundService
+class MockReceiveSocketServerService(ILogger<MockReceiveSocketServerService> logger) : BackgroundService
 {
     /// <summary>
     /// 运行任务
@@ -52,7 +52,7 @@ internal class MockSocketServerService(ILogger<MockSocketServerService> logger) 
             catch (SocketException) { break; }
             catch (Exception ex)
             {
-                logger.LogError(ex, "MockSocketServerService encountered an error while sending data.");
+                logger.LogError(ex, "MockReceiveSocketServerService encountered an error while sending data.");
                 break;
             }
         }

--- a/src/BootstrapBlazor.Server/docs.json
+++ b/src/BootstrapBlazor.Server/docs.json
@@ -243,7 +243,8 @@
     "vditor": "Vditors",
     "socket-factory": "SocketFactories",
     "office-viewer": "OfficeViewers",
-    "socket/receive": "Sockets\\Receives"
+    "socket/receive": "Sockets\\Receives",
+    "socket/adapter": "Sockets\\Adapters"
   },
   "video": {
     "table": "BV1ap4y1x7Qn?p=1",

--- a/src/BootstrapBlazor/Services/TcpSocket/TcpSocketClientBase.cs
+++ b/src/BootstrapBlazor/Services/TcpSocket/TcpSocketClientBase.cs
@@ -16,7 +16,7 @@ namespace BootstrapBlazor.Components;
 /// clients.
 /// </summary>
 /// <remarks>The <see cref="TcpSocketClientBase"/> class offers core functionality for managing TCP socket
-/// connections,  including connecting to remote endpoints, sending and receiving data, and handling data packages. 
+/// connections,  including connecting to remote endpoints, sending and receiving data, and handling data packages.
 /// Derived classes can extend or override its behavior to implement specific client logic.  Key features include: -
 /// Connection management with support for timeouts and cancellation tokens. - Data transmission and reception with
 /// optional data package handling. - Logging capabilities for tracking events and errors. - Dependency injection
@@ -29,7 +29,6 @@ public abstract class TcpSocketClientBase(SocketClientOptions options) : ITcpSoc
     /// Gets or sets the socket client provider used for managing socket connections.
     /// </summary>
     protected ISocketClientProvider? SocketClientProvider { get; set; }
-
 
     /// <summary>
     /// Gets or sets the logger instance used for logging messages and events.
@@ -273,7 +272,7 @@ public abstract class TcpSocketClientBase(SocketClientOptions options) : ITcpSoc
     /// <summary>
     /// Logs a message with the specified log level, exception, and additional context.
     /// </summary>
-    protected void Log(LogLevel logLevel, Exception? ex, string? message)
+    protected virtual void Log(LogLevel logLevel, Exception? ex, string? message)
     {
         Logger ??= ServiceProvider?.GetRequiredService<ILogger<TcpSocketClientBase>>();
         Logger?.Log(logLevel, ex, "{Message}", message);


### PR DESCRIPTION
## Link issues
fixes #6330 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a new DataAdapter sample demonstrating custom protocol handling with ITcpSocketClient, update related socket samples to use options-based configuration, introduce dedicated mock server services for receive and adapter scenarios, and refresh menu entries and extensibility points.

New Features:
- Add Adapters sample component illustrating custom protocol data handling with ITcpSocketClient
- Introduce MockCustomProtocolSocketServerService to simulate a custom protocol server

Enhancements:
- Refactor Receives sample and SocketFactories snippet to use options-based GetOrCreate with explicit IPEndPoint
- Make TcpSocketClientBase.Log method virtual to allow overriding
- Update menu localization to include SocketDataAdapter entry and remove outdated IsNew/IsUpdate flags

Documentation:
- Add Razor page and localized strings for the Adapters sample

Chores:
- Rename MockSocketServerService to MockReceiveSocketServerService and register it alongside the custom protocol server in DI