### PR TITLE
feat(Badge): use text-bg-color class

### DIFF
--- a/src/BootstrapBlazor/Components/Badge/Badge.razor.cs
+++ b/src/BootstrapBlazor/Components/Badge/Badge.razor.cs
@@ -11,7 +11,7 @@ namespace BootstrapBlazor.Components;
 public partial class Badge
 {
     private string? ClassString => CssBuilder.Default("badge")
-        .AddClass($"bg-{Color.ToDescriptionString()}", Color != Color.None)
+        .AddClass($"text-bg-{Color.ToDescriptionString()}", Color != Color.None)
         .AddClass("rounded-pill", IsPill)
         .AddClassFromAttributes(AdditionalAttributes)
         .Build();

--- a/src/BootstrapBlazor/Components/Badge/Badge.razor.scss
+++ b/src/BootstrapBlazor/Components/Badge/Badge.razor.scss
@@ -1,5 +1,5 @@
-.badge {
-    &.bg-secondary, &.bg-light {
+﻿.badge {
+    &.text-bg-secondary, &.text-bg-light {
         --bs-badge-color: #{$bb-badge-color};
     }
 }


### PR DESCRIPTION
## Link issues
fixes #6500 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Switch Badge component styling to use Bootstrap’s text-bg-{color} utility classes for background colors

New Features:
- Use text-bg-{color} utility classes for badge backgrounds

Bug Fixes:
- Fix issue #6500 by replacing deprecated bg-{color} classes with text-bg-{color} in Badge component