### PR TITLE
feat(TableColumnFilter): contains filter support case-sensitive

### DIFF
--- a/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/LambdaExtensions.cs
@@ -230,8 +230,9 @@ public static class LambdaExtensions
 
     private static BinaryExpression Contains(this Expression left, Expression right)
     {
-        var method = typeof(string).GetMethod("Contains", [typeof(string)])!;
-        return Expression.AndAlso(Expression.NotEqual(left, Expression.Constant(null)), Expression.Call(left, method, right));
+        var method = typeof(string).GetMethod("Contains", [typeof(string), typeof(StringComparison)])!;
+        var comparison = Expression.Constant(StringComparison.OrdinalIgnoreCase);
+        return Expression.AndAlso(Expression.NotEqual(left, Expression.Constant(null)), Expression.Call(left, method, right, comparison));
     }
 
     #region Count

--- a/test/UnitTest/Extensions/LambadaExtensionsTest.cs
+++ b/test/UnitTest/Extensions/LambadaExtensionsTest.cs
@@ -244,6 +244,10 @@ public class LambadaExtensionsTest : BootstrapBlazorTestBase
         var filter = new FilterKeyValueAction() { FieldKey = "Name", FieldValue = "test", FilterAction = FilterAction.Contains };
         var invoker = filter.GetFilterLambda<Foo>().Compile();
         Assert.True(invoker.Invoke(new Foo() { Name = "1test1" }));
+        Assert.True(invoker.Invoke(new Foo() { Name = "1Test1" }));
+        Assert.True(invoker.Invoke(new Foo() { Name = "1Test123" }));
+        Assert.True(invoker.Invoke(new Foo() { Name = "Test" }));
+        Assert.True(invoker.Invoke(new Foo() { Name = "Test2" }));
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #6625 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enable and test case-insensitive string comparison for the Contains filter, addressing issue #6625

Bug Fixes:
- Fix Contains filter not matching values with differing letter cases

Enhancements:
- Enable case-insensitive matching for the Contains filter by using the StringComparison.OrdinalIgnoreCase overload

Tests:
- Add unit tests to verify case-insensitive Contains filter behavior