### PR TITLE
feat(FullScreenButton): adjust the gap

### DIFF
--- a/src/BootstrapBlazor.Server/Extensions/MenusLocalizerExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/MenusLocalizerExtensions.cs
@@ -94,7 +94,7 @@ internal static class MenusLocalizerExtensions
         item = new DemoMenuItem()
         {
             Text = Localizer["SocketComponents"],
-            Icon = "fa-solid fa-square-binary text-danger"
+            Icon = "fa-fw fa-solid fa-square-binary text-danger"
         };
         AddSocket(item);
 
@@ -130,7 +130,7 @@ internal static class MenusLocalizerExtensions
         item = new DemoMenuItem()
         {
             Text = Localizer["Components"],
-            Icon = "fa-solid fa-fw fa-heart fa-beat icon-summary",
+            Icon = "fa-fw fa-solid fa-heart fa-beat icon-summary",
             Url = "components"
         };
         AddSummary(item);

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.scss
@@ -775,7 +775,7 @@
                     background-color: var(--bb-tabs-item-hover-bg-color);
                 }
 
-                .btn {
+                &.tabs-nav-toolbar-fs {
                     padding: 0;
                 }
             }


### PR DESCRIPTION
## Link issues
fixes #6340 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Address gap and alignment issues for menu icons and the full-screen toolbar button by adding fixed-width icon classes and scoping CSS rules.

Bug Fixes:
- Fix menu icon spacing by adding Font Awesome "fa-fw" class to square-binary and heart icons.
- Correct padding on the full-screen toolbar button by scoping the padding reset to the ".tabs-nav-toolbar-fs" selector.