### PR TITLE
feat(Message): Add ”DismissMode“ in MessageOption

### DIFF
--- a/src/BootstrapBlazor/Components/Message/Message.razor.cs
+++ b/src/BootstrapBlazor/Components/Message/Message.razor.cs
@@ -133,6 +133,8 @@ public partial class Message
         {
             await option.OnDismiss();
         }
+        if (option is { DismissMode: MessageDismissMode.DeleteSource })
+            _messages.Remove(option);
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Message/Message.razor.js
+++ b/src/BootstrapBlazor/Components/Message/Message.razor.js
@@ -46,10 +46,13 @@ export function show(id, msgId) {
             clearTimeout(hideHandler);
 
             // remove Id
-            msg.items.pop();
+            const rmDom = msg.items.pop();
             if (msg.items.length === 0) {
                 // call server method prepare remove dom
                 msg.invoke.invokeMethodAsync(msg.callback);
+            } else {
+                const alertId = rmDom.el.id;
+                msg.invoke.invokeMethodAsync('Dismiss', alertId);
             }
         }, 500);
     };

--- a/src/BootstrapBlazor/Components/Message/MessageOption.cs
+++ b/src/BootstrapBlazor/Components/Message/MessageOption.cs
@@ -54,4 +54,9 @@ public class MessageOption : PopupOptionBase
     /// 获得/设置 消息显示模式，默认为 <see cref="MessageShowMode.Multiple"/>
     /// </summary>
     public MessageShowMode ShowMode { get; set; } = MessageShowMode.Multiple;
+
+    /// <summary>
+    /// 获得/设置 消息关闭模式，默认为 <see cref="MessageDismissMode.OnlyHidden"/>
+    /// </summary>
+    public MessageDismissMode DismissMode { get; set; } = MessageDismissMode.OnlyHidden;
 }

--- a/src/BootstrapBlazor/Enums/MessageShowMode.cs
+++ b/src/BootstrapBlazor/Enums/MessageShowMode.cs
@@ -20,3 +20,18 @@ public enum MessageShowMode
     /// </summary>
     Multiple
 }
+
+/// <summary>
+/// 消息关闭模式
+/// </summary>
+public enum MessageDismissMode
+{
+    /// <summary>
+    /// 关闭时仅隐藏原弹窗，保持占位直到所有弹窗均隐藏时一次性清空，这是之前的默认行为
+    /// </summary>
+    OnlyHidden,
+    /// <summary>
+    /// 关闭时直接删除原弹窗的数据对象，不存在占位
+    /// </summary>
+    DeleteSource,
+}

--- a/test/UnitTest/Components/MessageTest.cs
+++ b/test/UnitTest/Components/MessageTest.cs
@@ -147,5 +147,10 @@ public class MessageTest : BootstrapBlazorTestBase
             Icon = "fa-solid fa-font-awesome",
             DismissMode = MessageDismissMode.DeleteSource
         }, cut.Instance));
+        var alert = cut.Find(".alert");
+        Assert.NotNull(alert);
+        Assert.NotNull(alert.Id);
+
+        await cut.Instance.Dismiss(alert.Id);
     }
 }

--- a/test/UnitTest/Components/MessageTest.cs
+++ b/test/UnitTest/Components/MessageTest.cs
@@ -133,4 +133,19 @@ public class MessageTest : BootstrapBlazorTestBase
             ShowMode = MessageShowMode.Single
         }, cut.Instance));
     }
+
+    [Fact]
+    public async Task DisMissMode_Ok()
+    {
+        var service = Context.Services.GetRequiredService<MessageService>();
+        var cut = Context.RenderComponent<Message>();
+        await cut.InvokeAsync(() => service.Show(new MessageOption()
+        {
+            Content = "Test Content",
+            IsAutoHide = false,
+            ShowDismiss = true,
+            Icon = "fa-solid fa-font-awesome",
+            DismissMode = MessageDismissMode.DeleteSource
+        }, cut.Instance));
+    }
 }


### PR DESCRIPTION
## Link issues
fixes #6506 

## Summary By Copilot

## Regression?
- [ ] Yes
- [ ] No

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Introduce configurable dismiss behavior for message component by adding a new DismissMode option and supporting client-server handling for per-message dismissal.

New Features:
- Add MessageDismissMode enum to specify OnlyHidden or DeleteSource dismiss behaviors
- Expose DismissMode property on MessageOption with default OnlyHidden

Enhancements:
- Invoke server-side Dismiss callback for each message closed in the client-side JS when multiple messages are present
- Remove messages from the server-side source list in DeleteSource mode upon dismiss