### PR TITLE
refactor(Select): rename IsUseActiveWhenValueIsNull parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.8.1-beta03</Version>
+    <Version>9.8.1-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -27,11 +27,24 @@ public partial class Select<TValue> : ISelect, ILookup
     private ILookupService? InjectLookupService { get; set; }
 
     /// <summary>
-    /// 获得/设置 值为 null 时是否使用第一个选项作为默认值
-    /// <para>Gets or sets a value indicating whether the "active" state should be used when the associated value is null.</para>
+    /// 获得/设置 值为 null 时是否使用第一个选项或者标记为 active 的候选项作为默认值
+    /// <para>Gets or sets a value indicating Whether to use the first option or the candidate marked as active as the default value when the value is null</para>
     /// </summary>
     [Parameter]
-    public bool IsUseActiveWhenValueIsNull { get; set; }
+    [Obsolete("已弃用，请使用 IsUseDefaultItemWhenValueIsNull 参数代替；Deprecated, use the IsUseDefaultItemWhenValueIsNull parameter instead")]
+    [ExcludeFromCodeCoverage]
+    public bool IsUseActiveWhenValueIsNull
+    {
+        get => IsUseDefaultItemWhenValueIsNull;
+        set => IsUseDefaultItemWhenValueIsNull = value;
+    }
+
+    /// <summary>
+    /// 获得/设置 值为 null 时是否使用第一个选项或者标记为 active 的候选项作为默认值
+    /// <para>Gets or sets a value indicating Whether to use the first option or the candidate marked as active as the default value when the value is null</para>
+    /// </summary>
+    [Parameter]
+    public bool IsUseDefaultItemWhenValueIsNull { get; set; }
 
     /// <summary>
     /// Gets or sets the display template. Default is null.
@@ -452,7 +465,7 @@ public partial class Select<TValue> : ISelect, ILookup
             _lastSelectedValueString = "";
             _init = false;
 
-            return IsUseActiveWhenValueIsNull && !IsVirtualize
+            return IsUseDefaultItemWhenValueIsNull && !IsVirtualize
                 ? SetSelectedItemState(GetItemByRows())
                 : null;
         }

--- a/test/UnitTest/Components/SelectTest.cs
+++ b/test/UnitTest/Components/SelectTest.cs
@@ -27,7 +27,7 @@ public class SelectTest : BootstrapBlazorTestBase
                     new("1", "Test1"),
                     new("2", "Test2") { Active = true }
                 });
-                pb.Add(a => a.IsUseActiveWhenValueIsNull, true);
+                pb.Add(a => a.IsUseDefaultItemWhenValueIsNull, true);
                 pb.Add(a => a.OnSelectedItemChanged, item =>
                 {
                     selectedValue = item.Value;


### PR DESCRIPTION
## Link issues
fixes #6389 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Rename Select component parameter for default value selection from IsUseActiveWhenValueIsNull to IsUseDefaultItemWhenValueIsNull, maintain backward compatibility via an obsolete wrapper, and update related logic and tests.

Bug Fixes:
- Fix issue #6389 by addressing inconsistent parameter naming

Enhancements:
- Introduce new IsUseDefaultItemWhenValueIsNull parameter to control default selection behavior when value is null
- Mark legacy IsUseActiveWhenValueIsNull property as obsolete and delegate its getter/setter to the new parameter

Tests:
- Update unit tests to reference IsUseDefaultItemWhenValueIsNull instead of the deprecated property