### PR TITLE
fix(Message): should clear when use same option

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Messages.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Messages.razor.cs
@@ -23,7 +23,9 @@ public sealed partial class Messages
         Message.SetPlacement(Placement.Top);
         await MessageService.Show(new MessageOption()
         {
-            Content = "This is a reminder message"
+            Content = "This is a reminder message",
+            DismissMode = MessageDismissMode.DeleteSource,
+            ShowDismiss = true
         });
     }
 
@@ -33,16 +35,16 @@ public sealed partial class Messages
         _option.IsAutoHide = false;
         _option.Delay = 3000;
         _option.Content = Localizer["MessagesAsyncDemoStep1Text"];
-        _option.Color = Color.Info;
+        _option.Color = Color.Primary;
         await MessageService.Show(_option);
 
         await Task.Delay(3000);
         _option.Content = Localizer["MessagesAsyncDemoStep2Text"];
-        _option.IsAutoHide = true;
         _option.Color = Color.Info;
         await MessageService.Show(_option);
 
         await Task.Delay(2000);
+        _option.IsAutoHide = true;
         _option.Content = Localizer["MessagesAsyncDemoStep3Text"];
         _option.Color = Color.Success;
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Messages.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Messages.razor.cs
@@ -23,9 +23,7 @@ public sealed partial class Messages
         Message.SetPlacement(Placement.Top);
         await MessageService.Show(new MessageOption()
         {
-            Content = "This is a reminder message",
-            DismissMode = MessageDismissMode.DeleteSource,
-            ShowDismiss = true
+            Content = "This is a reminder message"
         });
     }
 

--- a/src/BootstrapBlazor/Components/Message/Message.razor.js
+++ b/src/BootstrapBlazor/Components/Message/Message.razor.js
@@ -77,6 +77,7 @@ export function dispose(id) {
         msg.items.forEach(item => {
             if (item.animationId) {
                 cancelAnimationFrame(item.animationId);
+                item.animationId = null;
             }
         });
     }

--- a/src/BootstrapBlazor/Components/Message/Message.razor.js
+++ b/src/BootstrapBlazor/Components/Message/Message.razor.js
@@ -16,12 +16,12 @@ export function show(id, msgId) {
 
     let msgItem = msg.items.find(i => i.el.id === msgId)
     if (msgItem === void 0) {
-        msgitem = { el, animationId: null }
+        msgItem = { el, animationId: null }
         msg.items.push(msgItem)
     }
 
-    if (msgitem.animationId) {
-        cancelAnimationFrame(msgitem.animationId);
+    if (msgItem.animationId) {
+        cancelAnimationFrame(msgItem.animationId);
     }
 
     const autoHide = el.getAttribute('data-bb-autohide') === 'true';

--- a/src/BootstrapBlazor/Components/Message/Message.razor.js
+++ b/src/BootstrapBlazor/Components/Message/Message.razor.js
@@ -15,11 +15,12 @@ export function show(id, msgId) {
     }
 
     const msgItem = { el, animationId: null }
-    msg.items.push(msgItem)
-    const autoHide = el.getAttribute('data-bb-autohide') === 'true';
+    if (msg.items.find(i => i.el.id === msgId) === void 0) {
+        msg.items.push(msgItem)
+    }
 
+    const autoHide = el.getAttribute('data-bb-autohide') === 'true';
     if (autoHide) {
-        // auto close
         const delay = parseInt(el.getAttribute('data-bb-delay'));
         let start = void 0
         const autoCloseAnimation = ts => {
@@ -45,10 +46,8 @@ export function show(id, msgId) {
         const hideHandler = setTimeout(function () {
             clearTimeout(hideHandler);
 
-            // remove Id
             msg.items.pop();
             if (msg.items.length === 0) {
-                // call server method prepare remove dom
                 msg.invoke.invokeMethodAsync(msg.callback);
             }
         }, 500);
@@ -58,9 +57,8 @@ export function show(id, msgId) {
         e.preventDefault();
         e.stopPropagation();
 
-        // trigger on-dismiss event callback
         const alert = e.delegateTarget.closest('.alert');
-        if(alert) {
+        if (alert) {
             const alertId = alert.getAttribute('id');
             msg.invoke.invokeMethodAsync('Dismiss', alertId);
         }

--- a/src/BootstrapBlazor/Components/Message/Message.razor.js
+++ b/src/BootstrapBlazor/Components/Message/Message.razor.js
@@ -14,9 +14,14 @@ export function show(id, msgId) {
         return
     }
 
-    const msgItem = { el, animationId: null }
-    if (msg.items.find(i => i.el.id === msgId) === void 0) {
+    let msgItem = msg.items.find(i => i.el.id === msgId)
+    if (msgItem === void 0) {
+        msgitem = { el, animationId: null }
         msg.items.push(msgItem)
+    }
+
+    if (msgitem.animationId) {
+        cancelAnimationFrame(msgitem.animationId);
     }
 
     const autoHide = el.getAttribute('data-bb-autohide') === 'true';


### PR DESCRIPTION
## Link issues
fixes #6512 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor the message display logic to properly clear and update existing message items when reusing the same option, cancel pending animations, and improve the sample usage to reflect the updated behavior.

Bug Fixes:
- Prevent duplicate message items by reusing existing entries when showing messages with the same ID
- Cancel pending auto-hide animations before re-displaying the same message

Enhancements:
- Update sample code to demonstrate auto-hide and color changes in the message demo