### PR TITLE
feat(AutoComplete): use javascript update input value

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -12,7 +12,6 @@
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
            data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString" data-bb-trigger-delete="true"
-           @bind="@CurrentValueAsString"
            placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement"/>
     <span class="form-select-append"><i class="@Icon"></i></span>
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -39,7 +39,7 @@
             }
             @if (ShowNoDataTip && Rows.Count == 0)
             {
-                <div class="dropdown-item">@NoDataTip</div>
+                <div class="dropdown-item tip">@NoDataTip</div>
             }
         </div>
     </div>;

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -12,7 +12,6 @@
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
            data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString" data-bb-trigger-delete="true"
-           @bind="@CurrentValueAsString"
            placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement"/>
     <span class="form-select-append"><i class="@Icon"></i></span>
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>
@@ -27,7 +26,7 @@
         <div class="dropdown-menu-body">
             @foreach (var item in Rows)
             {
-                <div @key="item" class="dropdown-item" @onclick="() => OnClickItem(item)">
+                <div @key="item" class="dropdown-item" data-bb-val="@item">
                     @if (ItemTemplate == null)
                     {
                         <div>@item</div>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -39,7 +39,7 @@
             }
             @if (ShowNoDataTip && Rows.Count == 0)
             {
-                <div class="dropdown-item tip">@NoDataTip</div>
+                <div class="dropdown-item">@NoDataTip</div>
             }
         </div>
     </div>;

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -12,6 +12,7 @@
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
            data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString" data-bb-trigger-delete="true"
+           @bind="@CurrentValueAsString"
            placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement"/>
     <span class="form-select-append"><i class="@Icon"></i></span>
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>
@@ -26,7 +27,7 @@
         <div class="dropdown-menu-body">
             @foreach (var item in Rows)
             {
-                <div @key="item" class="dropdown-item" data-bb-val="@item">
+                <div @key="item" class="dropdown-item" @onclick="() => OnClickItem(item)">
                     @if (ItemTemplate == null)
                     {
                         <div>@item</div>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -120,6 +120,12 @@ public partial class AutoComplete
     }
 
     /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, Value);
+
+    /// <summary>
     /// Callback method when a candidate item is clicked
     /// </summary>
     private async Task OnClickItem(string val)
@@ -137,6 +143,9 @@ public partial class AutoComplete
         }
 
         await TriggerFilter(val);
+
+        // 使用脚本更新 input 值
+        await InvokeVoidAsync("setValue", Id, val);
     }
 
     private List<string> Rows => _filterItems ?? [.. Items];

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -129,11 +129,11 @@ public partial class AutoComplete
     /// Callback method when a candidate item is clicked
     /// </summary>
     [JSInvokable]
-    public async Task<string?> TriggerClick(int index)
+    public async Task TriggerClick(int index)
     {
         if (index < 0 || index >= Rows.Count)
         {
-            return null;
+            return;
         }
 
         var item = Rows[index];
@@ -150,7 +150,6 @@ public partial class AutoComplete
         }
 
         await TriggerFilter(Value);
-        return Value;
     }
 
     private List<string> Rows => _filterItems ?? [.. Items];

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -120,15 +120,28 @@ public partial class AutoComplete
     }
 
     /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, Value);
+
+    /// <summary>
     /// Callback method when a candidate item is clicked
     /// </summary>
-    private async Task OnClickItem(string val)
+    [JSInvokable]
+    public async Task TriggerClick(int index)
     {
-        CurrentValue = val;
+        if (index < 0 || index >= Rows.Count)
+        {
+            return;
+        }
+
+        var item = Rows[index];
+        CurrentValueAsString = item;
 
         if (OnSelectedItemChanged != null)
         {
-            await OnSelectedItemChanged(val);
+            await OnSelectedItemChanged(Value);
         }
 
         if (OnBlurAsync != null)
@@ -136,7 +149,7 @@ public partial class AutoComplete
             await OnBlurAsync(Value);
         }
 
-        await TriggerFilter(val);
+        await TriggerFilter(Value);
     }
 
     private List<string> Rows => _filterItems ?? [.. Items];

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -120,28 +120,15 @@ public partial class AutoComplete
     }
 
     /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, Value);
-
-    /// <summary>
     /// Callback method when a candidate item is clicked
     /// </summary>
