### PR TITLE
feat(DateTimePicker): add PickTimeMode parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/DateTimePickers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/DateTimePickers.razor
@@ -5,7 +5,7 @@
 <h4>@Localizer["Description"]</h4>
 
 <DemoBlock Title="@Localizer["DateTimePickerTitle"]" Introduction="@Localizer["DateTimePickerIntro"]" Name="DateTimePicker">
-    <DateTimePicker ViewMode="DatePickerViewMode.DateTime"
+    <DateTimePicker ViewMode="DatePickerViewMode.DateTime" TimeFormat="hh\:mm"
                     Value="@DateTimePickerValue" OnValueChanged="@TimePickerValueChanged">
         <TimePickerSetting ShowClockScale="true" IsAutoSwitch="false" />
     </DateTimePicker>

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.9.3</Version>
+    <Version>9.10.0-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -165,6 +165,16 @@
             </div>
         </div>
     </div>
+    @if (true)
+    {
+        <div class="@TimePickerClassString">
+            <span>@TimePlaceHolder</span>
+            <input type="text" autocomplete="off" readonly class="form-control"
+                   value="@CurrentTime.ToString(TimeFormat)"
+                   @onclick="@OnShowTimePicker" />
+            <TimePicker Value="CurrentTime" OnClose="OnCloseTime" OnConfirm="OnConfirmTime"></TimePicker>
+        </div>
+    }
     @if (ShowFooter)
     {
         <div class="picker-panel-footer">

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -40,7 +40,7 @@
                         <div class="@HeaderLabelString">
                             <span role="button" class="picker-panel-header-label" @onclick="() => SwitchView(DatePickerViewMode.Year)">@YearString</span>
                             <span role="button" class="@CurrentMonthViewClassName" @onclick="() => SwitchView(DatePickerViewMode.Month)">@MonthString</span>
-                            @if (IsDateTimeMode)
+                            @if (IsDateTimeMode && PickTimeMode == DateTimePickerTimeMode.PickTimeByClock)
                             {
                                 <span role="button" class="picker-panel-header-label" @onclick="SwitchTimeView">@CurrentTime.ToString(TimeFormat)</span>
                             }
@@ -165,7 +165,7 @@
             </div>
         </div>
     </div>
-    @if (true)
+    @if (IsDateTimeMode && PickTimeMode == DateTimePickerTimeMode.PickTimeByDropdown)
     {
         <div class="@TimePickerClassString">
             <span>@TimePlaceHolder</span>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -172,7 +172,9 @@
             <input type="text" autocomplete="off" readonly class="form-control"
                    value="@CurrentTime.ToString(TimeFormat)"
                    @onclick="@OnShowTimePicker" />
-            <TimePicker Value="CurrentTime" OnClose="OnCloseTime" OnConfirm="OnConfirmTime"></TimePicker>
+            <TimePicker Value="CurrentTime" HasSeconds="HasSeconds()"
+                        ShowRequired="false" ShowLabel="false" SkipValidate="true"
+                        OnClose="OnCloseTime" OnConfirm="OnConfirmTime"></TimePicker>
         </div>
     }
     @if (ShowFooter)

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -40,7 +40,7 @@
                         <div class="@HeaderLabelString">
                             <span role="button" class="picker-panel-header-label" @onclick="() => SwitchView(DatePickerViewMode.Year)">@YearString</span>
                             <span role="button" class="@CurrentMonthViewClassName" @onclick="() => SwitchView(DatePickerViewMode.Month)">@MonthString</span>
-                            @if (IsDateTimeMode && PickTimeMode == DateTimePickerTimeMode.PickTimeByClock)
+                            @if (IsDateTimeMode && PickTimeMode == PickTimeMode.Clock)
                             {
                                 <span role="button" class="picker-panel-header-label" @onclick="SwitchTimeView">@CurrentTime.ToString(TimeFormat)</span>
                             }
@@ -165,14 +165,14 @@
             </div>
         </div>
     </div>
-    @if (IsDateTimeMode && PickTimeMode == DateTimePickerTimeMode.PickTimeByDropdown)
+    @if (IsDateTimeMode && PickTimeMode == PickTimeMode.Dropdown)
     {
         <div class="@TimePickerClassString">
             <span>@TimePlaceHolder</span>
             <input type="text" autocomplete="off" readonly class="form-control"
                    value="@CurrentTime.ToString(TimeFormat)"
                    @onclick="@OnShowTimePicker" />
-            <TimePicker Value="CurrentTime" HasSeconds="HasSeconds()"
+            <TimePicker Value="CurrentTime" HasSeconds="HasSeconds"
                         ShowRequired="false" ShowLabel="false" SkipValidate="true"
                         OnClose="OnCloseTime" OnConfirm="OnConfirmTime"></TimePicker>
         </div>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -155,7 +155,8 @@
                         @ChildContent
                     </CascadingValue>
                     <CascadingValue Value="this" IsFixed="true">
-                        <ClockPicker Value="CurrentTime" OnValueChanged="OnTimeChanged" @ref="TimePickerPanel" class="clock-panel-body"
+                        <ClockPicker @ref="TimePickerPanel" class="clock-panel-body"
+                                     Value="CurrentTime" OnValueChanged="OnTimeChanged" 
                                      ShowClockScale="TimePickerOption.ShowClockScale" IsAutoSwitch="TimePickerOption.IsAutoSwitch"
                                      ShowMinute="TimePickerOption.ShowMinute" ShowSecond="TimePickerOption.ShowSecond">
                         </ClockPicker>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor
@@ -80,12 +80,12 @@
                                                 else if (IsDisabled(day))
                                                 {
                                                     <span class="cell">
-                                                        @if(ShowLunar)
+                                                        @if (ShowLunar)
                                                         {
                                                             <span>@text</span>
                                                             <span class="bb-picker-body-lunar-text">@GetLunarText(day)</span>
                                                         }
-                                                        else if(DayDisabledTemplate != null)
+                                                        else if (DayDisabledTemplate != null)
                                                         {
                                                             @DayDisabledTemplate(day)
                                                         }

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -597,6 +597,7 @@ public partial class DatePickerBody
     /// </summary>
     private async Task OnClickPrevYear()
     {
+        _showTimePicker = false;
         CurrentDate = CurrentViewMode == DatePickerViewMode.Year
             ? GetSafeYearDateTime(CurrentDate, -20)
             : GetSafeYearDateTime(CurrentDate, -1);
@@ -616,6 +617,7 @@ public partial class DatePickerBody
     /// </summary>
     private async Task OnClickPrevMonth()
     {
+        _showTimePicker = false;
         CurrentDate = CurrentDate.GetSafeMonthDateTime(-1);
 
         _render = false;
@@ -633,6 +635,7 @@ public partial class DatePickerBody
     /// </summary>
     private async Task OnClickNextYear()
     {
+        _showTimePicker = false;
         CurrentDate = CurrentViewMode == DatePickerViewMode.Year
             ? GetSafeYearDateTime(CurrentDate, 20)
             : GetSafeYearDateTime(CurrentDate, 1);
@@ -652,6 +655,7 @@ public partial class DatePickerBody
     /// </summary>
     private async Task OnClickNextMonth()
     {
+        _showTimePicker = false;
         CurrentDate = CurrentDate.GetSafeMonthDateTime(1);
 
         _render = false;
@@ -738,6 +742,7 @@ public partial class DatePickerBody
     /// <param name="view"></param>
     private async Task SwitchView(DatePickerViewMode view)
     {
+        _showTimePicker = false;
         if (AllowSwitchModes[ViewMode].Contains(view))
         {
             CurrentViewMode = view;

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -391,6 +391,12 @@ public partial class DatePickerBody
     [Parameter]
     public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Sunday;
 
+    /// <summary>
+    /// 获得/设置 选择时间方式 默认使用 <see cref="DateTimePickerTimeMode.PickTimeByDropdown"/>
+    /// </summary>
+    [Parameter]
+    public DateTimePickerTimeMode PickTimeMode { get; set; } = DateTimePickerTimeMode.PickTimeByDropdown;
+
     [Inject]
     [NotNull]
     private ICalendarFestivals? CalendarFestivals { get; set; }

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -392,10 +392,10 @@ public partial class DatePickerBody
     public DayOfWeek FirstDayOfWeek { get; set; } = DayOfWeek.Sunday;
 
     /// <summary>
-    /// 获得/设置 选择时间方式 默认使用 <see cref="DateTimePickerTimeMode.PickTimeByDropdown"/>
+    /// 获得/设置 选择时间方式 默认使用 <see cref="PickTimeMode.Dropdown"/>
     /// </summary>
     [Parameter]
-    public DateTimePickerTimeMode PickTimeMode { get; set; } = DateTimePickerTimeMode.PickTimeByDropdown;
+    public PickTimeMode PickTimeMode { get; set; } = PickTimeMode.Dropdown;
 
     [Inject]
     [NotNull]
@@ -707,18 +707,12 @@ public partial class DatePickerBody
 
     private bool _showTimePicker;
 
-    private async Task OnConfirmTime(TimeSpan time)
+    private Task OnConfirmTime(TimeSpan time)
     {
         _showTimePicker = false;
         CurrentTime = time;
-        if (ShouldConfirm)
-        {
-            await ClickConfirmButton();
-        }
-        else
-        {
-            StateHasChanged();
-        }
+        StateHasChanged();
+        return Task.CompletedTask;
     }
 
     private Task OnCloseTime()
@@ -734,15 +728,7 @@ public partial class DatePickerBody
         StateHasChanged();
     }
 
-    private bool HasSeconds()
-    {
-        if (TimeFormat != null)
-        {
-            return TimeFormat.Contains('s');
-        }
-
-        return TimePickerOption.ShowSecond;
-    }
+    private bool HasSeconds => TimeFormat.Contains('s');
 
     private bool ShouldConfirm => !IsDateTimeMode && (AutoClose || ShowFooter == false);
 

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -691,6 +691,39 @@ public partial class DatePickerBody
         }
     }
 
+    private string? TimePickerClassString => CssBuilder.Default("picker-panel-time")
+        .AddClass("show", _showTimePicker)
+        .Build();
+
+    private bool _showTimePicker;
+
+    private async Task OnConfirmTime(TimeSpan time)
+    {
+        _showTimePicker = false;
+        CurrentTime = time;
+        if (ShouldConfirm)
+        {
+            await ClickConfirmButton();
+        }
+        else
+        {
+            StateHasChanged();
+        }
+    }
+
+    private Task OnCloseTime()
+    {
+        _showTimePicker = false;
+        StateHasChanged();
+        return Task.CompletedTask;
+    }
+
+    private void OnShowTimePicker()
+    {
+        _showTimePicker = true;
+        StateHasChanged();
+    }
+
     private bool ShouldConfirm => !IsDateTimeMode && (AutoClose || ShowFooter == false);
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -45,10 +45,7 @@ public partial class DatePickerBody
     /// </summary>
     private DateTime SelectValue { get; set; }
 
-    /// <summary>
-    /// 获得/设置 是否显示时刻选择框
-    /// </summary>
-    private bool ShowTimePicker { get; set; }
+    private bool _showClockPicker;
 
     private string? ClassString => CssBuilder.Default("picker-panel")
         .AddClass("is-sidebar", ShowSidebar)
@@ -71,7 +68,7 @@ public partial class DatePickerBody
         .Build();
 
     private string? WrapperClassString => CssBuilder.Default("picker-panel-body-main-wrapper")
-        .AddClass("is-open", ShowTimePicker)
+        .AddClass("is-open", _showClockPicker)
         .Build();
 
     private bool IsDisabled(DateTime day) => day < MinValue || day > MaxValue || IsDisableDay(day);
@@ -720,12 +717,13 @@ public partial class DatePickerBody
 
     private void SwitchTimeView()
     {
-        ShowTimePicker = true;
+        _showClockPicker = true;
     }
 
     internal void SwitchDateView()
     {
-        ShowTimePicker = false;
+        _showClockPicker = false;
+        _showTimePicker = false;
         StateHasChanged();
     }
 
@@ -851,7 +849,8 @@ public partial class DatePickerBody
     private async Task ClickClearButton()
     {
         // 关闭 TimerPicker
-        ShowTimePicker = false;
+        _showClockPicker = false;
+        _showTimePicker = false;
 
         CurrentDate = DateTime.MinValue;
         CurrentTime = TimeSpan.Zero;
@@ -876,7 +875,8 @@ public partial class DatePickerBody
     private void ResetTimePickerPanel()
     {
         // 关闭 TimerPicker
-        ShowTimePicker = false;
+        _showClockPicker = false;
+        _showTimePicker = false;
 
         TimePickerPanel?.Reset();
     }

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -734,6 +734,16 @@ public partial class DatePickerBody
         StateHasChanged();
     }
 
+    private bool HasSeconds()
+    {
+        if (TimeFormat != null)
+        {
+            return TimeFormat.Contains('s');
+        }
+
+        return TimePickerOption.ShowSecond;
+    }
+
     private bool ShouldConfirm => !IsDateTimeMode && (AutoClose || ShowFooter == false);
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
@@ -335,6 +335,7 @@
         width: 178px;
         cursor: pointer;
         padding: 3px 8px;
+        text-align: center;
     }
 
     .bb-time-picker {

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
@@ -91,8 +91,11 @@
                 table {
                     table-layout: fixed;
                     width: 100%;
-                    font-size: 12px;
                     user-select: none;
+
+                    .date-table-row {
+                        font-size: 12px;
+                    }
 
                     td {
                         text-align: center;

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
@@ -322,6 +322,31 @@
     }
 }
 
+.picker-panel-time {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: nowrap;
+    padding: 4px 1rem;
+    border-top: var(--bs-border-width) solid var(--bs-border-color);
+    position: relative;
+
+    .form-control {
+        font-size: 12px;
+        width: 178px;
+        cursor: pointer;
+    }
+
+    .bb-time-picker {
+        position: absolute;
+        bottom: 2.5rem;
+        right: 1rem;
+    }
+
+    &:not(.show) .bb-time-picker {
+        display: none;
+    }
+}
+
 .picker-panel-footer {
     border-top: var(--bs-border-width) solid var(--bs-border-color);
     padding: 4px;

--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.scss
@@ -331,9 +331,10 @@
     position: relative;
 
     .form-control {
-        font-size: 12px;
+        font-size: 14px;
         width: 178px;
         cursor: pointer;
+        padding: 3px 8px;
     }
 
     .bb-time-picker {

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor
@@ -8,7 +8,9 @@
     <BootstrapLabel required="@Required" for="@Id" ShowLabelTooltip="ShowLabelTooltip" Value="@DisplayText" />
 }
 <div @attributes="@AdditionalAttributes" tabindex="@TabIndexString" id="@Id" class="@ClassString" data-bb-dropdown=".picker-panel">
-    <input readonly="@ReadonlyString" class="@InputClassName" @bind="@CurrentValueAsString" placeholder="@PlaceholderString" disabled="@Disabled" data-bs-toggle="@Constants.DropdownToggleString" data-bs-placement="@PlacementString" data-bs-custom-class="@CustomClassString" @onblur="OnBlur" />
+    <input readonly="@ReadonlyString" class="@InputClassName" @bind="@CurrentValueAsString" placeholder="@PlaceholderString"
+           disabled="@Disabled" data-bs-toggle="@Constants.DropdownToggleString" data-bs-placement="@PlacementString"
+           data-bs-custom-class="@CustomClassString" @onblur="OnBlur" />
     @if (ShowIcon)
     {
         <i class="@DateTimePickerIconClassString"></i>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor
@@ -21,7 +21,7 @@
                     ShowLunar="ShowLunar" ShowSolarTerm="ShowSolarTerm" ShowFestivals="ShowFestivals" ShowHolidays="ShowHolidays"
                     OnConfirm="OnConfirm" OnClear="OnClear" MinValue="MinValue" MaxValue="MaxValue"
                     AutoClose="AutoClose" ViewMode="ViewMode" DayTemplate="DayTemplate!" DayDisabledTemplate="DayDisabledTemplate!"
-                    OnGetDisabledDaysCallback="OnGetDisabledDaysCallback!"
+                    PickTimeMode="PickTimeMode" OnGetDisabledDaysCallback="OnGetDisabledDaysCallback!"
                     EnableDisabledDaysCache="EnableDisabledDaysCache">
         @ChildContent
     </DatePickerBody>

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePicker.razor.cs
@@ -119,6 +119,12 @@ public partial class DateTimePicker<TValue>
     public DatePickerViewMode ViewMode { get; set; } = DatePickerViewMode.Date;
 
     /// <summary>
+    /// 获得/设置 选择时间方式 默认使用 <see cref="PickTimeMode.Dropdown"/>
+    /// </summary>
+    [Parameter]
+    public PickTimeMode PickTimeMode { get; set; } = PickTimeMode.Dropdown;
+
+    /// <summary>
     /// 获得/设置 是否显示快捷侧边栏 默认不显示
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/DateTimePicker/DateTimePickerTimeMode.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DateTimePickerTimeMode.cs
@@ -1,0 +1,22 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+namespace BootstrapBlazor.Components;
+
+/// <summary>
+/// <see cref="DateTimePicker{TValue}"/> 组件选择时间方式枚举
+/// </summary>
+public enum DateTimePickerTimeMode
+{
+    /// <summary>
+    /// 使用 Dropdown 下拉方式选择时间
+    /// </summary>
+    PickTimeByDropdown,
+
+    /// <summary>
+    /// 使用 Clock 拖拽指针方式选择时间
+    /// </summary>
+    PickTimeByClock
+}

--- a/src/BootstrapBlazor/Components/DateTimePicker/PickTimeMode.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/PickTimeMode.cs
@@ -8,15 +8,15 @@ namespace BootstrapBlazor.Components;
 /// <summary>
 /// <see cref="DateTimePicker{TValue}"/> 组件选择时间方式枚举
 /// </summary>
-public enum DateTimePickerTimeMode
+public enum PickTimeMode
 {
     /// <summary>
     /// 使用 Dropdown 下拉方式选择时间
     /// </summary>
-    PickTimeByDropdown,
+    Dropdown,
 
     /// <summary>
     /// 使用 Clock 拖拽指针方式选择时间
     /// </summary>
-    PickTimeByClock
+    Clock
 }

--- a/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
@@ -322,10 +322,10 @@ public partial class DateTimeRange
 
         SidebarItems ??=
         [
-            new() { Text = Localizer["Last7Days"], StartDateTime = DateTime.Today.AddDays(-7), EndDateTime = DateTime.Today.AddDays(1).AddSeconds(-1) },
-            new() { Text = Localizer["Last30Days"], StartDateTime = DateTime.Today.AddDays(-30), EndDateTime = DateTime.Today.AddDays(1).AddSeconds(-1) },
-            new() { Text = Localizer["ThisMonth"], StartDateTime = DateTime.Today.AddDays(1 - DateTime.Today.Day), EndDateTime = DateTime.Today.AddDays(1 - DateTime.Today.Day).AddMonths(1).AddSeconds(-1) },
-            new() { Text = Localizer["LastMonth"], StartDateTime = DateTime.Today.AddDays(1- DateTime.Today.Day).AddMonths(-1), EndDateTime = DateTime.Today.AddDays(1- DateTime.Today.Day).AddSeconds(-1) },
+            new() { Text = Localizer["Last7Days"], StartDateTime = DateTime.Today.AddDays(-7), EndDateTime = DateTime.Today.AddDays(1).AddMilliseconds(-1) },
+            new() { Text = Localizer["Last30Days"], StartDateTime = DateTime.Today.AddDays(-30), EndDateTime = DateTime.Today.AddDays(1).AddMilliseconds(-1) },
+            new() { Text = Localizer["ThisMonth"], StartDateTime = DateTime.Today.AddDays(1 - DateTime.Today.Day), EndDateTime = DateTime.Today.AddDays(1 - DateTime.Today.Day).AddMonths(1).AddMilliseconds(-1) },
+            new() { Text = Localizer["LastMonth"], StartDateTime = DateTime.Today.AddDays(1- DateTime.Today.Day).AddMonths(-1), EndDateTime = DateTime.Today.AddDays(1- DateTime.Today.Day).AddMilliseconds(-1) },
         ];
 
         ResetBodyValue();
@@ -478,7 +478,7 @@ public partial class DateTimeRange
             // 结束时间为空
             if (d < SelectedValue.Start)
             {
-                SelectedValue.End = SelectedValue.Start;
+                SelectedValue.End = SelectedValue.Start.AddDays(1).AddMilliseconds(-1);
                 SelectedValue.Start = d;
             }
             else

--- a/src/BootstrapBlazor/Components/TimePicker/TimePicker.razor
+++ b/src/BootstrapBlazor/Components/TimePicker/TimePicker.razor
@@ -15,7 +15,3 @@
         <button type="button" class="btn time-panel-btn confirm" @onclick="@OnClickConfirm">@ConfirmButtonText</button>
     </div>
 </div>
-
-@code {
-
-}

--- a/test/UnitTest/Components/DateTimePickerTest.cs
+++ b/test/UnitTest/Components/DateTimePickerTest.cs
@@ -322,6 +322,7 @@ public class DateTimePickerTest : BootstrapBlazorTestBase
         {
             builder.Add(a => a.Value, new DateTime(2023, 10, 1, 1, 0, 0));
             builder.Add(a => a.ViewMode, DatePickerViewMode.DateTime);
+            builder.Add(a => a.PickTimeMode, PickTimeMode.Clock);
         });
 
         var labels = cut.FindAll(".picker-panel-header-label");
@@ -352,6 +353,39 @@ public class DateTimePickerTest : BootstrapBlazorTestBase
         Assert.ThrowsAny<InvalidOperationException>(() =>
         {
             Context.RenderComponent<DateTimePicker<int>>();
+        });
+    }
+
+    [Fact]
+    public async Task PickTimeMode_Ok()
+    {
+        var cut = Context.RenderComponent<DatePickerBody>(builder =>
+        {
+            builder.Add(a => a.ViewMode, DatePickerViewMode.DateTime);
+            builder.Add(a => a.PickTimeMode, PickTimeMode.Dropdown);
+            builder.Add(a => a.ShowFooter, true);
+            builder.Add(a => a.Value, DateTime.Today.AddDays(-1));
+            builder.Add(a => a.TimeFormat, "hh\\:mm");
+        });
+
+        cut.Contains("picker-panel-time");
+
+        // 点击时间选择器
+        var input = cut.Find(".picker-panel-time .form-control");
+        await cut.InvokeAsync(() => input.Click());
+        cut.Contains("picker-panel-time show");
+
+        // 点击时间选择器下拉框中的确定按钮
+        var picker = cut.FindComponent<TimePicker>();
+        await cut.InvokeAsync(() => picker.Instance.OnClose!());
+
+        var ts = DateTime.Now.TimeOfDay;
+        await cut.InvokeAsync(() => picker.Instance.OnConfirm!(ts));
+        Assert.Contains(ts.ToString("hh\\:mm"), cut.Markup);
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.TimeFormat, null);
         });
     }
     #endregion


### PR DESCRIPTION
## Link issues
fixes #6669 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enable configurable time picking modes in DateTimePicker by adding PickTimeMode parameter and corresponding enum, implement dropdown-based time picker UI alongside existing clock picker, fix DateTimeRange end-of-day logic, and update demo sample.

New Features:
- Add PickTimeMode parameter to DateTimePicker to toggle between clock and dropdown time picking
- Introduce DateTimePickerTimeMode enum

Bug Fixes:
- Fix DateTimeRange default end-of-day calculation to use milliseconds rather than seconds
- Ensure end value resets to full day when start is after end

Enhancements:
- Separate flags and handlers for clock and dropdown pickers and conditionally render them
- Add dropdown time picker panel with SCSS styling and improved markup formatting

Documentation:
- Update sample to include TimeFormat usage