### PR TITLE
feat(Table): disable editing in virtual scroll mode

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.8.1-beta05</Version>
+    <Version>9.8.1-beta06</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -366,17 +366,6 @@
             @RenderHeader(false)
         }
         <tbody>
-            @if (InsertRowMode == InsertRowMode.First)
-            {
-                if (!IsExcel && EditMode == EditMode.EditForm && ShowAddForm)
-                {
-                    @RenderEditForm.Invoke((EditModel, ItemChangedType.Add))
-                }
-                if (AddInCell)
-                {
-                    @RenderRow(EditModel)
-                }
-            }
             @if (ScrollMode == ScrollMode.Virtual)
             {
                 @if (Items != null)
@@ -394,7 +383,18 @@
             }
             else
             {
-                @foreach (var item in Rows)
+                if (InsertRowMode == InsertRowMode.First)
+                {
+                    if (!IsExcel && EditMode == EditMode.EditForm && ShowAddForm)
+                    {
+                        @RenderEditForm.Invoke((EditModel, ItemChangedType.Add))
+                    }
+                    if (AddInCell)
+                    {
+                        @RenderRow(EditModel)
+                    }
+                }
+                foreach (var item in Rows)
                 {
                     OnBeforeRenderRow?.Invoke(item);
                     if (RowTemplate != null)
@@ -439,7 +439,18 @@
                         @RenderEditForm((EditModel, ItemChangedType.Update))
                     }
                 }
-                @if (IsShowEmpty)
+                if (InsertRowMode == InsertRowMode.Last)
+                {
+                    if (!IsExcel && EditMode == EditMode.EditForm && ShowAddForm)
+                    {
+                        @RenderEditForm.Invoke((EditModel, ItemChangedType.Add))
+                    }
+                    if (AddInCell)
+                    {
+                        @RenderRow(EditModel)
+                    }
+                }
+                if (IsShowEmpty)
                 {
                     <tr>
                         <td colspan="@GetEmptyColumnCount()">
@@ -447,17 +458,6 @@
                             </Empty>
                         </td>
                     </tr>
-                }
-            }
-            @if (InsertRowMode == InsertRowMode.Last)
-            {
-                if (!IsExcel && EditMode == EditMode.EditForm && ShowAddForm)
-                {
-                    @RenderEditForm.Invoke((EditModel, ItemChangedType.Add))
-                }
-                if (AddInCell)
-                {
-                    @RenderRow(EditModel)
                 }
             }
         </tbody>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -47,11 +47,11 @@
                     }
                     @if (ShowDefaultButtons)
                     {
-                        @if (ShowAddButton)
+                        @if (ShowAddButton && ScrollMode == ScrollMode.None)
                         {
                             <TableToolbarButton TItem="TItem" Color="Color.Success" OnClick="AddAsync" Icon="@AddButtonIcon" Text="@AddButtonText" IsDisabled="GetAddButtonStatus()" />
                         }
-                        @if (!IsExcel && ShowEditButton)
+                        @if (!IsExcel && ShowEditButton && ScrollMode == ScrollMode.None)
                         {
                             <TableToolbarButton TItem="TItem" IsDisabled="GetEditButtonStatus()" Color="Color.Primary" OnClick="EditAsync" Icon="@EditButtonIcon" Text="@EditButtonText" IsEnableWhenSelectedOneRow="true" />
                         }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -1219,7 +1219,7 @@ public partial class Table<TItem>
     /// 是否显示行内编辑按钮
     /// </summary>
     /// <returns></returns>
-    protected bool GetShowExtendEditButton(TItem item) => ShowExtendEditButtonCallback?.Invoke(item) ?? ShowExtendEditButton;
+    protected bool GetShowExtendEditButton(TItem item) => ScrollMode != ScrollMode.Virtual && (ShowExtendEditButtonCallback?.Invoke(item) ?? ShowExtendEditButton);
 
     /// <summary>
     /// 是否显示行内删除按钮


### PR DESCRIPTION
## Link issues
fixes #6398 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Disable table editing features (add, edit, inline row edits, and insert-row UI) when virtual scrolling is enabled.

Enhancements:
- Hide Add and Edit toolbar buttons unless scroll mode is None
- Skip rendering insert-row forms and cell insertion when in virtual scroll mode
- Disable inline row edit buttons for virtual scroll mode