### PR TITLE
doc(Modbus): add not support wasm documentation

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -81,10 +81,10 @@
     <PackageReference Include="BootstrapBlazor.VideoPlayer" Version="9.0.3" />
     <PackageReference Include="BootstrapBlazor.WinBox" Version="9.0.7" />
     <PackageReference Include="Longbow.Logging" Version="9.0.1" />
-    <PackageReference Include="Longbow.Modbus" Version="9.0.2" />
-    <PackageReference Include="Longbow.Socket" Version="9.0.3" />
+    <PackageReference Include="Longbow.Modbus" Version="9.0.3" />
+    <PackageReference Include="Longbow.Sockets" Version="9.0.0" />
     <PackageReference Include="Longbow.Tasks" Version="9.0.2" />
-    <PackageReference Include="Longbow.TcpSocket" Version="9.0.4" />
+    <PackageReference Include="Longbow.TcpSocket" Version="9.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -81,10 +81,10 @@
     <PackageReference Include="BootstrapBlazor.VideoPlayer" Version="9.0.3" />
     <PackageReference Include="BootstrapBlazor.WinBox" Version="9.0.7" />
     <PackageReference Include="Longbow.Logging" Version="9.0.1" />
-    <PackageReference Include="Longbow.Modbus" Version="9.0.3" />
+    <PackageReference Include="Longbow.Modbus" Version="9.0.4" />
     <PackageReference Include="Longbow.Sockets" Version="9.0.0" />
     <PackageReference Include="Longbow.Tasks" Version="9.0.2" />
-    <PackageReference Include="Longbow.TcpSocket" Version="9.0.6" />
+    <PackageReference Include="Longbow.TcpSocket" Version="9.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -6,6 +6,8 @@
 
 <PackageTips Name="Longbow.Modbus" />
 
+<Tips><div>特别注意：本服务需要 <code>Socket</code> 支持，不支持 <code>wasm</code> 模式</div></Tips>
+
 <p class="code-label">1. 服务注入</p>
 
 <Pre>services.AddModbusFactory();</Pre>

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/SocketFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/SocketFactories.razor
@@ -6,6 +6,8 @@
 
 <PackageTips Name="Longbow.TcpSocket" />
 
+<Tips><div>特别注意：本服务需要 <code>Socket</code> 支持，不支持 <code>wasm</code> 模式</div></Tips>
+
 <p class="code-label">1. 服务注入</p>
 
 <Pre>services.AddTcpSocketFactory();</Pre>


### PR DESCRIPTION
## Link issues
fixes #6740 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add warnings to the Modbus and Socket factory sample components indicating that they require Socket support and are not supported in WASM mode.

Documentation:
- Insert tips in ModbusFactories.razor to note that the service needs Socket support and isn’t available in WASM mode
- Insert tips in SocketFactories.razor to note that the service needs Socket support and isn’t available in WASM mode