### PR TITLE
fix(DateTimePicker): width overflow when set ViewMode to DateTime

### DIFF
--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -37,7 +37,7 @@
                                 <i class="@PreviousMonthIcon"></i>
                             </button>
                         }
-                        <div class="d-flex align-items-center justify-content-center flex-fill">
+                        <div class="@HeaderLabelString">
                             <span role="button" class="picker-panel-header-label" @onclick="() => SwitchView(DatePickerViewMode.Year)">@YearString</span>
                             <span role="button" class="@CurrentMonthViewClassName" @onclick="() => SwitchView(DatePickerViewMode.Month)">@MonthString</span>
                             @if (IsDateTimeMode)

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -465,6 +465,10 @@ public partial class DatePickerBody
 
     private bool IsDateTimeMode => ViewMode == DatePickerViewMode.DateTime && CurrentViewMode == DatePickerViewMode.DateTime;
 
+    private string? HeaderLabelString => CssBuilder.Default("d-flex align-items-center justify-content-center flex-fill")
+        .AddClass("picker-panel-header-bar", ViewMode == DatePickerViewMode.DateTime)
+        .Build();
+
     private readonly Dictionary<string, List<DateTime>> _monthDisabledDaysCache = [];
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
@@ -1,4 +1,4 @@
-.picker-panel {
+﻿.picker-panel {
     --bb-picker-panel-body-width: 320px;
     --bb-picker-hover-color: #409eff;
     --bb-picker-panel-side-width: 0;
@@ -59,6 +59,12 @@
 
                     &:hover {
                         color: var(--bb-picker-hover-color);
+                    }
+                }
+
+                .picker-panel-header-bar {
+                    .picker-panel-header-label {
+                        font-size: 14px;
                     }
                 }
 


### PR DESCRIPTION
## Link issues
fixes #6589 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Prevent header width overflow in DateTimePicker when ViewMode is DateTime by adding a dedicated CSS class and reducing the header label font size