### PR TITLE
refactor(INetworkMonitor): update return type nullable NetworkMonitorState

### DIFF
--- a/src/BootstrapBlazor/Services/DefaultNetworkMonitorService.cs
+++ b/src/BootstrapBlazor/Services/DefaultNetworkMonitorService.cs
@@ -34,10 +34,10 @@ class DefaultNetowrkMonitorService : INetworkMonitorService, IAsyncDisposable
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
-    public async Task<NetworkMonitorState> GetNetworkMonitorState(CancellationToken token = default)
+    public async Task<NetworkMonitorState?> GetNetworkMonitorState(CancellationToken token = default)
     {
         _module ??= await LoadModule();
-        return await _module.InvokeAsync<NetworkMonitorState?>("getNetworkInfo", token) ?? new();
+        return await _module.InvokeAsync<NetworkMonitorState?>("getNetworkInfo", token);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Services/INetworkMonitorService.cs
+++ b/src/BootstrapBlazor/Services/INetworkMonitorService.cs
@@ -16,7 +16,7 @@ public interface INetworkMonitorService
     /// <param name="token">A cancellation token that can be used to cancel the operation.</param>
     /// <returns>A task representing the asynchronous operation. The task result contains the current <see
     /// cref="NetworkMonitorState"/>.</returns>
-    Task<NetworkMonitorState> GetNetworkMonitorState(CancellationToken token = default);
+    Task<NetworkMonitorState?> GetNetworkMonitorState(CancellationToken token = default);
 
     /// <summary>
     /// Registers a callback to be invoked when the network monitor state changes.

--- a/test/UnitTest/Services/DefaultNetworkMonitorServiceTest.cs
+++ b/test/UnitTest/Services/DefaultNetworkMonitorServiceTest.cs
@@ -18,6 +18,7 @@ public class DefaultNetworkMonitorServiceTest : BootstrapBlazorTestBase
         });
         var service = Context.Services.GetRequiredService<INetworkMonitorService>();
         var state = await service.GetNetworkMonitorState(CancellationToken.None);
+        Assert.NotNull(state);
         Assert.Equal("4g", state.NetworkType);
         Assert.Equal(10, state.Downlink);
         Assert.Equal(100, state.RTT);

--- a/test/UnitTest/Services/TcpSocketFactoryTest.cs
+++ b/test/UnitTest/Services/TcpSocketFactoryTest.cs
@@ -637,7 +637,7 @@ public class TcpSocketFactoryTest
         var ex = Assert.Throws<ArgumentNullException>(() => new DelimiterDataPackageHandler(string.Empty));
         Assert.NotNull(ex);
 
-        ex = Assert.Throws<ArgumentNullException>(() => new DelimiterDataPackageHandler((byte[])null!));
+        ex = Assert.Throws<ArgumentNullException>(() => new DelimiterDataPackageHandler(null!));
         Assert.NotNull(ex);
     }
 


### PR DESCRIPTION
## Link issues
fixes #6416 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor network monitor service to return a nullable NetworkMonitorState and update related tests to accommodate the change.

Enhancements:
- Change INetworkMonitorService and DefaultNetworkMonitorService GetNetworkMonitorState methods to return NetworkMonitorState? instead of non-nullable type
- Remove default fallback instantiation in DefaultNetworkMonitorService when invoking JS module

Tests:
- Add assertion in DefaultNetworkMonitorServiceTest to verify the returned state is not null
- Simplify TcpSocketFactoryTest by removing unnecessary byte[] cast when testing null argument