-    [JSInvokable]
-    public async Task TriggerClick(int index)
+    private async Task OnClickItem(string val)
     {
-        if (index < 0 || index >= Rows.Count)
-        {
-            return;
-        }
-
-        var item = Rows[index];
-        CurrentValueAsString = item;
+        CurrentValue = val;
 
         if (OnSelectedItemChanged != null)
         {
-            await OnSelectedItemChanged(Value);
+            await OnSelectedItemChanged(val);
         }
 
         if (OnBlurAsync != null)
@@ -149,7 +136,7 @@ public partial class AutoComplete
             await OnBlurAsync(Value);
         }
 
-        await TriggerFilter(Value);
+        await TriggerFilter(val);
     }
 
     private List<string> Rows => _filterItems ?? [.. Items];

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -129,11 +129,11 @@ public partial class AutoComplete
     /// Callback method when a candidate item is clicked
     /// </summary>
     [JSInvokable]
-    public async Task TriggerClick(int index)
+    public async Task<string?> TriggerClick(int index)
     {
         if (index < 0 || index >= Rows.Count)
         {
-            return;
+            return null;
         }
 
         var item = Rows[index];
@@ -150,6 +150,7 @@ public partial class AutoComplete
         }
 
         await TriggerFilter(Value);
+        return Value;
     }
 
     private List<string> Rows => _filterItems ?? [.. Items];

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -175,6 +175,14 @@ const handlerKeyup = (ac, e) => {
     }
 }
 
+export function setValue(id, value) {
+    const ac = Data.get(id)
+    const { input } = ac;
+    if (input) {
+        input.value = value;
+    }
+}
+
 export function dispose(id) {
     const ac = Data.get(id)
     Data.remove(id)

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -51,15 +51,24 @@ export function init(id, invoke, value) {
         })
     }
 
