### PR TITLE
doc(IOptions): use IOptions improve performance

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Components/BBLogo.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/BBLogo.razor
@@ -1,3 +1,3 @@
-﻿@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+﻿@inject IOptions<WebsiteOptions> WebsiteOption
 
-<img alt="logo" class="bb-icon" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+<img alt="logo" class="bb-icon" src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />

--- a/src/BootstrapBlazor.Server/Components/Components/BlazorReconnector.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/BlazorReconnector.razor
@@ -1,4 +1,4 @@
-﻿@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+﻿@inject IOptions<WebsiteOptions> WebsiteOption
 
 <Reconnector>
     <ReconnectingTemplate>
@@ -59,7 +59,7 @@
 </Reconnector>
 
 @code {
-    private string TemplateUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/wikis/%E9%A1%B9%E7%9B%AE%E6%A8%A1%E6%9D%BF%E4%BD%BF%E7%94%A8%E6%95%99%E7%A8%8B";
+    private string TemplateUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/wikis/%E9%A1%B9%E7%9B%AE%E6%A8%A1%E6%9D%BF%E4%BD%BF%E7%94%A8%E6%95%99%E7%A8%8B";
 
     RenderFragment RenderBootstrapBlazor =>
     @<div class="col-12 col-sm-5">
@@ -71,7 +71,7 @@
                 <p></p>
                 <div>已提供项目模板方便快速上手 <a class="connection-link" href="@TemplateUrl" target="_blank">项目模板</a></div>
             </div>
-            <img altt="QQ" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/QQGroup@2x.png")" alt="QQGroup" />
+            <img altt="QQ" src="@WebsiteOption.Value.GetAssetUrl("images/QQGroup@2x.png")" alt="QQGroup" />
             <div class="connection-body-tail d-none d-sm-block"></div>
         </div>
     </div>;

--- a/src/BootstrapBlazor.Server/Components/Components/ComponentCard.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/ComponentCard.razor.cs
@@ -13,9 +13,9 @@ namespace BootstrapBlazor.Server.Components.Components;
 public sealed partial class ComponentCard
 {
     [Inject, NotNull]
-    private IOptionsMonitor<WebsiteOptions>? WebsiteOption { get; set; }
+    private IOptions<WebsiteOptions>? WebsiteOption { get; set; }
 
-    private string ImageUrl => $"{WebsiteOption.CurrentValue.AssetRootPath}images/{Image}";
+    private string ImageUrl => $"{WebsiteOption.Value.AssetRootPath}images/{Image}";
 
     private string? ClassString => CssBuilder.Default("col-12 col-sm-6 col-md-4 col-lg-3")
         .AddClass("d-none", IsHide)

--- a/src/BootstrapBlazor.Server/Components/Components/CultureChooser.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/CultureChooser.razor
@@ -4,7 +4,7 @@
     <span>@Label</span>
     <Select Value="@SelectedCulture" OnSelectedItemChanged="@SetCulture">
         <Options>
-            @foreach (var kv in BootstrapOptions.CurrentValue.GetSupportedCultures())
+            @foreach (var kv in BootstrapOptions.Value.GetSupportedCultures())
             {
                 <SelectOption Text="@GetDisplayName(kv)" Value="@kv.Name" />
             }

--- a/src/BootstrapBlazor.Server/Components/Components/CultureChooser.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/CultureChooser.razor.cs
@@ -16,7 +16,7 @@ public partial class CultureChooser
 {
     [Inject]
     [NotNull]
-    private IOptionsMonitor<BootstrapBlazorOptions>? BootstrapOptions { get; set; }
+    private IOptions<BootstrapBlazorOptions>? BootstrapOptions { get; set; }
 
     [Inject]
     [NotNull]

--- a/src/BootstrapBlazor.Server/Components/Components/CustomWinBoxContent.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/CustomWinBoxContent.razor
@@ -1,4 +1,4 @@
-﻿@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+﻿@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div class="bb-winbox-body">
     <h3>Custom WinBox Content Create @DateTime.Now</h3>

--- a/src/BootstrapBlazor.Server/Components/Components/CustomWinBoxContent.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/CustomWinBoxContent.razor.cs
@@ -49,7 +49,7 @@ public partial class CustomWinBoxContent
     {
         if (Option != null)
         {
-            Option.Icon = $"{WebsiteOption.CurrentValue.AssetRootPath}images/Argo-C.png";
+            Option.Icon = $"{WebsiteOption.Value.AssetRootPath}images/Argo-C.png";
             await WinBoxService.SetIcon(Option);
         }
     }

--- a/src/BootstrapBlazor.Server/Components/Components/Header.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/Header.razor
@@ -24,13 +24,13 @@
     <CultureChooser class="flex-md" />
     <ul class="navbar-nav nav-repo ms-3">
         <li class="nav-item">
-            <a class="nav-link p-2" href="@WebsiteOption.CurrentValue.GithubRepositoryUrl" target="_blank">
-                <img alt="git" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/git.svg")" />
+            <a class="nav-link p-2" href="@WebsiteOption.Value.GithubRepositoryUrl" target="_blank">
+                <img alt="git" src="@WebsiteOption.Value.GetAssetUrl("images/git.svg")" />
             </a>
         </li>
         <li class="nav-item">
-            <a class="nav-link p-2" href="@WebsiteOption.CurrentValue.GiteeRepositoryUrl" target="_blank">
-                <img alt="gitee" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/gitee.svg")" />
+            <a class="nav-link p-2" href="@WebsiteOption.Value.GiteeRepositoryUrl" target="_blank">
+                <img alt="gitee" src="@WebsiteOption.Value.GetAssetUrl("images/gitee.svg")" />
             </a>
         </li>
         <li class="nav-item">

--- a/src/BootstrapBlazor.Server/Components/Components/Header.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/Header.razor.cs
@@ -14,7 +14,7 @@ public partial class Header
 {
     [Inject]
     [NotNull]
-    private IOptionsMonitor<WebsiteOptions>? WebsiteOption { get; set; }
+    private IOptions<WebsiteOptions>? WebsiteOption { get; set; }
 
     [Inject]
     [NotNull]

--- a/src/BootstrapBlazor.Server/Components/Components/InstallContent.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/InstallContent.razor
@@ -1,7 +1,7 @@
 ﻿@using Microsoft.Extensions.DependencyInjection
 @inject PackageVersionService VersionManager
 @inject IStringLocalizer<InstallContent> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Title</h3>
 
@@ -14,17 +14,17 @@
 <p class="code-label">1. @Localizer["P11"]</p>
 <p class="code-label">2. @Localizer["P12"]</p>
 <p class="code-label">3. @Localizer["P13"] <b>Blazor App</b> @Localizer["P14"] <b>@Localizer["P15"]</b>, @Localizer["P16"] <b>Create</b></p>
-<img alt="install" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/create-new-application.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+<img alt="install" src="@WebsiteOption.Value.GetAssetUrl("images/create-new-application.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
 @ChooseTemplate
 
 <h5>@Localizer["P17"]</h5>
 <p class="code-label">1. @Localizer["P18"] <b>nuget.org</b> @Localizer["P19"] <code>BootstrapBlazor</code></p>
 <p>@Localizer["P20"] <b>Manage Nuget Packages</b></p>
 <Pre @key="@Version" class="no-highlight">dotnet add package BootstrapBlazor --version @Version</Pre>
-<img alt="install" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/manage-nuget-packages-for-server-app.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+<img alt="install" src="@WebsiteOption.Value.GetAssetUrl("images/manage-nuget-packages-for-server-app.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
 
 <p class="code-label">2. @Localizer["P21"]</p>
-<img alt="install" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/nuget_install.png")" style="width: 1000px; border-radius: 6px;" class="d-none d-sm-block" />
+<img alt="install" src="@WebsiteOption.Value.GetAssetUrl("images/nuget_install.png")" style="width: 1000px; border-radius: 6px;" class="d-none d-sm-block" />
 
 <p class="code-label">3. @Localizer["P22"]</p>
 <p>@Localizer["P23"]</p>
@@ -69,4 +69,4 @@
 <p class="code-label">1. @Localizer["P39"] <code>Button</code> @Localizer["P40"]</p>
 <Pre>&lt;Button Color="Color.Primary" Icon="fa-solid fa-font-awesome" Text="@Localizer["P41"]" /&gt;</Pre>
 <p class="code-label">2. @Localizer["P42"] <b>Visual studio</b> @Localizer["P43"] <kbd>F5</kbd> @Localizer["P44"]</p>
-<img alt="install" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/preview.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+<img alt="install" src="@WebsiteOption.Value.GetAssetUrl("images/preview.png")" style="border-radius: 6px;" class="d-none d-sm-block" />

--- a/src/BootstrapBlazor.Server/Components/Components/Pre.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/Pre.razor
@@ -1,6 +1,6 @@
 ﻿@inherits WebSiteModuleComponentBase
 @attribute [JSModuleAutoLoader("Components/Pre.razor.js")]
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div @attributes="@AdditionalAttributes" class="@ClassString" id="@Id" data-bb-title="@CopiedText">
     <p class="loading">@LoadingText</p>

--- a/src/BootstrapBlazor.Server/Components/Components/Pre.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/Pre.razor.cs
@@ -114,7 +114,7 @@ public partial class Pre
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, CopiedText, WebsiteOption.CurrentValue.AssetRootPath);
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, CopiedText, WebsiteOption.Value.AssetRootPath);
 
     private async Task GetCodeAsync()
     {

--- a/src/BootstrapBlazor.Server/Components/Components/QQGroup.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/QQGroup.razor
@@ -1,14 +1,14 @@
-﻿@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+﻿@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<QQGroup> Localzier
 
 <div>
     @Localzier["Group"]：BootstrapAdmin & Blazor
-    <a class="mx-1" target="_blank" href="@WebsiteOption.CurrentValue.QQGroup1Link">
+    <a class="mx-1" target="_blank" href="@WebsiteOption.Value.QQGroup1Link">
         <span class="text-success fa-brands fa-qq">
             <span class="ms-1"><b>795206915</b></span>
         </span>
     </a>
-    <a class="mx-1" target="_blank" href="@WebsiteOption.CurrentValue.QQGroup2Link">
+    <a class="mx-1" target="_blank" href="@WebsiteOption.Value.QQGroup2Link">
         <span class="text-success fa-brands fa-qq">
             <span class="ms-1"><b>675147445</b></span>
         </span>

--- a/src/BootstrapBlazor.Server/Components/Components/ThemeChooser.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/ThemeChooser.razor
@@ -1,6 +1,6 @@
 ﻿@inherits WebSiteModuleComponentBase
 @attribute [JSModuleAutoLoader("Components/ThemeChooser.razor.js")]
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <HeadContent>
     @foreach (var css in _currentTheme)
@@ -10,7 +10,7 @@
 </HeadContent>
 
 <div id="@Id" class="theme" @onclick:stopPropagation>
-    <PulseButton TooltipPlacement="Placement.Left" TooltipText="@Title" Color="Color.None" ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/m.svg")" class="btn-fade btn-theme" />
+    <PulseButton TooltipPlacement="Placement.Left" TooltipText="@Title" Color="Color.None" ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/m.svg")" class="btn-fade btn-theme" />
 </div>
 
 <BootstrapBlazorRootContent>

--- a/src/BootstrapBlazor.Server/Components/Components/ThemeChooser.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/ThemeChooser.razor.cs
@@ -34,15 +34,15 @@ public partial class ThemeChooser
 
         Title ??= Localizer[nameof(Title)];
         HeaderText ??= Localizer[nameof(HeaderText)];
-        Themes = WebsiteOption.CurrentValue.Themes.Select(i => new SelectedItem { Text = i.Name, Value = i.Key });
-        WebsiteOption.CurrentValue.CurrentTheme = "bootstrap";
+        Themes = WebsiteOption.Value.Themes.Select(i => new SelectedItem { Text = i.Name, Value = i.Key });
+        WebsiteOption.Value.CurrentTheme = "bootstrap";
     }
 
     private void OnClickTheme(SelectedItem item)
     {
         _currentTheme.Clear();
-        WebsiteOption.CurrentValue.CurrentTheme = item.Value;
-        var theme = WebsiteOption.CurrentValue.Themes.FirstOrDefault(i => i.Key == item.Value);
+        WebsiteOption.Value.CurrentTheme = item.Value;
+        var theme = WebsiteOption.Value.Themes.FirstOrDefault(i => i.Key == item.Value);
         if (theme is { Files: not null })
         {
             _currentTheme.AddRange(theme.Files);
@@ -50,6 +50,6 @@ public partial class ThemeChooser
     }
 
     private string? GetThemeItemClass(SelectedItem item) => CssBuilder.Default("theme-item")
-        .AddClass("active", WebsiteOption.CurrentValue.CurrentTheme == item.Value)
+        .AddClass("active", WebsiteOption.Value.CurrentTheme == item.Value)
         .Build();
 }

--- a/src/BootstrapBlazor.Server/Components/Components/UpdateIntro.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/UpdateIntro.razor
@@ -6,19 +6,19 @@
     <h5><b>Bootstrap Blazor</b> @Localizer["H1"] <span class="version">@PackageVersionService.Version</span></h5>
     <div class="d-flex">
         <div class="blazor-intro-body">
-            <p>@Localizer["B1"] <b>Bootstrap</b> <b>Blazor</b> @Localizer["B2"] <a href="@WebsiteOption.CurrentValue.AdminUrl" target="_blank"><b>@Localizer["B3"]</b></a> @Localizer["B4"]。<b>Bootstrap Blazor</b> @((MarkupString)Localizer["B5"].Value)</p>
+            <p>@Localizer["B1"] <b>Bootstrap</b> <b>Blazor</b> @Localizer["B2"] <a href="@WebsiteOption.Value.AdminUrl" target="_blank"><b>@Localizer["B3"]</b></a> @Localizer["B4"]。<b>Bootstrap Blazor</b> @((MarkupString)Localizer["B5"].Value)</p>
             <p>
                 @Localizer["P1"] <span class="version">@PackageVersionService.Version</span> @Localizer["P2"] <a target="_blank" href="@UpdateLogUrl"><b>[@Localizer["P3"]]</b></a> @Localizer["P4"] <b>Star</b>
-                <a class="px-2" href="@WebsiteOption.CurrentValue.GithubRepositoryUrl" target="_blank">
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/git.svg")" alt="github" />
+                <a class="px-2" href="@WebsiteOption.Value.GithubRepositoryUrl" target="_blank">
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/git.svg")" alt="github" />
                 </a>
-                <a href="@WebsiteOption.CurrentValue.GiteeRepositoryUrl" target="_blank">
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/gitee.svg")" alt="gitee" />
+                <a href="@WebsiteOption.Value.GiteeRepositoryUrl" target="_blank">
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/gitee.svg")" alt="gitee" />
                 </a>
             </p>
         </div>
         <div class="blazor-intro-barcode">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/QQGroup@2x.png")" alt="QQGroup" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/QQGroup@2x.png")" alt="QQGroup" />
             <div>QQ 795206915</div>
         </div>
     </div>

--- a/src/BootstrapBlazor.Server/Components/Components/UpdateIntro.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/UpdateIntro.razor.cs
@@ -14,13 +14,13 @@ public partial class UpdateIntro
 {
     [Inject]
     [NotNull]
-    private IOptionsMonitor<WebsiteOptions>? WebsiteOption { get; set; }
+    private IOptions<WebsiteOptions>? WebsiteOption { get; set; }
 
     [Inject]
     [NotNull]
     private PackageVersionService? PackageVersionService { get; set; }
 
-    private string UpdateLogUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/wikis/%E6%9B%B4%E6%96%B0%E6%97%A5%E5%BF%97?sort_id=4062034";
+    private string UpdateLogUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/wikis/%E6%9B%B4%E6%96%B0%E6%97%A5%E5%BF%97?sort_id=4062034";
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor.Server/Components/Components/Video.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/Video.razor
@@ -1,4 +1,4 @@
-﻿@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+﻿@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<Video> Localizer
 
 <p><b>@Localizer["H1"]</b></p>
@@ -44,11 +44,11 @@ else
             Name = comNameWithHash.Split('?').First();
         }
 
-        if (!string.IsNullOrEmpty(Name) && WebsiteOption.CurrentValue.Videos.TryGetValue(Name, out var url))
+        if (!string.IsNullOrEmpty(Name) && WebsiteOption.Value.Videos.TryGetValue(Name, out var url))
         {
             if (!string.IsNullOrEmpty(url))
             {
-                VideoUrl.AddRange(url.Split(';').Select(a => $"{WebsiteOption.CurrentValue.VideoUrl}{a}"));
+                VideoUrl.AddRange(url.Split(';').Select(a => $"{WebsiteOption.Value.VideoUrl}{a}"));
             }
         }
     }

--- a/src/BootstrapBlazor.Server/Components/Components/Widget.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/Widget.razor
@@ -1,4 +1,4 @@
-﻿@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+﻿@inject IOptions<WebsiteOptions> WebsiteOption
 
 <DropdownWidget class="px-3 d-none d-sm-block">
     <DropdownWidgetItem Icon="fa-regular fa-envelope" BadgeNumber="4">
@@ -10,7 +10,7 @@
             {
                 <a class="dropdown-item d-flex align-items-center" href="#" @onclick:preventDefault>
                     <div style="width: 40px; height: 40px;">
-                        <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.Small" />
+                        <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.Small" />
                     </div>
                     <div class="ms-2">
                         <div class="d-flex position-relative">

--- a/src/BootstrapBlazor.Server/Components/Components/Wwads.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/Wwads.razor
@@ -1,9 +1,9 @@
 ﻿@inherits WebSiteModuleComponentBase
 @attribute [JSModuleAutoLoader("Components/Wwads.razor.js", AutoInvokeDispose = false)]
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <HeadContent>
-    <link rel="stylesheet" href="@Assets[$"{WebsiteOption.CurrentValue.AssetRootPath}css/wwads.css"]" />
+    <link rel="stylesheet" href="@Assets[$"{WebsiteOption.Value.AssetRootPath}css/wwads.css"]" />
 </HeadContent>
 
 <div @attributes="AdditionalAttributes" id="@Id" class="@ClassString"></div>

--- a/src/BootstrapBlazor.Server/Components/Layout/ComponentLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/ComponentLayout.razor
@@ -1,6 +1,6 @@
 ﻿@inherits LayoutComponentBase
 @layout MainLayout
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div class="tabs-coms-header">
     <div class="bb-title">

--- a/src/BootstrapBlazor.Server/Components/Layout/ComponentLayout.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Layout/ComponentLayout.razor.cs
@@ -52,7 +52,7 @@ public partial class ComponentLayout : IAsyncDisposable
     [NotNull]
     private IOptions<IconThemeOptions>? IconThemeOptions { get; set; }
 
-    private string GVPUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/badge/star.svg?theme=gvp";
+    private string GVPUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/badge/star.svg?theme=gvp";
 
     private List<SelectedItem> IconThemes { get; } = [];
 
@@ -104,7 +104,7 @@ public partial class ComponentLayout : IAsyncDisposable
     {
         if (firstRender)
         {
-            Module = await JSRuntime.LoadModule($"{WebsiteOption.CurrentValue.AssetRootPath}Components/Layout/ComponentLayout.razor.js");
+            Module = await JSRuntime.LoadModule($"{WebsiteOption.Value.AssetRootPath}Components/Layout/ComponentLayout.razor.js");
         }
         if (Module != null)
         {

--- a/src/BootstrapBlazor.Server/Components/Layout/DockLayout.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Layout/DockLayout.razor.cs
@@ -27,7 +27,7 @@ public partial class DockLayout : IAsyncDisposable
 
     [Inject]
     [NotNull]
-    private IOptionsMonitor<WebsiteOptions>? WebsiteOption { get; set; }
+    private IOptions<WebsiteOptions>? WebsiteOption { get; set; }
 
     /// <summary>
     /// <inheritdoc/>
@@ -38,7 +38,7 @@ public partial class DockLayout : IAsyncDisposable
     {
         if (firstRender)
         {
-            Module = await JSRuntime.LoadModule($"{WebsiteOption.CurrentValue.AssetRootPath}Components/Layout/DockLayout.razor.js");
+            Module = await JSRuntime.LoadModule($"{WebsiteOption.Value.AssetRootPath}Components/Layout/DockLayout.razor.js");
             await Module.InvokeVoidAsync("init");
         }
     }

--- a/src/BootstrapBlazor.Server/Components/Layout/HomeLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/HomeLayout.razor
@@ -1,7 +1,7 @@
 ﻿@inherits LayoutComponentBase
 @layout BaseLayout
 @inject NavigationManager NavigationManager
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<HomeLayout> Localizer
 @inject PackageVersionService VersionService
 
@@ -11,7 +11,7 @@
     <div class="bb-foundation">
         <div class="bb-foundation-content">本项目属于 <a href="https://www.dotnetfoundation.org/">.NET 基金会</a>，并根据其 <a href="https://www.dotnetfoundation.org/code-of-conduct">行为准则</a> 运作</div>
         <a class="bb-foundation-img d-none d-sm-block" href="https://www.dotnetfoundation.org/">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/dotnet_foundation_v4.png")" width="100" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/dotnet_foundation_v4.png")" width="100" />
         </a>
     </div>
     <div class="footer-body">
@@ -19,7 +19,7 @@
             <h4>@Localizer["FooterH1"]</h4>
             <ul>
                 <li>
-                    <a class="footer-link" href="@WebsiteOption.CurrentValue.BootstrapAdminLink" target="_blank">Bootstrap Admin</a>
+                    <a class="footer-link" href="@WebsiteOption.Value.BootstrapAdminLink" target="_blank">Bootstrap Admin</a>
                 </li>
                 <li>
                     <a class="footer-link" href="https://gitee.com/Longbow/SliderCaptcha" target="_blank">@Localizer["FooterLi1"]</a>
@@ -35,7 +35,7 @@
         <div>
             <h4>@Localizer["FriendLink"]</h4>
             <ul>
-                @foreach (var link in WebsiteOption.CurrentValue.Links)
+                @foreach (var link in WebsiteOption.Value.Links)
                 {
                     <li>
                         <a class="footer-link" href="@link.Value" target="_blank">@link.Key</a>
@@ -69,11 +69,11 @@
             </div>
         </div>
         <div class="d-flex flex-fill align-items-center justify-content-center">
-            <a class="d-none d-md-block me-3" href="@WebsiteOption.CurrentValue.GiteeRepositoryUrl" target="_blank">@Localizer["Footer"]</a>
+            <a class="d-none d-md-block me-3" href="@WebsiteOption.Value.GiteeRepositoryUrl" target="_blank">@Localizer["Footer"]</a>
             <a class="d-none d-lg-block me-3" href="https://beian.miit.gov.cn/" target="_blank">鲁ICP备19015061号-4</a>
         </div>
         <div class="d-md-flex d-none">
-            <img alt="global" class="footer-lang" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/global.svg")" />
+            <img alt="global" class="footer-lang" src="@WebsiteOption.Value.GetAssetUrl("images/global.svg")" />
             <a @onclick:preventDefault @onclick="@(e => SetLang("zh-CN"))">简 体</a>
             <span class="mx-1">/</span>
             <a @onclick:preventDefault @onclick="@(e => SetLang("en-US"))">English</a>

--- a/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor
@@ -21,7 +21,7 @@
     <DialButton DialMode="DialMode.Radial" Icon="fa-solid fa-gear" Radius="100" Placement="Placement.BottomEnd" class="bb-dial-gear">
         <ButtonTemplate>
             <div class="btn-circle btn-fade dial-button-gear">
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
             </div>
         </ButtonTemplate>
         <ChildContent>
@@ -35,7 +35,7 @@
                 <ThemeChooser></ThemeChooser>
             </DialButtonItem>
             <DialButtonItem>
-                <LinkButton TooltipPlacement="Placement.Left" ButtonStyle="ButtonStyle.Circle" Color="Color.None" TooltipText="@Title" class="btn-fade btn-update" Url="@WebsiteOption.CurrentValue.WikiUrl" Target="_blank" ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/log.svg")"></LinkButton>
+                <LinkButton TooltipPlacement="Placement.Left" ButtonStyle="ButtonStyle.Circle" Color="Color.None" TooltipText="@Title" class="btn-fade btn-update" Url="@WebsiteOption.Value.WikiUrl" Target="_blank" ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/log.svg")"></LinkButton>
             </DialButtonItem>
         </ChildContent>
     </DialButton>

--- a/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Layout/MainLayout.razor.cs
@@ -22,7 +22,7 @@ public partial class MainLayout : IDisposable
 
     [Inject]
     [NotNull]
-    private IOptionsMonitor<WebsiteOptions>? WebsiteOption { get; set; }
+    private IOptions<WebsiteOptions>? WebsiteOption { get; set; }
 
     [Inject]
     [NotNull]

--- a/src/BootstrapBlazor.Server/Components/Layout/PageLayout.razor
+++ b/src/BootstrapBlazor.Server/Components/Layout/PageLayout.razor
@@ -1,8 +1,8 @@
 ﻿@inherits LayoutComponentBase
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <HeadContent>
-    <link href="@WebsiteOption.CurrentValue.GetAssetUrl("css/layout.css")" rel="stylesheet" />
+    <link href="@WebsiteOption.Value.GetAssetUrl("css/layout.css")" rel="stylesheet" />
 </HeadContent>
 
 <CascadingValue Value="this" IsFixed="true">
@@ -14,7 +14,7 @@
         <Header>
             <span class="ms-3 flex-fill">Bootstrap of Blazor</span>
             <Widget></Widget>
-            <Logout ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" DisplayName="超级管理员" UserName="Admin">
+            <Logout ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" DisplayName="超级管理员" UserName="Admin">
                 <LinkTemplate>
                     <a href="#"><i class="fa-solid fa-suitcase"></i>个人中心</a>
                     <a href="#"><i class="fa-solid fa-cog"></i>设置</a>
@@ -25,7 +25,7 @@
         </Header>
         <Side>
             <div class="layout-banner">
-                <img alt="logo" class="layout-logo" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+                <img alt="logo" class="layout-logo" src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
                 <div class="layout-title">
                     <span>后台管理</span>
                 </div>
@@ -36,7 +36,7 @@
         </Main>
         <Footer>
             <div class="text-center flex-fill">
-                <a class="page-layout-demo-footer-link" href="@WebsiteOption.CurrentValue.BootstrapAdminLink" target="_blank">Bootstrap Admin</a>
+                <a class="page-layout-demo-footer-link" href="@WebsiteOption.Value.BootstrapAdminLink" target="_blank">Bootstrap Admin</a>
             </div>
         </Footer>
     </Layout>

--- a/src/BootstrapBlazor.Server/Components/Pages/Index.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Index.razor
@@ -2,7 +2,7 @@
 @page "/"
 @page "/index"
 @page "/home"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <section class="bd-masthead">
     <div class="container-xxl bd-gutter">
@@ -35,6 +35,6 @@
     <div class="donate">
         <h3>@Localizer["DonateH1"]</h3>
         <h5 class="d-none d-sm-block mb-3">@Localizer["DonateH2"]</h5>
-        <img alt="barcode" class="barcode" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/BarCode@2x.png")" />
+        <img alt="barcode" class="barcode" src="@WebsiteOption.Value.GetAssetUrl("images/BarCode@2x.png")" />
     </div>
 </section>

--- a/src/BootstrapBlazor.Server/Components/Pages/Install.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Install.razor
@@ -1,7 +1,7 @@
 ﻿@page "/install"
 @inject PackageVersionService VersionManager
 @inject IStringLocalizer<Install> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["InstallTitle"]</h3>
 
@@ -12,13 +12,13 @@
 <div class="row mb-sm-3">
     <div class="git col-12 col-sm-6 mb-3 mb-sm-0">
         <a class="git-fork" href="https://fork.dev/" target="_blank">
-            <img alt="fork" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/fork.png")" />
+            <img alt="fork" src="@WebsiteOption.Value.GetAssetUrl("images/fork.png")" />
             <span>Fork</span>
         </a>
     </div>
     <div class="git col-12 col-sm-6 mb-3 mb-sm-0">
         <a href="https://tortoisegit.org/download/" target="_blank">
-            <img alt="tortoisegit" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/tortoisegit.svg")" />
+            <img alt="tortoisegit" src="@WebsiteOption.Value.GetAssetUrl("images/tortoisegit.svg")" />
         </a>
     </div>
 </div>
@@ -34,10 +34,10 @@
 <ol class="ul-demo">
     <li>@((MarkupString)Localizer["EnvLi1"].Value)</li>
     <li>@((MarkupString)Localizer["EnvLi2"].Value)</li>
-    <li>@((MarkupString)string.Format(Localizer["EnvLi3"].Value, WebsiteOption.CurrentValue.GiteeRepositoryUrl))</li>
+    <li>@((MarkupString)string.Format(Localizer["EnvLi3"].Value, WebsiteOption.Value.GiteeRepositoryUrl))</li>
 </ol>
 
-<Pre class="no-highlight">git clone @WebsiteOption.CurrentValue.GiteeRepositoryUrl</Pre>
+<Pre class="no-highlight">git clone @WebsiteOption.Value.GiteeRepositoryUrl</Pre>
 
 @code {
     /// <summary>

--- a/src/BootstrapBlazor.Server/Components/Pages/Install_Maui.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Install_Maui.razor
@@ -1,7 +1,7 @@
 ﻿@page "/install-maui"
 @inject IStringLocalizer<Install_Maui> Localizer
 @inject PackageVersionService VersionManager
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Title</h3>
 
@@ -19,15 +19,15 @@
 <p class="code-label">1.Visual Studio</p>
 <p class="code-label">2. @Localizer["P5"]</p>
 <p class="code-label">3. @Localizer["P6"] <b>@Localizer["P7"]</b> @Localizer["P8"] <b>@Localizer["P9"]</b>, @Localizer["P10"] <b>@Localizer["P11"]</b>, <b>@Localizer["P12"]</b></p>
-<img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/choose-project-template-maui-blazor.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+<img src="@WebsiteOption.Value.GetAssetUrl("images/choose-project-template-maui-blazor.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
 
 <h5>@Localizer["P13"]</h5>
 <p class="code-label">@((MarkupString)Localizer["P14"].Value)</p>
 <p>@Localizer["P15"] <b>Manage Nuget Packages</b></p>
 <Pre @key="@Version" class="no-highlight">dotnet add package BootstrapBlazor --version @Version</Pre>
-<img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/manage-nuget-packages-for-maui-app.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+<img src="@WebsiteOption.Value.GetAssetUrl("images/manage-nuget-packages-for-maui-app.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
 <p class="code-label">@Localizer["P16"]</p>
-<img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/nuget_install.png")" style="width: 1000px; border-radius: 6px;" class="d-none d-sm-block" />
+<img src="@WebsiteOption.Value.GetAssetUrl("images/nuget_install.png")" style="width: 1000px; border-radius: 6px;" class="d-none d-sm-block" />
 <p class="code-label">@Localizer["P17"]</p>
 <p>@Localizer["P18"]</p>
 <ul class="ul-demo">
@@ -93,7 +93,7 @@ return builder.Build();
 <p class="code-label">@Localizer["P34"] <code>Button</code> @Localizer["P35"]</p>
 <Pre>&lt;Button Color="Color.Primary" Icon="fa-solid fa-font-awesome" Text="@Localizer["P36"]" /&gt;</Pre>
 <p class="code-label">@Localizer["P37"] <b>Visual studio</b> @Localizer["P38"] <kbd>F5</kbd> @Localizer["P39"]</p>
-<img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/preview-maui.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+<img src="@WebsiteOption.Value.GetAssetUrl("images/preview-maui.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
 
 <h4 class="code-label">@Localizer["P40"]</h4>
 <p class="code-label">@Localizer["P41"] <code>NativeContent.xaml</code> @Localizer["P42"]</p>
@@ -206,7 +206,7 @@ return builder.Build();
     }
 }</Pre>
 <p class="code-label">@Localizer["P48"] <b>Visual studio</b> @Localizer["P49"] <kbd>F5</kbd> @Localizer["P50"]</p>
-<img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/maui-blazor.gif")" style="border-radius: 6px;width: 320px;" class="d-none d-sm-block" />
+<img src="@WebsiteOption.Value.GetAssetUrl("images/maui-blazor.gif")" style="border-radius: 6px;width: 320px;" class="d-none d-sm-block" />
 
 @code
 {

--- a/src/BootstrapBlazor.Server/Components/Pages/Install_Server.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Install_Server.razor
@@ -1,11 +1,11 @@
 ﻿@page "/install-server"
 @inject IStringLocalizer<Install_Server> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <InstallContent Title="@Localizer["Title"]">
     <ChooseTemplate>
         <p class="code-label">4. @Localizer["D1"] <b>Blazor Server App</b> @Localizer["D2"] <b>Create</b></p>
-        <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/choose-project-template-server-blazor.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
+        <img src="@WebsiteOption.Value.GetAssetUrl("images/choose-project-template-server-blazor.png")" style="border-radius: 6px;" class="d-none d-sm-block" />
     </ChooseTemplate>
     <SheetTemplate>
         <ul class="ul-demo">

--- a/src/BootstrapBlazor.Server/Components/Pages/Install_wasm.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Install_wasm.razor
@@ -1,11 +1,11 @@
 ﻿@page "/install-wasm"
 @inject IStringLocalizer<Install_wasm> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <InstallContent Title="@Localizer["Install_wasmHeading"]">
     <ChooseTemplate>
         <p class="code-label">4. @((MarkupString)Localizer["Install_wasmDescription"].Value)</p>
-        <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/choose-project-template.png")" style="width: 800px; border-radius: 6px;" class="d-none d-sm-block" />
+        <img src="@WebsiteOption.Value.GetAssetUrl("images/choose-project-template.png")" style="width: 800px; border-radius: 6px;" class="d-none d-sm-block" />
     </ChooseTemplate>
     <SheetTemplate>
         <p><code>wwwroot/index.html</code></p>

--- a/src/BootstrapBlazor.Server/Components/Pages/Introduction.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Introduction.razor
@@ -10,7 +10,7 @@
 
 <p>
     @((MarkupString)Localizer["UpdateLog"].Value)
-    <a href="@WebsiteOption.CurrentValue.WikiUrl" target="_blank">@Localizer["UpdateLogLink"]</a>
+    <a href="@WebsiteOption.Value.WikiUrl" target="_blank">@Localizer["UpdateLogLink"]</a>
 </p>
 
 <h3>@Localizer["LearnTitle"]</h3>
@@ -45,9 +45,9 @@
 
 <p>@((MarkupString)Localizer["P5", LocalizerRules].Value)</p>
 
-<p>@Localizer["ShowWebSiteTitle1"]：<a href="@($"{WebsiteOption.CurrentValue.AdminUrl}/Pages")" target="_blank">@WebsiteOption.CurrentValue.AdminUrl</a></p>
+<p>@Localizer["ShowWebSiteTitle1"]：<a href="@($"{WebsiteOption.Value.AdminUrl}/Pages")" target="_blank">@WebsiteOption.Value.AdminUrl</a></p>
 
-<p>@Localizer["ShowWebSiteTitle2"]：<a href="@($"{WebsiteOption.CurrentValue.AdminProUrl}")" target="_blank" class="text-success">@WebsiteOption.CurrentValue.AdminProUrl</a></p>
+<p>@Localizer["ShowWebSiteTitle2"]：<a href="@($"{WebsiteOption.Value.AdminProUrl}")" target="_blank" class="text-success">@WebsiteOption.Value.AdminProUrl</a></p>
 
 <h4>@Localizer["GetStarted"]</h4>
 

--- a/src/BootstrapBlazor.Server/Components/Pages/Introduction.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Pages/Introduction.razor.cs
@@ -17,7 +17,7 @@ public partial class Introduction
     /// </summary>
     [Inject]
     [NotNull]
-    private IOptionsMonitor<WebsiteOptions>? WebsiteOption { get; set; }
+    private IOptions<WebsiteOptions>? WebsiteOption { get; set; }
 
     /// <summary>
     /// 
@@ -38,10 +38,10 @@ public partial class Introduction
 
         LocalizerRules =
         [
-            WebsiteOption.CurrentValue.BootstrapAdminLink,
-            WebsiteOption.CurrentValue.BootstrapAdminLink + "/stargazers",
-            WebsiteOption.CurrentValue.BootstrapAdminLink + "/badge/star.svg?theme=gvp",
-            WebsiteOption.CurrentValue.BootstrapAdminLink
+            WebsiteOption.Value.BootstrapAdminLink,
+            WebsiteOption.Value.BootstrapAdminLink + "/stargazers",
+            WebsiteOption.Value.BootstrapAdminLink + "/badge/star.svg?theme=gvp",
+            WebsiteOption.Value.BootstrapAdminLink
         ];
     }
 }

--- a/src/BootstrapBlazor.Server/Components/Pages/Localization.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Localization.razor
@@ -77,17 +77,11 @@ builder.Services.AddServerSideBlazor();
 builder.Services.AddBootstrapBlazor();
 
 // @Localizer["N26"]
-builder.Services.AddRequestLocalization&lt;IOptionsMonitor&lt;BootstrapBlazorOptions&gt;&gt;((localizerOption, blazorOption)=>
+builder.Services.AddRequestLocalization&lt;IOptions&lt;BootstrapBlazorOptions&gt;&gt;((localizerOption, blazorOption)=>
 {
-    blazorOption.OnChange(op => Invoke(op));
-    Invoke(blazorOption.CurrentValue);
-
-    void Invoke(BootstrapBlazorOptions option)
-    {
-        var supportedCultures = option.GetSupportedCultures();
-        localizerOption.SupportedCultures = supportedCultures;
-        localizerOption.SupportedUICultures = supportedCultures;
-    }
+    var supportedCultures = blazorOption.Value.GetSupportedCultures();
+    localizerOption.SupportedCultures = supportedCultures;
+    localizerOption.SupportedUICultures = supportedCultures;
 });
 
 var app = builder.Build();

--- a/src/BootstrapBlazor.Server/Components/Pages/Template.razor
+++ b/src/BootstrapBlazor.Server/Components/Pages/Template.razor
@@ -1,7 +1,7 @@
 ﻿@page "/template"
 @inject PackageVersionService VersionManager
 @inject IStringLocalizer<Template> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Pages/Template.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Pages/Template.razor.cs
@@ -15,7 +15,7 @@ public sealed partial class Template
     /// </summary>
     private string Version { get; set; } = "*";
 
-    private string TemplateUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/wikis/%E9%A1%B9%E7%9B%AE%E6%A8%A1%E6%9D%BF%E4%BD%BF%E7%94%A8%E6%95%99%E7%A8%8B?sort_id=3059284";
+    private string TemplateUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/wikis/%E9%A1%B9%E7%9B%AE%E6%A8%A1%E6%9D%BF%E4%BD%BF%E7%94%A8%E6%95%99%E7%A8%8B?sort_id=3059284";
 
     /// <summary>
     /// OnInitializedAsync 方法

--- a/src/BootstrapBlazor.Server/Components/Samples/AutoFills.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/AutoFills.razor
@@ -1,6 +1,6 @@
 ﻿@page "/auto-fill"
 @inject IStringLocalizer<AutoFills> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 <h4>@Localizer["Description"]</h4>
@@ -14,7 +14,7 @@
         <ItemTemplate>
             <div class="d-flex">
                 <div>
-                    <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                    <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                 </div>
                 <div class="ps-2">
                     <div>@context.Name</div>
@@ -24,7 +24,7 @@
         </ItemTemplate>
     </AutoFill>
     <section ignore>
-        <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(Model1.Id)" class="shadow" style="width: 140px; margin-bottom: 1rem; border-radius: 6px;" />
+        <img src="@WebsiteOption.Value.GetAvatarUrl(Model1.Id)" class="shadow" style="width: 140px; margin-bottom: 1rem; border-radius: 6px;" />
         <EditorForm Model="@Model1" RowType="RowType.Inline" ItemsPerRow="2" />
     </section>
 </DemoBlock>
@@ -36,7 +36,7 @@
         <ItemTemplate>
             <div class="d-flex">
                 <div>
-                    <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                    <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                 </div>
                 <div class="ps-2">
                     <div>@context.Name</div>
@@ -58,7 +58,7 @@
         <ItemTemplate>
             <div class="d-flex">
                 <div>
-                    <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                    <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                 </div>
                 <div class="ps-2">
                     <div>@context.Name</div>
@@ -93,7 +93,7 @@
                 <ItemTemplate>
                     <div class="d-flex">
                         <div>
-                            <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                            <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                         </div>
                         <div class="ps-2">
                             <div>@context.Name</div>
@@ -120,7 +120,7 @@
                 <ItemTemplate>
                     <div class="d-flex">
                         <div>
-                            <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                            <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                         </div>
                         <div class="ps-2">
                             <div>@context.Name</div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Avatars.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Avatars.razor
@@ -1,6 +1,6 @@
 ﻿@page "/avatar"
 @inject IStringLocalizer<Avatars> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 
@@ -10,24 +10,24 @@
     <div class="d-flex flex-column">
         <p class="text-center">Circle</p>
         <div class="d-flex justify-content-between align-items-center">
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraExtraLarge" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraLarge" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.Large" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.Small" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraSmall" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraExtraLarge" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraLarge" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.Large" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.Small" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraSmall" />
         </div>
     </div>
     <Divider Text="@Localizer["BasicUsageDivider"]" />
     <div class="d-flex flex-column">
         <p class="text-center mt-3">Square</p>
         <div class="d-flex justify-content-between align-items-center">
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" Size="Size.ExtraExtraLarge" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" Size="Size.ExtraLarge" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" Size="Size.Large" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" Size="Size.Small" />
-            <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" Size="Size.ExtraSmall" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" Size="Size.ExtraExtraLarge" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" Size="Size.ExtraLarge" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" Size="Size.Large" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" Size="Size.Small" />
+            <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" Size="Size.ExtraSmall" />
         </div>
     </div>
 </DemoBlock>
@@ -35,15 +35,15 @@
 <DemoBlock Title="@Localizer["IconTitle"]" Introduction="@Localizer["IconIntro"]" Name="Icon">
     <div class="d-flex justify-content-between align-items-center">
         <Avatar IsCircle="true" IsIcon="true" Icon="fa-solid fa-user" />
-        <Avatar IsCircle="true" Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" />
+        <Avatar IsCircle="true" Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" />
         <Avatar IsCircle="true" IsText="true" Text="User" />
     </div>
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["BorderTitle"]" Introduction="@Localizer["BorderIntro"]" Name="Border">
     <div class="d-flex justify-content-between align-items-center">
-        <Avatar IsCircle="false" IsBorder="true" Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatar2.png")" />
-        <Avatar IsCircle="true" IsBorder="true" Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-c1.png")" />
+        <Avatar IsCircle="false" IsBorder="true" Url="@WebsiteOption.Value.GetAssetUrl("images/avatar2.png")" />
+        <Avatar IsCircle="true" IsBorder="true" Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-c1.png")" />
         <Avatar IsCircle="true" IsBorder="true" IsIcon="true" Icon="fa-solid fa-tv" />
         <Avatar IsCircle="true" IsBorder="true" IsText="true" Text="AZ" />
     </div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Avatars.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Avatars.razor.cs
@@ -14,7 +14,7 @@ public sealed partial class Avatars
     {
         // 模拟异步获取图像地址
         await Task.Delay(500);
-        return $"{WebsiteOption.CurrentValue.AssetRootPath}images/Argo-C.png";
+        return $"{WebsiteOption.Value.AssetRootPath}images/Argo-C.png";
     }
 
     /// <summary>

--- a/src/BootstrapBlazor.Server/Components/Samples/Carousels.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Carousels.razor
@@ -1,6 +1,6 @@
 ﻿@page "/carousel"
 @inject IStringLocalizer<Carousels> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 
@@ -25,13 +25,13 @@
 <DemoBlock Title="@Localizer["CaptionTitle"]" Introduction="@Localizer["CaptionIntro"]" Name="Caption">
     <Carousel Width="280" IsFade="true">
         <CarouselItem Caption="First slide label">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
         </CarouselItem>
         <CarouselItem Caption="Second slide label">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
         </CarouselItem>
         <CarouselItem Caption="Thrid slide label">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
         </CarouselItem>
     </Carousel>
 </DemoBlock>
@@ -39,13 +39,13 @@
 <DemoBlock Title="@Localizer["IntervalTitle"]" Introduction="@Localizer["IntervalIntro"]" Name="Interval">
     <Carousel Width="280" IsFade="true">
         <CarouselItem Caption="First slide label" Interval="5000">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
         </CarouselItem>
         <CarouselItem Caption="Second slide label" Interval="2000">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
         </CarouselItem>
         <CarouselItem Caption="Thrid slide label">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
         </CarouselItem>
     </Carousel>
 </DemoBlock>
@@ -58,7 +58,7 @@
                 <p>Pic0.jpg</p>
             </CaptionTemplate>
             <ChildContent>
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
             </ChildContent>
         </CarouselItem>
         <CarouselItem>
@@ -67,7 +67,7 @@
                 <p>Pic1.jpg</p>
             </CaptionTemplate>
             <ChildContent>
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
             </ChildContent>
         </CarouselItem>
         <CarouselItem>
@@ -76,7 +76,7 @@
                 <p>Pic2.jpg</p>
             </CaptionTemplate>
             <ChildContent>
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
             </ChildContent>
         </CarouselItem>
     </Carousel>
@@ -91,7 +91,7 @@
                 <p>Pic0.jpg</p>
             </CaptionTemplate>
             <ChildContent>
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
             </ChildContent>
         </CarouselItem>
         <CarouselItem CaptionClass="d-none d-md-block">
@@ -100,7 +100,7 @@
                 <p>Pic1.jpg</p>
             </CaptionTemplate>
             <ChildContent>
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
             </ChildContent>
         </CarouselItem>
         <CarouselItem CaptionClass="d-none d-md-block">
@@ -109,7 +109,7 @@
                 <p>Pic2.jpg</p>
             </CaptionTemplate>
             <ChildContent>
-                <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
+                <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
             </ChildContent>
         </CarouselItem>
     </Carousel>
@@ -124,13 +124,13 @@
 <DemoBlock Title="@Localizer["TouchSwipingTitle"]" Introduction="@Localizer["TouchSwipingIntro"]" Name="DisableTouchSwiping">
     <Carousel Width="280" IsFade="true" DisableTouchSwiping="true">
         <CarouselItem Caption="First slide label" Interval="5000">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic0.jpg")" alt="demo-image" />
         </CarouselItem>
         <CarouselItem Caption="Second slide label" Interval="2000">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
         </CarouselItem>
         <CarouselItem Caption="Thrid slide label">
-            <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
+            <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
         </CarouselItem>
     </Carousel>
 </DemoBlock>
@@ -144,7 +144,7 @@
                         <div>Sales champion</div>
                         <div>www.blazor.zone</div>
                     </div>
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatars/150-5.jpg")" alt="demo-image" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/avatars/150-5.jpg")" alt="demo-image" />
                     <div class="bottom">
                         Carousel Item
                     </div>
@@ -154,7 +154,7 @@
                         <div>Sales champion</div>
                         <div>www.blazor.zone</div>
                     </div>
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatars/150-7.jpg")" alt="demo-image" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/avatars/150-7.jpg")" alt="demo-image" />
                     <div class="bottom">
                         Carousel Item
                     </div>
@@ -164,7 +164,7 @@
                         <div>Sales champion</div>
                         <div>www.blazor.zone</div>
                     </div>
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatars/150-11.jpg")" alt="demo-image" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/avatars/150-11.jpg")" alt="demo-image" />
                     <div class="bottom">
                         Carousel Item
                     </div>
@@ -178,7 +178,7 @@
                         <div>Sales champion</div>
                         <div>www.blazor.zone</div>
                     </div>
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatars/150-6.jpg")" alt="demo-image" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/avatars/150-6.jpg")" alt="demo-image" />
                     <div class="bottom">
                         Carousel Item
                     </div>
@@ -188,7 +188,7 @@
                         <div>Sales champion</div>
                         <div>www.blazor.zone</div>
                     </div>
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatars/150-12.jpg")" alt="demo-image" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/avatars/150-12.jpg")" alt="demo-image" />
                     <div class="bottom">
                         Carousel Item
                     </div>
@@ -198,7 +198,7 @@
                         <div>Sales champion</div>
                         <div>www.blazor.zone</div>
                     </div>
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/avatars/150-15.jpg")" alt="demo-image" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/avatars/150-15.jpg")" alt="demo-image" />
                     <div class="bottom">
                         Carousel Item
                     </div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Carousels.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Carousels.razor
@@ -30,7 +30,7 @@
         <CarouselItem Caption="Second slide label">
             <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
         </CarouselItem>
-        <CarouselItem Caption="Thrid slide label">
+        <CarouselItem Caption="Third slide label">
             <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
         </CarouselItem>
     </Carousel>
@@ -44,7 +44,7 @@
         <CarouselItem Caption="Second slide label" Interval="2000">
             <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
         </CarouselItem>
-        <CarouselItem Caption="Thrid slide label">
+        <CarouselItem Caption="Third slide label">
             <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
         </CarouselItem>
     </Carousel>
@@ -129,7 +129,7 @@
         <CarouselItem Caption="Second slide label" Interval="2000">
             <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic1.jpg")" alt="demo-image" />
         </CarouselItem>
-        <CarouselItem Caption="Thrid slide label">
+        <CarouselItem Caption="Third slide label">
             <img src="@WebsiteOption.Value.GetAssetUrl("images/Pic2.jpg")" alt="demo-image" />
         </CarouselItem>
     </Carousel>

--- a/src/BootstrapBlazor.Server/Components/Samples/Carousels.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Carousels.razor.cs
@@ -23,9 +23,9 @@ public sealed partial class Carousels
         base.OnInitialized();
 
         _images.AddRange([
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/Pic0.jpg",
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/Pic1.jpg",
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/Pic2.jpg"
+            $"{WebsiteOption.Value.AssetRootPath}images/Pic0.jpg",
+            $"{WebsiteOption.Value.AssetRootPath}images/Pic1.jpg",
+            $"{WebsiteOption.Value.AssetRootPath}images/Pic2.jpg"
         ]);
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/CherryMarkdowns.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/CherryMarkdowns.razor
@@ -1,5 +1,5 @@
 ﻿@page "/cherry-markdown"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Header"]</h3>
 <h4>@Localizer["Tip"]</h4>

--- a/src/BootstrapBlazor.Server/Components/Samples/CherryMarkdowns.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/CherryMarkdowns.razor.cs
@@ -52,7 +52,7 @@ public partial class CherryMarkdowns
     {
         var url = Path.Combine("images", "uploader",
             $"{Path.GetFileNameWithoutExtension(arg.FileName)}-{DateTimeOffset.Now:yyyyMMddHHmmss}{Path.GetExtension(arg.FileName)}");
-        var fileName = Path.Combine(WebsiteOption.CurrentValue.WebRootPath, url);
+        var fileName = Path.Combine(WebsiteOption.Value.WebRootPath, url);
         var ret = await arg.SaveToFile(fileName);
         return ret ? url : "";
     }

--- a/src/BootstrapBlazor.Server/Components/Samples/Dispatches.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dispatches.razor.cs
@@ -22,7 +22,7 @@ public partial class Dispatches
 
     [Inject]
     [NotNull]
-    private IOptionsMonitor<BootstrapBlazorOptions>? Options { get; set; }
+    private IOptions<BootstrapBlazorOptions>? Options { get; set; }
 
     private async Task OnDispatch()
     {
@@ -36,7 +36,7 @@ public partial class Dispatches
         var clientInfo = await ClientService.GetClientInfo();
         if (clientInfo.Ip != null)
         {
-            var provider = IpLocatorFactory.Create(Options.CurrentValue.IpLocatorOptions.ProviderName);
+            var provider = IpLocatorFactory.Create(Options.Value.IpLocatorOptions.ProviderName);
             var location = await provider.Locate(clientInfo.Ip);
             message = $"{message} {location}";
         }

--- a/src/BootstrapBlazor.Server/Components/Samples/Downloads.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Downloads.razor
@@ -2,7 +2,7 @@
 @inject IStringLocalizer<Downloads> Localizer
 @inject ToastService ToastService
 @inject DownloadService DownloadService
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["DownloadsTitle"]</h3>
 <h4>@Localizer["DownloadsSubTitle"]</h4>

--- a/src/BootstrapBlazor.Server/Components/Samples/Downloads.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Downloads.razor.cs
@@ -18,7 +18,7 @@ public partial class Downloads
     {
         try
         {
-            var filePath = Path.Combine(WebsiteOption.CurrentValue.WebRootPath, "favicon.png");
+            var filePath = Path.Combine(WebsiteOption.Value.WebRootPath, "favicon.png");
             await using var stream = File.OpenRead(filePath);
             await DownloadService.DownloadFromStreamAsync("favicon.png", stream);
         }
@@ -48,7 +48,7 @@ public partial class Downloads
     {
         try
         {
-            await DownloadService.DownloadFolderAsync("test.zip", WebsiteOption.CurrentValue.WebRootPath);
+            await DownloadService.DownloadFolderAsync("test.zip", WebsiteOption.Value.WebRootPath);
         }
         catch (Exception ex)
         {

--- a/src/BootstrapBlazor.Server/Components/Samples/FileViewers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/FileViewers.razor
@@ -1,6 +1,6 @@
 ﻿@page "/file-viewer"
 @inject IStringLocalizer<FileViewers> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/FileViewers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/FileViewers.razor.cs
@@ -39,9 +39,9 @@ public partial class FileViewers
     private string CombineFilename(string filename)
     {
 #if DEBUG
-        filename = Path.Combine(WebsiteOption.CurrentValue.WebRootPath, "samples", filename);
+        filename = Path.Combine(WebsiteOption.Value.WebRootPath, "samples", filename);
 #else
-        filename = Path.Combine(WebsiteOption.CurrentValue.ContentRootPath, "wwwroot", "samples", filename);
+        filename = Path.Combine(WebsiteOption.Value.ContentRootPath, "wwwroot", "samples", filename);
 #endif
         return filename;
     }

--- a/src/BootstrapBlazor.Server/Components/Samples/ImageCroppers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/ImageCroppers.razor
@@ -1,6 +1,6 @@
 ﻿@page "/image-cropper"
 @inject IStringLocalizer<ImageCroppers> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/ImageCroppers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ImageCroppers.razor.cs
@@ -35,8 +35,8 @@ public partial class ImageCroppers
 
         _images.AddRange(
         [
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/picture.jpg",
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/ImageList2.jpeg"
+            $"{WebsiteOption.Value.AssetRootPath}images/picture.jpg",
+            $"{WebsiteOption.Value.AssetRootPath}images/ImageList2.jpeg"
         ]);
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/ImageViewers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/ImageViewers.razor
@@ -1,6 +1,6 @@
 ﻿@page "/image-viewer"
 @inject IStringLocalizer<ImageViewers> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["ImageViewerTitle"]</h3>
 
@@ -19,23 +19,23 @@
     <div class="images mt-3">
         <div class="images-item">
             <div>Fill</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.Fill" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.Fill" />
         </div>
         <div class="images-item">
             <div>Contain</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.Contain" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.Contain" />
         </div>
         <div class="images-item">
             <div>Cover</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.Cover" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.Cover" />
         </div>
         <div class="images-item">
             <div>None</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.None" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.None" />
         </div>
         <div class="images-item">
             <div>ScaleDown</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.ScaleDown" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/bird.jpeg")" FitMode="ObjectFitMode.ScaleDown" />
         </div>
     </div>
 </DemoBlock>
@@ -47,11 +47,11 @@
     <div class="images img-ph mt-3">
         <div class="images-item">
             <div>@Localizer["ImageViewerPlaceHolderDefault"]</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/image-ph.jpeg")" ShowPlaceHolder="true" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/image-ph.jpeg")" ShowPlaceHolder="true" />
         </div>
         <div class="images-item">
             <div>@Localizer["ImageViewerPlaceHolderCustom"]</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/image-ph.jpeg")" ShowPlaceHolder="true">
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/image-ph.jpeg")" ShowPlaceHolder="true">
                 <PlaceHolderTemplate>
                     <div class="bb-img-holder">
                         <div class="bb-img-loading">@Localizer["ImageViewerPlaceHolderLoading"]</div>
@@ -79,7 +79,7 @@
         </div>
         <div class="images-item">
             <div>@Localizer["ImageViewerPlaceHolderTemplateLoadingShow"]</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/image-ph.jpeg")" ShowPlaceHolder="true">
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/image-ph.jpeg")" ShowPlaceHolder="true">
                 <PlaceHolderTemplate>
                     <div class="bb-img-holder">
                         <div class="bb-img-loading">@Localizer["ImageViewerPlaceHolderTemplatePlaceholder"]</div>
@@ -96,11 +96,11 @@
     <div class="images img-ph mt-3">
         <div class="images-item">
             <div>@Localizer["ImageViewerErrorTemplateUrlError"]</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/error-image.jpeg")" HandleError="true" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/error-image.jpeg")" HandleError="true" />
         </div>
         <div class="images-item">
             <div>@Localizer["ImageViewerErrorTemplateCustom"]</div>
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/error-image.jpeg")">
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/error-image.jpeg")">
                 <ErrorTemplate>
                     <div class="bb-img-holder">
                         <div class="bb-img-loading">@Localizer["ImageViewerErrorTemplateLoadFailed"]</div>
@@ -116,7 +116,7 @@
            Name="PreviewList">
     <div class="images img-ph mt-3">
         <div class="images-item">
-            <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/bird.jpeg")" PreviewList="PreviewList" ZoomSpeed="0.5" />
+            <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/bird.jpeg")" PreviewList="PreviewList" ZoomSpeed="0.5" />
         </div>
     </div>
 </DemoBlock>
@@ -131,7 +131,7 @@
 <DemoBlock Title="@Localizer["IntersectionObserverTitle"]"
            Introduction="@Localizer["IntersectionObserverIntro"]"
            Name="IsIntersectionObserver">
-    <ImageViewer Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/tutorials/waterfall.png")" IsIntersectionObserver="true" IsAsync="true" style="height: 400px;"></ImageViewer>
+    <ImageViewer Url="@WebsiteOption.Value.GetAssetUrl("images/tutorials/waterfall.png")" IsIntersectionObserver="true" IsAsync="true" style="height: 400px;"></ImageViewer>
 </DemoBlock>
 
 <AttributeTable Items="@GetAttributes()" />

--- a/src/BootstrapBlazor.Server/Components/Samples/ImageViewers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ImageViewers.razor.cs
@@ -26,8 +26,8 @@ public partial class ImageViewers
 
         PreviewList.AddRange(
         [
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/ImageList1.jpeg",
-            $"{WebsiteOption.CurrentValue.AssetRootPath}images/ImageList2.jpeg"
+            $"{WebsiteOption.Value.AssetRootPath}images/ImageList1.jpeg",
+            $"{WebsiteOption.Value.AssetRootPath}images/ImageList2.jpeg"
         ]);
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/InputGroups.razor
@@ -1,7 +1,7 @@
 ﻿@page "/input-group"
 @inject IStringLocalizer<InputGroups> Localizer
 @inject IStringLocalizer<Foo> LocalizerFoo
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["InputGroupsTitle"]</h3>
 
@@ -92,7 +92,7 @@
                     <ItemTemplate>
                         <div class="d-flex">
                             <div>
-                                <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                                <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                             </div>
                             <div class="ps-2">
                                 <div>@context.Name</div>

--- a/src/BootstrapBlazor.Server/Components/Samples/IntersectionObservers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/IntersectionObservers.razor
@@ -1,6 +1,6 @@
 ﻿@page "/intersection-observer"
 @inject IStringLocalizer<IntersectionObservers> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <HeadContent>
     <style>

--- a/src/BootstrapBlazor.Server/Components/Samples/IntersectionObservers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/IntersectionObservers.razor.cs
@@ -23,7 +23,7 @@ public partial class IntersectionObservers
     {
         base.OnInitialized();
 
-        _images = [.. Enumerable.Range(1, 100).Select(i => $"{WebsiteOption.CurrentValue.AssetRootPath}images/default.jpeg")];
+        _images = [.. Enumerable.Range(1, 100).Select(i => $"{WebsiteOption.Value.AssetRootPath}images/default.jpeg")];
         _items = [.. Enumerable.Range(1, 20).Select(i => $"https://picsum.photos/160/160?random={i}")];
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/LinkButtons.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/LinkButtons.razor
@@ -1,5 +1,5 @@
 ﻿@page "/link-button"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<LinkButtons> Localizer
 
 <h3>@Localizer["LinkButtonsComTitle"]</h3>
@@ -15,7 +15,7 @@
 <DemoBlock Title="@Localizer["LinkButtonUrlTitle"]"
            Introduction="@Localizer["LinkButtonUrlIntro"]"
            Name="Url">
-    <LinkButton Text="@Localizer["LinkButtonText"]" Url="@WebsiteOption.CurrentValue.ServerUrl" />
+    <LinkButton Text="@Localizer["LinkButtonText"]" Url="@WebsiteOption.Value.ServerUrl" />
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["LinkButtonTitleTitle"]"
@@ -28,7 +28,7 @@
 <DemoBlock Title="@Localizer["LinkButtonImageTitle"]"
            Introduction="@Localizer["LinkButtonImageIntro"]"
            Name="Image">
-    <LinkButton ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" />
+    <LinkButton ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" />
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["LinkButtonIconTitle"]"

--- a/src/BootstrapBlazor.Server/Components/Samples/ListViews.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/ListViews.razor
@@ -1,5 +1,5 @@
 ﻿@page "/list-view"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<ListViews> Localizer
 
 <h3>@Localizer["ListViewsTitle"]</h3>

--- a/src/BootstrapBlazor.Server/Components/Samples/ListViews.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ListViews.razor.cs
@@ -25,7 +25,7 @@ public sealed partial class ListViews
 
         Products = Enumerable.Range(1, 8).Select(i => new Product()
         {
-            ImageUrl = $"{WebsiteOption.CurrentValue.AssetRootPath}images/Pic{i}.jpg",
+            ImageUrl = $"{WebsiteOption.Value.AssetRootPath}images/Pic{i}.jpg",
             Description = $"Pic{i}.jpg",
             Category = $"Group{(i % 4) + 1}"
         });

--- a/src/BootstrapBlazor.Server/Components/Samples/Live2DDisplays.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Live2DDisplays.razor
@@ -1,6 +1,6 @@
 ﻿@page "/live2d-display"
 @inject IStringLocalizer<Live2DDisplays> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <HeadContent>
     <style>

--- a/src/BootstrapBlazor.Server/Components/Samples/Live2DDisplays.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Live2DDisplays.razor.cs
@@ -45,8 +45,8 @@ public partial class Live2DDisplays
 
         _srcItems.AddRange(
         [
-            new SelectedItem($"{WebsiteOption.CurrentValue.AssetRootPath}models/shizuku/shizuku.model.json", "shizuku"),
-            new SelectedItem($"{WebsiteOption.CurrentValue.AssetRootPath}models/haru/haru_greeter_t03.model3.json", "haru"),
+            new SelectedItem($"{WebsiteOption.Value.AssetRootPath}models/shizuku/shizuku.model.json", "shizuku"),
+            new SelectedItem($"{WebsiteOption.Value.AssetRootPath}models/haru/haru_greeter_t03.model3.json", "haru"),
             new SelectedItem("https://raw.githubusercontent.com/iCharlesZ/vscode-live2d-models/master/model-library/bilibili-22/index.json", "bilibili-22"),
             new SelectedItem("https://raw.githubusercontent.com/iCharlesZ/vscode-live2d-models/master/model-library/bilibili-33/index.json", "bilibili-33"),
             new SelectedItem("https://raw.githubusercontent.com/iCharlesZ/vscode-live2d-models/master/model-library/chiaki_kitty/chiaki_kitty.model.json", "chiaki_kitty"),

--- a/src/BootstrapBlazor.Server/Components/Samples/Logouts.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Logouts.razor
@@ -1,6 +1,6 @@
 ﻿@page "/logout"
 @inject IStringLocalizer<Logouts> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["LogoutsTitle"]</h3>
 
@@ -10,7 +10,7 @@
            Introduction="@Localizer["LogoutsNormalIntro"]"
            Name="Normal">
     <div class="logout-custom">
-        <Logout ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" />
+        <Logout ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" />
         <div style="height: 80px;"></div>
     </div>
 </DemoBlock>
@@ -19,7 +19,7 @@
            Introduction="@Localizer["LogoutsShowUserNameIntro"]"
            Name="ShowUserName">
     <div class="logout-custom">
-        <Logout ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" ShowUserName="false" />
+        <Logout ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" ShowUserName="false" />
         <div style="height: 80px;"></div>
     </div>
 </DemoBlock>
@@ -27,7 +27,7 @@
 <DemoBlock Title="@Localizer["LogoutsChildContentTitle"]"
            Introduction="@Localizer["LogoutsChildContentIntro"]"
            Name="ChildContent">
-    <Logout ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin">
+    <Logout ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin">
         <i class="fa-fw fa-solid fa-user"></i>
         <span>@Localizer["LogoutsChildContentCustomDisplay"]</span>
     </Logout>
@@ -37,10 +37,10 @@
 <DemoBlock Title="@Localizer["LogoutsHeaderTemplateTitle"]"
            Introduction="@Localizer["LogoutsHeaderTemplateIntro"]"
            Name="HeaderTemplate">
-    <Logout ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" class="bg-warning">
+    <Logout ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" class="bg-warning">
         <HeaderTemplate>
             <div class="d-flex flex-fill align-items-center">
-                <img alt="avatar" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" style="border-radius: 50%;">
+                <img alt="avatar" src="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" style="border-radius: 50%;">
                 <div class="flex-fill">
                     <div class="logout-dn">@Localizer["LogoutsHeaderTemplateUser1"]</div>
                     <div class="logout-un">@Localizer["LogoutsHeaderTemplateUser2"]</div>
@@ -54,7 +54,7 @@
 <DemoBlock Title="@Localizer["LogoutsLinkTemplateTitle"]"
            Introduction="@Localizer["LogoutsLinkTemplateIntro"]"
            Name="LinkTemplate">
-    <Logout ImageUrl="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" class="bg-primary">
+    <Logout ImageUrl="@WebsiteOption.Value.GetAssetUrl("images/Argo.png")" DisplayName="Administrators" UserName="Admin" class="bg-primary">
         <LinkTemplate>
             <a href="#">
                 <i class="fa-solid fa-user"></i><span>@Localizer["LogoutsLinkTemplatePersonalCenter"]</span>

--- a/src/BootstrapBlazor.Server/Components/Samples/Menus.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Menus.razor
@@ -1,5 +1,5 @@
 ﻿@page "/menu"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<Menus> Localizer
 
 <h3>@Localizer["MenusTitle"]</h3>
@@ -70,7 +70,7 @@
             </Header>
             <Side>
                 <div class="layout-banner">
-                    <img class="layout-logo" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+                    <img class="layout-logo" src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
                     <div class="layout-title">
                         <span>@Localizer["MenusClickShrinkMenuTitle"]</span>
                     </div>
@@ -81,7 +81,7 @@
             </Main>
             <Footer>
                 <div class="text-center flex-fill">
-                    <a href="@WebsiteOption.CurrentValue.BootstrapAdminLink" target="_blank">Bootstrap Admin</a>
+                    <a href="@WebsiteOption.Value.BootstrapAdminLink" target="_blank">Bootstrap Admin</a>
                 </div>
             </Footer>
         </Layout>

--- a/src/BootstrapBlazor.Server/Components/Samples/MouseFollowers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/MouseFollowers.razor
@@ -1,5 +1,5 @@
 ﻿@page "/mouse-follower"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <HeadContent>
     <style>
@@ -61,7 +61,7 @@
            Introduction="@Localizer["MouseFollowerIconIntro"]"
            Name="MouseFollowerIcon">
     <MouseFollower FollowerMode="MouseFollowerMode.Image"
-                   Content="@WebsiteOption.CurrentValue.GetAssetUrl("images/performance.svg")">
+                   Content="@WebsiteOption.Value.GetAssetUrl("images/performance.svg")">
         <div class="mouseFollower-demo" />
     </MouseFollower>
 </DemoBlock>
@@ -71,7 +71,7 @@
            Name="MouseFollowerImage">
     <MouseFollower Options="@FollowerImageOptions"
                    FollowerMode="MouseFollowerMode.Image"
-                   Content="@WebsiteOption.CurrentValue.GetAssetUrl("images/mousefollower/cat.gif")">
+                   Content="@WebsiteOption.Value.GetAssetUrl("images/mousefollower/cat.gif")">
         <div class="mouseFollower-demo" />
     </MouseFollower>
 </DemoBlock>

--- a/src/BootstrapBlazor.Server/Components/Samples/Navigation.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Navigation.razor
@@ -1,5 +1,5 @@
 ﻿@page "/navigation"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<Navigation> Localizer
 
 <h3>@Localizer["NavsTitle"]</h3>

--- a/src/BootstrapBlazor.Server/Components/Samples/Navigation.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Navigation.razor.cs
@@ -20,7 +20,7 @@ public sealed partial class Navigation
         var link = new NavLink();
         var parameters = new Dictionary<string, object?>()
         {
-            ["href"] = WebsiteOption.CurrentValue.AdminUrl,
+            ["href"] = WebsiteOption.Value.AdminUrl,
             ["class"] = "nav-link nav-item",
             ["target"] = "_blank",
             ["ChildContent"] = new RenderFragment(builder =>

--- a/src/BootstrapBlazor.Server/Components/Samples/Notifications.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Notifications.razor
@@ -1,6 +1,6 @@
 ﻿@page "/notification"
 @inject IStringLocalizer<Notifications> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["NotificationsTitle"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Notifications.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Notifications.razor.cs
@@ -31,7 +31,7 @@ public partial class Notifications
 
         Model = new()
         {
-            Icon = $"{WebsiteOption.CurrentValue.AssetRootPath}images/Argo-C.png",
+            Icon = $"{WebsiteOption.Value.AssetRootPath}images/Argo-C.png",
             Title = Localizer["NotificationsNormalTitleSampleText"],
             Message = Localizer["NotificationsNormalMessageSampleText"],
             OnClick = OnClickNotificationCallback

--- a/src/BootstrapBlazor.Server/Components/Samples/Reconnectors.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Reconnectors.razor
@@ -1,6 +1,6 @@
 ﻿@page "/reconnector"
 @inject IStringLocalizer<Reconnectors> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Reconnectors.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Reconnectors.razor.cs
@@ -10,7 +10,7 @@ namespace BootstrapBlazor.Server.Components.Samples;
 /// </summary>
 public partial class Reconnectors
 {
-    private string TemplateUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/wikis/%E9%A1%B9%E7%9B%AE%E6%A8%A1%E6%9D%BF%E4%BD%BF%E7%94%A8%E6%95%99%E7%A8%8B";
+    private string TemplateUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/wikis/%E9%A1%B9%E7%9B%AE%E6%A8%A1%E6%9D%BF%E4%BD%BF%E7%94%A8%E6%95%99%E7%A8%8B";
 
     private AttributeItem[] GetAttributes() =>
     [

--- a/src/BootstrapBlazor.Server/Components/Samples/Searches.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Searches.razor
@@ -1,7 +1,7 @@
 ﻿@page "/search"
 @inject IStringLocalizer<Searches> Localizer
 @inject IStringLocalizer<Foo> LocalizerFoo
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["SearchesTitle"]</h3>
 
@@ -36,7 +36,7 @@
         <ItemTemplate>
             <div class="search-result">
                 <div class="search-result-avatar">
-                    <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" alt="avatar" />
+                    <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" alt="avatar" />
                 </div>
                 <div class="search-result-main">
                     <div class="search-result-name">@context.Name</div>

--- a/src/BootstrapBlazor.Server/Components/Samples/SelectGenerics.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/SelectGenerics.razor
@@ -1,7 +1,7 @@
 ﻿@page "/select-generic"
 @inject DialogService Dialog
 @inject IStringLocalizer<Selects> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["SelectsTitle"]</h3>
 
@@ -276,7 +276,7 @@
                         </div>
                         <Divider />
                         <div class="select-custom-body">
-                            <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(foo.Id)" class="bb-avatar" />
+                            <img src="@WebsiteOption.Value.GetAvatarUrl(foo.Id)" class="bb-avatar" />
                             <div class="select-custom-detail">
                                 <div class="d-flex">
                                     <div class="flex-fill">

--- a/src/BootstrapBlazor.Server/Components/Samples/SelectObjects.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/SelectObjects.razor
@@ -1,6 +1,6 @@
 ﻿@page "/select-object"
 @inject IStringLocalizer<SelectObjects> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/SelectObjects.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/SelectObjects.razor.cs
@@ -30,7 +30,7 @@ public partial class SelectObjects
 
         Products = Enumerable.Range(1, 8).Select(i => new ListViews.Product()
         {
-            ImageUrl = $"{WebsiteOption.CurrentValue.AssetRootPath}images/Pic{i}.jpg",
+            ImageUrl = $"{WebsiteOption.Value.AssetRootPath}images/Pic{i}.jpg",
             Description = $"Pic{i}.jpg",
             Category = $"Group{(i % 4) + 1}"
         });

--- a/src/BootstrapBlazor.Server/Components/Samples/SelectTables.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/SelectTables.razor
@@ -1,5 +1,5 @@
 ﻿@page "/select-table"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["Title"]</h3>
 
@@ -50,7 +50,7 @@
                 </div>
                 <Divider />
                 <div class="select-custom-body">
-                    <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(context.Id)" class="bb-avatar" />
+                    <img src="@WebsiteOption.Value.GetAvatarUrl(context.Id)" class="bb-avatar" />
                     <div class="select-custom-detail">
                         <div class="d-flex">
                             <div class="flex-fill">

--- a/src/BootstrapBlazor.Server/Components/Samples/Selects.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Selects.razor
@@ -1,7 +1,7 @@
 ﻿@page "/select"
 @inject DialogService Dialog
 @inject IStringLocalizer<Selects> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["SelectsTitle"]</h3>
 
@@ -288,7 +288,7 @@
                         </div>
                         <Divider />
                         <div class="select-custom-body">
-                            <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(foo.Id)" class="bb-avatar" />
+                            <img src="@WebsiteOption.Value.GetAvatarUrl(foo.Id)" class="bb-avatar" />
                             <div class="select-custom-detail">
                                 <div class="d-flex">
                                     <div class="flex-fill">

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumn.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumn.razor
@@ -2,7 +2,7 @@
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesColumn> Localizer
 @inject IStringLocalizer<Foo> FooLocalizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["TablesColumnTitle"] - @NavMenuLocalizer["TableColumn"]</h3>
 
@@ -226,7 +226,7 @@
                 <Template Context="value">
                     <div class="d-flex">
                         <div>
-                            <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(value.Row.Id)" class="bb-avatar" />
+                            <img src="@WebsiteOption.Value.GetAvatarUrl(value.Row.Id)" class="bb-avatar" />
                         </div>
                         <div class="ps-2">
                             <div>@value.Value</div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor
@@ -2,7 +2,7 @@
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesColumnDrag> Localizer
 @inject IStringLocalizer<Foo> FooLocalizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["TablesColumnTitle"] - @NavMenuLocalizer["TableColumnDrag"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnList.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnList.razor
@@ -1,7 +1,7 @@
 ﻿@page "/table/column/list"
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesColumnList> Localizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<Foo> FooLocalizer
 
 <h3>@Localizer["TablesColumnTitle"] - @NavMenuLocalizer["TableColumnList"]</h3>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnResizing.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnResizing.razor
@@ -2,7 +2,7 @@
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesColumnResizing> Localizer
 @inject IStringLocalizer<Foo> FooLocalizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject ToastService ToastService
 
 <h3>@Localizer["TablesColumnTitle"] - @NavMenuLocalizer["TableColumnResizing"]</h3>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnResizing.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnResizing.razor.cs
@@ -34,7 +34,7 @@ public partial class TablesColumnResizing
         IEnumerable<Foo> items = Items;
         // 过滤
         var isFiltered = false;
-        if (options.Filters.Count != 0)
+        if (options.Filters.Count > 0)
         {
             items = items.Where(options.Filters.GetFilterFunc<Foo>());
             isFiltered = true;

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnResizing.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnResizing.razor.cs
@@ -34,7 +34,7 @@ public partial class TablesColumnResizing
         IEnumerable<Foo> items = Items;
         // 过滤
         var isFiltered = false;
-        if (options.Filters.Any())
+        if (options.Filters.Count != 0)
         {
             items = items.Where(options.Filters.GetFilterFunc<Foo>());
             isFiltered = true;

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnTemplate.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnTemplate.razor
@@ -2,7 +2,7 @@
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesColumnTemplate> Localizer
 @inject IStringLocalizer<Foo> FooLocalizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["TablesColumnTitle"] - @NavMenuLocalizer["TableColumnTemplate"]</h3>
 
@@ -83,7 +83,7 @@
         <ul class="ul-demo mb-3">
             <li>@((MarkupString)Localizer["AutoGenerateColumnsLi1"].Value)</li>
             <li>@((MarkupString)Localizer["AutoGenerateColumnsLi2"].Value)</li>
-            <li>@((MarkupString)string.Format(Localizer["AutoGenerateColumnsLi3"].Value, WebsiteOption.CurrentValue.GiteeRepositoryUrl))</li>
+            <li>@((MarkupString)string.Format(Localizer["AutoGenerateColumnsLi3"].Value, WebsiteOption.Value.GiteeRepositoryUrl))</li>
         </ul>
         @((MarkupString)Localizer["AutoGenerateColumnsP2"].Value)
     </section>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesEdit.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesEdit.razor
@@ -3,7 +3,7 @@
 @inject IStringLocalizer<TablesEdit> Localizer
 @inject IStringLocalizer<Foo> LocalizerFoo
 @inject ToastService ToastService
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["TablesEditTitle"] - @NavMenuLocalizer["TableEdit"]</h3>
 <h4>@((MarkupString)Localizer["TablesEditDescription"].Value)</h4>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesEdit.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesEdit.razor.cs
@@ -36,7 +36,7 @@ public partial class TablesEdit
 
     private string? PlaceHolderString { get; set; }
 
-    private string DataServiceUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/wikis/Table%20%E7%BB%84%E4%BB%B6%E6%95%B0%E6%8D%AE%E6%9C%8D%E5%8A%A1%E4%BB%8B%E7%BB%8D?sort_id=3207977";
+    private string DataServiceUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/wikis/Table%20%E7%BB%84%E4%BB%B6%E6%95%B0%E6%8D%AE%E6%9C%8D%E5%8A%A1%E4%BB%8B%E7%BB%8D?sort_id=3207977";
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesExcel.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesExcel.razor
@@ -2,7 +2,7 @@
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesExcel> Localizer
 @inject IStringLocalizer<Foo> LocalizerFoo
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["TablesExcelTitle"] - @NavMenuLocalizer["TableExcel"]</h3>
 <h4>@Localizer["TablesExcelDescription"]</h4>
@@ -101,7 +101,7 @@
                 <EditTemplate Context="row">
                     <div class="d-flex disabled">
                         <div>
-                            <img src="@WebsiteOption.CurrentValue.GetAvatarUrl(row!.Id)" class="bb-avatar" />
+                            <img src="@WebsiteOption.Value.GetAvatarUrl(row!.Id)" class="bb-avatar" />
                         </div>
                         <div class="ps-2">
                             <div>@row.Name</div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesFilter.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesFilter.razor
@@ -3,7 +3,7 @@
 @inject IStringLocalizer<Tables> BaseLocalizer
 @inject IStringLocalizer<TablesFilter> Localizer
 @inject IStringLocalizer<Foo> FooLocalizer
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@BaseLocalizer["TableBaseTitle"] - @NavMenuLocalizer["TableFilter"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesFilter.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesFilter.razor.cs
@@ -24,7 +24,7 @@ public partial class TablesFilter
 
     private string SortString { get; set; } = "DateTime desc, Address";
 
-    private string ComponentSourceCodeUrl => $"{WebsiteOption.CurrentValue.GiteeRepositoryUrl}/blob/main/src/BootstrapBlazor.Server/Components/Components/CustomerFilter.razor";
+    private string ComponentSourceCodeUrl => $"{WebsiteOption.Value.GiteeRepositoryUrl}/blob/main/src/BootstrapBlazor.Server/Components/Components/CustomerFilter.razor";
 
     [NotNull]
     private Table<Foo>? TableSetFilter { get; set; }

--- a/src/BootstrapBlazor.Server/Components/Samples/Topologies.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Topologies.razor
@@ -3,7 +3,7 @@
 @inject IStringLocalizer<Topologies> Localizer
 @inject FanControllerDataService DataService
 @inject SwalService SwalService
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @attribute [JSModuleAutoLoader("Samples/Topologies.razor.js", JSObjectReference = true, AutoInvokeDispose = false)]
 
 <h3>@Localizer["TopologiesTitle"]</h3>

--- a/src/BootstrapBlazor.Server/Components/Samples/Topologies.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Topologies.razor.cs
@@ -31,7 +31,7 @@ public partial class Topologies
         {
             using var reader = new StreamReader(stream);
             Content = reader.ReadToEnd();
-            Content = Content.Replace("{AssetPath}", WebsiteOption.CurrentValue.AssetRootPath);
+            Content = Content.Replace("{AssetPath}", WebsiteOption.Value.AssetRootPath);
         }
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/Admin.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/Admin.razor
@@ -1,5 +1,5 @@
 ﻿@page "/tutorials/admin"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <p>后台权限管理演示系统</p>
 
@@ -9,7 +9,7 @@
             <div class="card">
                 <div class="card-header">BootstrapBlazor 组件库实现</div>
                 <div class="card-body">
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/tutorials/pro.jpg")" class="w-100" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/tutorials/pro.jpg")" class="w-100" />
                 </div>
             </div>
         </a>
@@ -19,7 +19,7 @@
             <div class="card">
                 <div class="card-header">MVC & Blazor 混合实现</div>
                 <div class="card-body">
-                    <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/tutorials/admin.jpg")" class="w-100" />
+                    <img src="@WebsiteOption.Value.GetAssetUrl("images/tutorials/admin.jpg")" class="w-100" />
                 </div>
             </div>
         </a>

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/LoginAndRegister/Template3.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/LoginAndRegister/Template3.razor
@@ -1,10 +1,10 @@
 ﻿@page "/tutorials/template3"
 @layout TutorialsLoginLayout
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div class="login-item login-item-avatar">
     <div class="text-center">
-        <Avatar Url="@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraExtraLarge" />
+        <Avatar Url="@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" IsCircle="true" Size="Size.ExtraExtraLarge" />
         <h4 class="text-dark">欢迎使用 BootstrapBlazor 组件库</h4>
     </div>
     <ValidateForm Model="@Model" OnValidSubmit="OnSubmit">

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/Login.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/Login.razor
@@ -1,9 +1,9 @@
 ﻿@page "/tutorials/mfa"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div class="bb-sign">
     <div class="text-center">
-        <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+        <img src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
         <h3>Sign in to Blazor</h3>
     </div>
     <div class="bb-sign-body">

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/Register.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/Register.razor
@@ -1,10 +1,10 @@
 ﻿@page "/tutorials/mfa/two-factor/register"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject ITotpService TotpService
 
 <div class="bb-sign">
     <div class="text-center">
-        <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+        <img src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
         <h3>Two-factor methods</h3>
     </div>
     <div class="bb-sign-body">

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/TwoFactor.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/TwoFactor.razor
@@ -1,14 +1,14 @@
 ﻿@page "/tutorials/mfa/two-factor"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div class="bb-sign">
     <div class="text-center">
-        <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+        <img src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
         <h1>Two-factor authentication</h1>
     </div>
     <div class="bb-sign-body">
         <div class="text-center">
-            <img class="rounded-2" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+            <img class="rounded-2" src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
             <h3>Blazor Mobile</h3>
         </div>
         <div>We sent you a sign-in request on your Blazor Mobile app. Approve the request to verify your identity.</div>

--- a/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/TwoFactorApp.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Tutorials/MFA/TwoFactorApp.razor
@@ -1,14 +1,14 @@
 ﻿@page "/tutorials/mfa/two-factor/app"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <div class="bb-sign">
     <div class="text-center">
-        <img src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+        <img src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
         <h3>Two-factor authentication</h3>
     </div>
     <div class="bb-sign-body">
         <div class="text-center">
-            <img class="rounded-2" src="@WebsiteOption.CurrentValue.GetAssetUrl("images/logo.png")" />
+            <img class="rounded-2" src="@WebsiteOption.Value.GetAssetUrl("images/logo.png")" />
             <h3>Authentication code</h3>
         </div>
         <div>

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor
@@ -1,5 +1,5 @@
 ﻿@page "/upload-avatar"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<UploadAvatars> Localizer
 @inject ToastService ToastService
 

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadAvatars.razor.cs
@@ -31,7 +31,7 @@ public partial class UploadAvatars
 
         _previewFileList.AddRange(
         [
-            new UploadFile { PrevUrl = $"{WebsiteOption.CurrentValue.AssetRootPath}images/Argo.png" }
+            new UploadFile { PrevUrl = $"{WebsiteOption.Value.AssetRootPath}images/Argo.png" }
         ]);
     }
 

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadButtons.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadButtons.razor
@@ -1,5 +1,5 @@
 ﻿@page "/upload-button"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<UploadButtons> Localizer
 @inject ToastService ToastService
 

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadButtons.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadButtons.razor.cs
@@ -52,9 +52,9 @@ public partial class UploadButtons : IDisposable
         // Server Side 使用
         // Web Assembly 模式下必须使用 WebApi 方式去保存文件到服务器或者数据库中
         // 生成写入文件名称
-        if (!string.IsNullOrEmpty(WebsiteOption.CurrentValue.WebRootPath))
+        if (!string.IsNullOrEmpty(WebsiteOption.Value.WebRootPath))
         {
-            var uploaderFolder = Path.Combine(WebsiteOption.CurrentValue.WebRootPath, "images", "uploader");
+            var uploaderFolder = Path.Combine(WebsiteOption.Value.WebRootPath, "images", "uploader");
             file.FileName = $"{Path.GetFileNameWithoutExtension(file.OriginFileName)}-{DateTimeOffset.Now:yyyyMMddHHmmss}{Path.GetExtension(file.OriginFileName)}";
             var fileName = Path.Combine(uploaderFolder, file.FileName);
 
@@ -66,7 +66,7 @@ public partial class UploadButtons : IDisposable
                 if (ret)
                 {
                     // 保存成功
-                    file.PrevUrl = $"{WebsiteOption.CurrentValue.AssetRootPath}images/uploader/{file.FileName}";
+                    file.PrevUrl = $"{WebsiteOption.Value.AssetRootPath}images/uploader/{file.FileName}";
                 }
                 else
                 {

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor
@@ -1,5 +1,5 @@
 ﻿@page "/upload-card"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<UploadCards> Localizer
 @inject ToastService ToastService
 

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor.cs
@@ -67,9 +67,9 @@ public partial class UploadCards : IDisposable
         // Server Side 使用
         // Web Assembly 模式下必须使用 WebApi 方式去保存文件到服务器或者数据库中
         // 生成写入文件名称
-        if (!string.IsNullOrEmpty(WebsiteOption.CurrentValue.WebRootPath))
+        if (!string.IsNullOrEmpty(WebsiteOption.Value.WebRootPath))
         {
-            var uploaderFolder = Path.Combine(WebsiteOption.CurrentValue.WebRootPath, "images", "uploader");
+            var uploaderFolder = Path.Combine(WebsiteOption.Value.WebRootPath, "images", "uploader");
             file.FileName = $"{Path.GetFileNameWithoutExtension(file.OriginFileName)}-{DateTimeOffset.Now:yyyyMMddHHmmss}{Path.GetExtension(file.OriginFileName)}";
             var fileName = Path.Combine(uploaderFolder, file.FileName);
 
@@ -81,7 +81,7 @@ public partial class UploadCards : IDisposable
                 if (ret)
                 {
                     // 保存成功
-                    file.PrevUrl = $"{WebsiteOption.CurrentValue.AssetRootPath}images/uploader/{file.FileName}";
+                    file.PrevUrl = $"{WebsiteOption.Value.AssetRootPath}images/uploader/{file.FileName}";
                 }
                 else
                 {

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadDrops.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadDrops.razor
@@ -1,5 +1,5 @@
 ﻿@page "/upload-drop"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 @inject IStringLocalizer<UploadDrops> Localizer
 @inject ToastService ToastService
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Vditors.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Vditors.razor
@@ -1,5 +1,5 @@
 ﻿@page "/vditor"
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["VditorTitle"]</h3>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/WinBoxes.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/WinBoxes.razor
@@ -1,7 +1,7 @@
 ﻿@page "/win-box"
 @inject IStringLocalizer<WinBoxes> Localizer
 @inject IStringLocalizer<Foo> LocalizerFoo
-@inject IOptionsMonitor<WebsiteOptions> WebsiteOption
+@inject IOptions<WebsiteOptions> WebsiteOption
 
 <h3>@Localizer["WinBoxTitle"]</h3>
 <h4>@Localizer["WinBoxDescription"]</h4>
@@ -57,7 +57,7 @@ private WinBoxService? WinBoxService { get; set; }</Pre>
 
 <GroupBox Title="设置图标" class="mb-3">
     <p class="code-label">通过 <code>WinBoxOption</code> 参数 <code>Icon</code> 设置</p>
-    <Pre>new WinBoxOption() { Icon = "@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")" }</Pre>
+    <Pre>new WinBoxOption() { Icon = "@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")" }</Pre>
 
     <p class="code-label">通过服务方法 <code>WinBoxService</code> 实例方法</p>
     <Pre>[Inject]
@@ -67,7 +67,7 @@ private WinBoxService? WinBoxService { get; set; }
 private async Task SetIcon()
 {
     // 提前保持弹窗 WinBoxOption 实例
-    option.Icon = "@WebsiteOption.CurrentValue.GetAssetUrl("images/Argo-C.png")";
+    option.Icon = "@WebsiteOption.Value.GetAssetUrl("images/Argo-C.png")";
     await WinBoxService.setIcon(option.Id);
 }</Pre>
 </GroupBox>

--- a/src/BootstrapBlazor.Server/Controllers/Api/CodeController.cs
+++ b/src/BootstrapBlazor.Server/Controllers/Api/CodeController.cs
@@ -25,10 +25,10 @@ public class CodeController : ControllerBase
     /// <param name="options"></param>
     /// <returns></returns>
     [HttpGet]
-    public async Task<string> Get([FromQuery] string fileName, [FromServices] HttpClient client, [FromServices] IOptionsMonitor<WebsiteOptions> options)
+    public async Task<string> Get([FromQuery] string fileName, [FromServices] HttpClient client, [FromServices] IOptions<WebsiteOptions> options)
     {
         var ret = "";
-        client.BaseAddress = new Uri(options.CurrentValue.SourceUrl);
+        client.BaseAddress = new Uri(options.Value.SourceUrl);
         try
         {
             ret = await client.GetStringAsync(fileName);

--- a/src/BootstrapBlazor.Server/Data/WebsiteOptions.cs
+++ b/src/BootstrapBlazor.Server/Data/WebsiteOptions.cs
@@ -13,32 +13,32 @@ namespace BootstrapBlazor.Server.Data;
 public class WebsiteOptions
 {
     /// <summary>
-    /// 
+    /// 获得/设置 网站地址
     /// </summary>
     public string ServerUrl { get; set; } = "https://www.blazor.zone";
 
     /// <summary>
-    /// 
+    /// BootstrapAdmin Admin 链接地址
     /// </summary>
     public string AdminUrl { get; set; } = "https://admin.blazor.zone";
 
     /// <summary>
-    /// 
+    /// BootstrapAdmin Pro 链接地址
     /// </summary>
     public string AdminProUrl { get; set; } = "https://pro.blazor.zone";
 
     /// <summary>
-    /// 
+    /// BootstrapAdmin 链接地址
     /// </summary>
     public string BootstrapAdminLink { get; set; } = "https://gitee.com/LongbowEnterprise/BootstrapAdmin";
 
     /// <summary>
-    /// 
+    /// Gitee 仓库地址
     /// </summary>
     public string GiteeRepositoryUrl { get; set; } = "https://gitee.com/LongbowEnterprise/BootstrapBlazor";
 
     /// <summary>
-    /// 
+    /// 视频资源地址
     /// </summary>
     public string VideoLibUrl { get; set; } = "https://gitee.com/LongbowEnterprise/BootstrapBlazor/wikis/%E8%A7%86%E9%A2%91%E8%B5%84%E6%BA%90?sort_id=3300624";
 
@@ -58,19 +58,19 @@ public class WebsiteOptions
     public string GithubRepositoryUrl { get; set; } = "https://github.com/dotnetcore/BootstrapBlazor?wt.mc_id=DT-MVP-5004174";
 
     /// <summary>
-    /// 
+    /// Wiki 地址
     /// </summary>
     public string WikiUrl { get; set; } = "https://github.com/dotnetcore/BootstrapBlazor/releases?wt.mc_id=DT-MVP-5004174";
 
     /// <summary>
     /// 获得 QQ 1 群链接地址
     /// </summary>
-    public string? QQGroup1Link { get; set; } = "https://qm.qq.com/cgi-bin/qm/qr?k=Geker7hCXK0HC-J8_974645j_n6w0OE0&jump_from=webapi";
+    public string QQGroup1Link { get; set; } = "https://qm.qq.com/cgi-bin/qm/qr?k=Geker7hCXK0HC-J8_974645j_n6w0OE0&jump_from=webapi";
 
     /// <summary>
     /// 获得 QQ 2 群链接地址
     /// </summary>
-    public string? QQGroup2Link { get; set; } = "https://qm.qq.com/cgi-bin/qm/qr?k=Geker7hCXK0HC-J8_974645j_n6w0OE0&jump_from=webapi";
+    public string QQGroup2Link { get; set; } = "https://qm.qq.com/cgi-bin/qm/qr?k=Geker7hCXK0HC-J8_974645j_n6w0OE0&jump_from=webapi";
 
     /// <summary>
     /// 获得/设置 系统 wwwroot 文件夹路径 Server Side 模式下 Upload 使用
@@ -85,16 +85,14 @@ public class WebsiteOptions
     public string? ContentRootPath { get; set; }
 
     /// <summary>
-    /// 获得/设置 资源文件根目录 默认值为 "./"
+    /// 获得/设置 资源文件根目录 默认值为 "/"
     /// </summary>
-    [NotNull]
-    public string? AssetRootPath { get; set; } = "./";
+    public string AssetRootPath { get; set; } = "/";
 
     /// <summary>
     /// 获得/设置 脚本根路径
     /// </summary>
-    [NotNull]
-    public string JSModuleRootPath { get; set; } = "./Components/";
+    public string JSModuleRootPath { get; set; } = "/Components/";
 
     /// <summary>
     /// 获得/设置 视频地址
@@ -115,11 +113,6 @@ public class WebsiteOptions
     /// 获得/设置 当前主题
     /// </summary>
     public string CurrentTheme { get; set; } = "";
-
-    /// <summary>
-    /// 获得/设置 组件总数
-    /// </summary>
-    public int TotalCount { get; set; } = 160;
 
     /// <summary>
     /// 获得 当前环境配置
@@ -170,7 +163,10 @@ public class WebsiteOptions
     /// </summary>
     /// <param name="url"></param>
     /// <returns></returns>
-    public string? GetAssetUrl(string url) => $"{AssetRootPath}{url}";
+    public string GetAssetUrl(string url)
+    {
+        return $"{AssetRootPath}{url}";
+    }
 
     /// <summary>
     /// 获得头像地址字符串

--- a/src/BootstrapBlazor.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/ServiceCollectionExtensions.cs
@@ -22,18 +22,11 @@ static class ServiceCollectionExtensions
         services.AddLogging(logging => logging.AddFileLogger());
 
         // 增加多语言支持配置信息
-        services.AddRequestLocalization<IOptionsMonitor<BootstrapBlazorOptions>>((localizerOption, blazorOption) =>
+        services.AddRequestLocalization<IOptions<BootstrapBlazorOptions>>((localizerOption, blazorOption) =>
         {
-            blazorOption.OnChange(Invoke);
-            Invoke(blazorOption.CurrentValue);
-            return;
-
-            void Invoke(BootstrapBlazorOptions option)
-            {
-                var supportedCultures = option.GetSupportedCultures();
-                localizerOption.SupportedCultures = supportedCultures;
-                localizerOption.SupportedUICultures = supportedCultures;
-            }
+            var supportedCultures = blazorOption.Value.GetSupportedCultures();
+            localizerOption.SupportedCultures = supportedCultures;
+            localizerOption.SupportedUICultures = supportedCultures;
         });
 
         services.AddControllers();


### PR DESCRIPTION
## Link issues
fixes #6484 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Switch configuration injection from IOptionsMonitor to IOptions to reduce overhead and improve performance across server components

Bug Fixes:
- Fix #6484

Enhancements:
- Replace IOptionsMonitor<WebsiteOptions> and IOptionsMonitor<BootstrapBlazorOptions> with IOptions<> in all razor components, pages, services, and extension methods
- Update all WebsiteOption.CurrentValue references to use WebsiteOption.Value consistently
- Simplify request localization setup by removing OnChange callbacks and using IOptions<BootstrapBlazorOptions> value directly
- Adjust WebsiteOptions class defaults and nullability: set AssetRootPath and JSModuleRootPath to absolute paths, remove obsolete TotalCount property, make QQGroup links non-nullable, and streamline GetAssetUrl signature