### PR TITLE
fix(Dialog): not trigger OnCloseAsync multiple dialog

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.8.0-beta07</Version>
+    <Version>9.8.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Link issues
fixes #6332 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix OnCloseAsync callback invocation for multiple stacked dialogs by storing callbacks in the dialog parameters and invoking them upon each dialog removal.

Bug Fixes:
- Ensure OnCloseAsync is triggered for every dialog in multi-dialog scenarios

Enhancements:
- Extend DialogParameters to include OnCloseCallback for each dialog instance
- Use dictionary removal with out parameter to retrieve and invoke the correct callback on dialog close