### PR TITLE
feat(SelectTree): add auto active value function

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/SelectTrees.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/SelectTrees.razor
@@ -50,7 +50,10 @@
 
 <DemoBlock Title="@Localizer["SelectTreesEditTitle"]"
            Introduction="@Localizer["SelectTreesEditIntro"]"
-           Name="Edit">
+           Name="IsEditable">
+    <section ignore>
+        <div>@((MarkupString)Localizer["SelectTreesEditDesc"].Value)</div>
+    </section>
     <div class="row g-3">
         <div class="col-12 col-sm-6">
             <SelectTree Items="EditItems" @bind-Value="@Value" IsEditable="true"></SelectTree>

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -4891,6 +4891,7 @@
     "SelectTreesClientValidationIntro": "validate the value when submit the form. Inside <code>ValidateForm</code>",
     "SelectTreesEditTitle": "Edit",
     "SelectTreesEditIntro": "By setting <code>IsEditable=\"true\"</code> you can edit the input textbox",
+    "SelectTreesEditDesc": "After setting <code>IsEditable=\"true\"</code>, the content displayed in the text box is the <code>Value</code> value of the node selected in the <code>TreeView</code>, the input value may not be in the <code>Items</code> collection",
     "SelectTreesIsPopoverTitle": "IsPopover",
     "SelectTreesIsPopoverIntro": "Set <code>IsPopover</code> to <b>true</b>, use popover render UI prevent The dropdown menu cannot be fully displayed because the parent container is set to <code>overflow: hidden</code>",
     "SelectTreesClientValidationButtonText": "Submit"

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -4893,6 +4893,7 @@
     "SelectTreesClientValidationIntro": "组件内置 <code>ValidateForm</code> 可设置验证规则",
     "SelectTreesEditTitle": "可输入",
     "SelectTreesEditIntro": "通过设置 <code>IsEditable=\"true\"</code> 可设置下拉框选择后文本框可输入",
+    "SelectTreesEditDesc": "设置 <code>IsEditable=\"true\"</code> 后，文本框显示的内容为 <code>TreeView</code> 选中节点的 <code>Value</code> 值，输入值可以不在 <code>Items</code> 集合中",
     "SelectTreesIsPopoverTitle": "悬浮弹窗",
     "SelectTreesIsPopoverIntro": "通过设置 <code>IsPopover</code> 参数，组件使用 <code>popover</code> 渲染 <code>UI</code> 防止由于父容器设置 <code>overflow: hidden;</code> 使弹窗无法显示问题",
     "SelectTreesClientValidationButtonText": "提交"

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor
@@ -20,7 +20,7 @@
         <span class="@AppendClassName"><i class="@DropdownIcon"></i></span>
     </div>
     <div class="dropdown-menu">
-        <TreeView TItem="TValue" Items="@Items" ShowIcon="ShowIcon"
+        <TreeView TItem="TValue" Items="@Items" ShowIcon="ShowIcon" @ref="_tv"
                   OnTreeItemClick="OnItemClick" ModelEqualityComparer="@ModelEqualityComparer"
                   ShowSearch="ShowSearch" ShowResetSearchButton="ShowResetSearchButton"
                   CanExpandWhenDisabled="CanExpandWhenDisabled"

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
@@ -68,9 +68,7 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
     /// </summary>
     [Parameter]
     [NotNull]
-#if NET6_0_OR_GREATER
     [EditorRequired]
-#endif
     public List<TreeViewItem<TValue>>? Items { get; set; }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
@@ -166,6 +166,7 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
     private TreeViewItem<TValue>? _selectedItem;
     private List<TreeViewItem<TValue>>? _itemCache;
     private List<TreeViewItem<TValue>>? _expandedItemsCache;
+    private TreeView<TValue> _tv = default!;
 
     private string? SelectTreeCustomClassString => CssBuilder.Default(CustomClassString)
         .AddClass("select-tree", IsPopover)
@@ -233,6 +234,12 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
         if (args.Value is string v)
         {
             CurrentValueAsString = v;
+
+            // 选中节点更改为当前值
+            if(_tv != null)
+            {
+                _tv.SetActiveItem(Value);
+            }
         }
     }
 

--- a/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTree.razor.cs
@@ -236,10 +236,7 @@ public partial class SelectTree<TValue> : IModelEqualityComparer<TValue>
             CurrentValueAsString = v;
 
             // 选中节点更改为当前值
-            if(_tv != null)
-            {
-                _tv.SetActiveItem(Value);
-            }
+            _tv.SetActiveItem(Value);
         }
     }
 


### PR DESCRIPTION
## Link issues
fixes #6684 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enable SelectTree to automatically set the active tree node when its bound value changes, remove obsolete conditional directive on the Items parameter, and refresh the sample demo accordingly

New Features:
- Automatically activate the corresponding tree node in SelectTree when the bound value changes

Enhancements:
- Remove .NET 6 conditional compilation around the Items parameter in SelectTree

Documentation:
- Update SelectTree sample to reference the internal TreeView via @ref and rename the editable demo block to IsEditable