-    EventHandler.on(menu, 'click', '.dropdown-item', e => {
+    EventHandler.on(menu, 'click', '.dropdown-item', async e => {
         const item = e.delegateTarget;
+        if (item.classList.contains('tip')) {
+            return;
+        }
+
         const val = item.getAttribute('data-bb-val');
-        input.value = val;
+        if (val) {
+            input.value = val;
+        }
         ac.close();
 
         const items = [...item.parentElement.children];
         const index = items.indexOf(item);
-        invoke.invokeMethodAsync('TriggerClick', index);
+        const text = await invoke.invokeMethodAsync('TriggerClick', index);
+        if (input.value !== text) {
+            input.value = text;
+        }
     });
 
     EventHandler.on(input, 'focus', e => {

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -51,24 +51,15 @@ export function init(id, invoke, value) {
         })
     }
 
-    EventHandler.on(menu, 'click', '.dropdown-item', async e => {
+    EventHandler.on(menu, 'click', '.dropdown-item', e => {
         const item = e.delegateTarget;
-        if (item.classList.contains('tip')) {
-            return;
-        }
-
         const val = item.getAttribute('data-bb-val');
-        if (val) {
-            input.value = val;
-        }
+        input.value = val;
         ac.close();
 
         const items = [...item.parentElement.children];
         const index = items.indexOf(item);
-        const text = await invoke.invokeMethodAsync('TriggerClick', index);
-        if (input.value !== text) {
-            input.value = text;
-        }
+        invoke.invokeMethodAsync('TriggerClick', index);
     });
 
     EventHandler.on(input, 'focus', e => {

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -5,12 +5,14 @@ import EventHandler from "../../modules/event-handler.js"
 import Input from "../../modules/input.js"
 import Popover from "../../modules/base-popover.js"
 
-export function init(id, invoke) {
+export function init(id, invoke, value) {
     const el = document.getElementById(id)
     const menu = el.querySelector('.dropdown-menu')
     const input = document.getElementById(`${id}_input`)
     const ac = { el, invoke, menu, input }
     Data.set(id, ac)
+
+    input.value = value;
 
     const isPopover = input.getAttribute('data-bs-toggle') === 'bb.dropdown';
     if (isPopover) {
@@ -50,7 +52,14 @@ export function init(id, invoke) {
     }
 
     EventHandler.on(menu, 'click', '.dropdown-item', e => {
+        const item = e.delegateTarget;
+        const val = item.getAttribute('data-bb-val');
+        input.value = val;
         ac.close();
+
+        const items = [...item.parentElement.children];
+        const index = items.indexOf(item);
+        invoke.invokeMethodAsync('TriggerClick', index);
     });
 
     EventHandler.on(input, 'focus', e => {
@@ -78,7 +87,6 @@ export function init(id, invoke) {
 
         el.classList.add('is-loading');
         filterCallback(v);
-
     });
 
     ac.show = () => {

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -5,14 +5,12 @@ import EventHandler from "../../modules/event-handler.js"
 import Input from "../../modules/input.js"
 import Popover from "../../modules/base-popover.js"
 
-export function init(id, invoke, value) {
+export function init(id, invoke) {
     const el = document.getElementById(id)
     const menu = el.querySelector('.dropdown-menu')
     const input = document.getElementById(`${id}_input`)
     const ac = { el, invoke, menu, input }
     Data.set(id, ac)
-
-    input.value = value;
 
     const isPopover = input.getAttribute('data-bs-toggle') === 'bb.dropdown';
     if (isPopover) {
@@ -52,14 +50,7 @@ export function init(id, invoke, value) {
     }
 
     EventHandler.on(menu, 'click', '.dropdown-item', e => {
-        const item = e.delegateTarget;
-        const val = item.getAttribute('data-bb-val');
-        input.value = val;
         ac.close();
-
-        const items = [...item.parentElement.children];
-        const index = items.indexOf(item);
-        invoke.invokeMethodAsync('TriggerClick', index);
     });
 
     EventHandler.on(input, 'focus', e => {
@@ -87,6 +78,7 @@ export function init(id, invoke, value) {
 
         el.classList.add('is-loading');
         filterCallback(v);
+
     });
 
     ac.show = () => {

--- a/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
@@ -159,12 +159,6 @@ public abstract class PopoverCompleteBase<TValue> : BootstrapInputBase<TValue>, 
     }
 
     /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop);
-
-    /// <summary>
     /// 触发 OnBlur 回调方法 由 Javascript 触发
     /// </summary>
     [JSInvokable]

--- a/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/PopoverCompleteBase.cs
@@ -159,6 +159,12 @@ public abstract class PopoverCompleteBase<TValue> : BootstrapInputBase<TValue>, 
     }
 
     /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop);
+
+    /// <summary>
     /// 触发 OnBlur 回调方法 由 Javascript 触发
     /// </summary>
     [JSInvokable]

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
@@ -14,7 +14,6 @@
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
            data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString"
-           @bind="@_displayText"
            placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement" />
     <span class="form-select-append"><i class="@Icon"></i></span>
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -184,6 +184,12 @@ public partial class AutoFill<TValue>
         Items ??= [];
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, _displayText);
+
 
     private bool IsNullable() => !ValueType.IsValueType || NullableUnderlyingType != null;
 
@@ -199,6 +205,9 @@ public partial class AutoFill<TValue>
     /// <returns></returns>
     private async Task OnClearValue()
     {
+        // 使用脚本更新 input 值
+        await InvokeVoidAsync("setValue", Id, "");
+
         if (OnClearAsync != null)
         {
             await OnClearAsync();
@@ -234,6 +243,9 @@ public partial class AutoFill<TValue>
         }
 
         await TriggerFilter(_displayText!);
+
+        // 使用脚本更新 input 值
+        await InvokeVoidAsync("setValue", Id, _displayText);
     }
 
     private string? GetDisplayText(TValue item) => OnGetDisplayText?.Invoke(item) ?? item?.ToString();

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -232,6 +232,9 @@ public partial class AutoFill<TValue>
         CurrentValue = val;
         _displayText = GetDisplayText(val);
 
+        // 使用脚本更新 input 值
+        await InvokeVoidAsync("setValue", Id, _displayText);
+
         if (OnSelectedItemChanged != null)
         {
             await OnSelectedItemChanged(val);
@@ -243,9 +246,6 @@ public partial class AutoFill<TValue>
         }
 
         await TriggerFilter(_displayText!);
-
-        // 使用脚本更新 input 值
-        await InvokeVoidAsync("setValue", Id, _displayText);
     }
 
     private string? GetDisplayText(TValue item) => OnGetDisplayText?.Invoke(item) ?? item?.ToString();

--- a/src/BootstrapBlazor/Components/Search/Search.razor
+++ b/src/BootstrapBlazor/Components/Search/Search.razor
@@ -29,7 +29,6 @@
                    data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
                    data-bb-scroll-behavior="@ScrollIntoViewBehaviorString"
                    data-bb-input="@UseInputString"
-                   @bind="@_displayText"
                    placeholder="@PlaceHolder" disabled="@Disabled" @ref="FocusElement" />
             @if (IsClearable)
             {

--- a/src/BootstrapBlazor/Components/Search/Search.razor.cs
+++ b/src/BootstrapBlazor/Components/Search/Search.razor.cs
@@ -209,6 +209,12 @@ public partial class Search<TValue>
         }
     }
 
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <returns></returns>
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, _displayText);
+
     private string? _displayText;
     private async Task OnSearchClick()
     {
@@ -229,6 +235,9 @@ public partial class Search<TValue>
 
     private async Task OnClearClick()
     {
+        // 使用脚本更新 input 值
+        await InvokeVoidAsync("setValue", Id, "");
+
         _displayText = null;
         if (OnClear != null)
         {
@@ -251,6 +260,9 @@ public partial class Search<TValue>
     {
         CurrentValue = val;
         _displayText = GetDisplayText(val);
+
+        // 使用脚本更新 input 值
+        await InvokeVoidAsync("setValue", Id, _displayText);
 
         if (OnSelectedItemChanged != null)
         {

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -212,7 +212,7 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
         });
 
         var item = cut.Find(".dropdown-item");
-        await cut.InvokeAsync(() => item.Click());
+        await cut.InvokeAsync(() => cut.Instance.TriggerClick(0));
         Assert.Equal("test1", selectedItem);
     }
 
@@ -268,8 +268,11 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Instance.TriggerBlur());
         Assert.Equal("test2", val);
 
-        var item = cut.Find(".dropdown-item");
-        await cut.InvokeAsync(() => item.Click());
+        await cut.InvokeAsync(() => cut.Instance.TriggerClick(0));
+        Assert.Equal("test2", val);
+
+        await cut.InvokeAsync(() => cut.Instance.TriggerClick(-1));
+        await cut.InvokeAsync(() => cut.Instance.TriggerClick(10));
     }
 
     [Fact]

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -212,7 +212,7 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
         });
 
         var item = cut.Find(".dropdown-item");
-        await cut.InvokeAsync(() => cut.Instance.TriggerClick(0));
+        await cut.InvokeAsync(() => item.Click());
         Assert.Equal("test1", selectedItem);
     }
 
@@ -268,11 +268,8 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Instance.TriggerBlur());
         Assert.Equal("test2", val);
 
-        await cut.InvokeAsync(() => cut.Instance.TriggerClick(0));
-        Assert.Equal("test2", val);
-
-        await cut.InvokeAsync(() => cut.Instance.TriggerClick(-1));
-        await cut.InvokeAsync(() => cut.Instance.TriggerClick(10));
+        var item = cut.Find(".dropdown-item");
+        await cut.InvokeAsync(() => item.Click());
     }
 
     [Fact]

--- a/test/UnitTest/Components/AutoFillTest.cs
+++ b/test/UnitTest/Components/AutoFillTest.cs
@@ -194,7 +194,7 @@ public class AutoFillTest : BootstrapBlazorTestBase
             pb.Add(a => a.OnGetDisplayText, foo => foo?.Name);
         });
         var input = cut.Find("input");
-        Assert.Equal("张三 1000", input.Attributes["value"]?.Value);
+        Assert.Null(input.Attributes["value"]?.Value);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #6708 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Use JavaScript interop to update input values in AutoComplete, AutoFill, and Search components instead of Blazor bindings, and adjust initialization and tests accordingly.

Bug Fixes:
- Fix #6708 by ensuring input displays correct value via JavaScript after clear or item selection

Enhancements:
- Override InvokeInitAsync in AutoComplete, AutoFill, and Search to call JS init with component ID and initial value
- Introduce a JS setValue function to update input.value for clear and selection actions
- Remove @bind attributes from input elements in AutoComplete, AutoFill, and Search to delegate value updates to JS

Tests:
- Update AutoFill unit test to expect no static value attribute after JS interop takes over

Chores:
- Remove redundant InvokeInitAsync override in PopoverCompleteBase