### PR TITLE
fix(TabItem): layout OnErrorHandleAsync callback not work on tab item

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.8.2-beta02</Version>
+    <Version>9.8.2-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -432,7 +432,7 @@ public partial class Tab
     public ITabHeader? TabHeader { get; set; }
 
     /// <summary>
-    /// 获得/设置 是否开启全局异常捕获 默认 null 读取配置文件 EnableErrorLogger 值
+    /// 获得/设置 是否开启全局异常捕获 默认 null 读取配置文件 <see cref="BootstrapBlazorOptions.EnableErrorLogger"/> 值
     /// </summary>
     [Parameter]
     public bool? EnableErrorLogger { get; set; }

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -15,6 +15,9 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
     [Parameter, NotNull]
     public TabItem? Item { get; set; }
 
+    [CascadingParameter]
+    private Layout? Layout { get; set; }
+
     [CascadingParameter, NotNull]
     private Tab? TabSet { get; set; }
 
@@ -67,6 +70,7 @@ class TabItemContent : IComponent, IHandlerException, IDisposable
             _logger.Register(this);
             return Task.CompletedTask;
         }));
+        builder.AddAttribute(6, nameof(ErrorLogger.OnErrorHandleAsync), Layout?.OnErrorHandleAsync);
         builder.CloseComponent();
     }
 


### PR DESCRIPTION
## Link issues
fixes #6460 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure TabItemContent correctly propagates the Layout.OnErrorHandleAsync callback for global error handling and update documentation for EnableErrorLogger default reference.

Bug Fixes:
- Fix layout OnErrorHandleAsync callback not invoked on tab items

Enhancements:
- Pass Layout.OnErrorHandleAsync to ErrorLogger in TabItemContent for consistent error handling

Documentation:
- Clarify default reference for EnableErrorLogger to BootstrapBlazorOptions.EnableErrorLogger in Tab component