### PR TITLE
doc(MaskOption): update ZIndex documentation

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Masks.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Masks.razor
@@ -6,6 +6,9 @@
 <h4>@Localizer["MaskDescription"]</h4>
 
 <DemoBlock Title="@Localizer["MaskNormalTitle"]" Introduction="@Localizer["MaskNormalIntro"]" Name="Normal">
+    <section ignore>
+        <div>@((MarkupString)Localizer["MaskNormalDesc"].Value)</div>
+    </section>
     <button class="btn btn-primary" @onclick="@ShowMask">@Localizer["ShowMaskButtonText"]</button>
 </DemoBlock>
 

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -456,6 +456,7 @@
     "MaskDescription": "By calling the service display and hide methods, a mask layer is displayed to mask the data.",
     "MaskNormalTitle": "Basic usage",
     "MaskNormalIntro": "Call the <code>MaskService</code> mask service example method <code>Show</code> to display a mask, and call the instance method <code>Close</code> to close the mask after 3 seconds",
+    "MaskNormalDesc": "You can adjust the <code>ZIndex</code> <code>Opacity</code> <code>BackgroundColor</code> parameters via <code>MaskOption</code>",
     "ShowMaskButtonText": "Show",
     "MaskContainerTitle": "Container",
     "MaskContainerIntro": "Specify the mask position by setting the <code>MaskOption</code> parameter <code>ContainerId</code>",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -456,6 +456,7 @@
     "MaskDescription": "通过调用服务显示，隐藏方法，显示一个遮罩层对数据进行遮罩操作",
     "MaskNormalTitle": "基本用法",
     "MaskNormalIntro": "调用 <code>MaskService</code> 遮罩服务示例方法 <code>Show</code> 方法显示一个遮罩，3 秒后调用实例方法 <code>Close</code> 关闭遮罩",
+    "MaskNormalDesc": "可以通过 <code>MaskOption</code> 调整 <code>ZIndex</code> <code>Opacity</code> <code>BackgroundColor</code> 参数",
     "ShowMaskButtonText": "打开",
     "MaskContainerTitle": "指定容器",
     "MaskContainerIntro": "通过设置 <code>MaskOption</code> 参数 <code>ContainerId</code> 指定遮罩出现位置",


### PR DESCRIPTION
## Link issues
fixes #6674 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update MaskOption documentation to incorporate ZIndex details by extending the Razor demo with a hidden description block and refreshing locale strings.

Enhancements:
- Add a hidden description section in the Mask demo to render the localized MaskNormalDesc value

Documentation:
- Update en-US.json and zh-CN.json locale files with MaskNormalDesc entries for ZIndex documentation