### PR TITLE
doc(Modbus): add Benchmark result

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -63,10 +63,19 @@ private IModbusFactory? ModbusFactory { get; set; }</Pre>
 <p>对应 <code>IModbusClient</code> 实例方法如下</p>
 
 <ul class="ul-demo">
-    <li>线圈 (Coils) <code>ReadCoilsAsync</code> <code>WriteCoilAsync</code> <code>WriteMultipleCoilsAsync</code> 最大读取数量 <code>2000</code> 最大写入数量 <code>1968</code></li>
-    <li>离散输入 (Discrete Inputs) <code>ReadInputsAsync</code> 最大读取数量 <code>2000</code></li>
-    <li>输入寄存器 (Input Registers) <code>ReadInputRegistersAsync</code> 最大读取数量 <code>125</code></li>
-    <li>保持寄存器 (Holding Registers) <code>ReadHoldingRegistersAsync</code> <code>WriteRegisterAsync</code> <code>WriteMultipleRegistersAsync</code> 最大读取数量 <code>125</code> 最大写入数量 <code>123</code></li>
+    <li>线圈 (Coils) <code>ReadCoilsAsync</code> <code>WriteCoilAsync</code> <code>WriteMultipleCoilsAsync</code></li>
+    <li>离散输入 (Discrete Inputs) <code>ReadInputsAsync</code></li>
+    <li>输入寄存器 (Input Registers) <code>ReadInputRegistersAsync</code></li>
+    <li>保持寄存器 (Holding Registers) <code>ReadHoldingRegistersAsync</code> <code>WriteRegisterAsync</code> <code>WriteMultipleRegistersAsync</code></li>
+</ul>
+
+<p>Modbus 协议的最大读取/写入数量限制参考自 Modbus Application Protocol Specification V1.1b3:</p>
+
+<ul class="ul-demo">
+    <li>线圈 (Coils) 最大读取数量: <code>2000</code>, 最大写入数量: <code>1968</code></li>
+    <li>离散输入 (Discrete Inputs) 最大读取数量: <code>2000</code></li>
+    <li>输入寄存器 (Input Registers) 最大读取数量: <code>125</code></li>
+    <li>保持寄存器 (Holding Registers) 最大读取数量: <code>125</code>, 最大写入数量: <code>123</code></li>
 </ul>
 
 <p>项目包含 Benchmark 基准测试工程</p>

--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -115,7 +115,7 @@ public async Task LongbowModbus()
     await Task.WhenAll(tasks);
 }</Pre>
 
-<p>共 10 个 <code>Socket</code> 连接，每个连接 10 个并发任务，每个任务进行 10 次 <code>ReadHoldingRegistersAsync</code> 方法调用，没个方法读取 100 个地址数据</p>
+<p>共 10 个 <code>Socket</code> 连接，每个连接 10 个并发任务，每个任务进行 10 次 <code>ReadHoldingRegistersAsync</code> 方法调用，每个方法读取 100 个地址数据</p>
 
 <p>Benchmark 结果如下：</p>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -63,15 +63,64 @@ private IModbusFactory? ModbusFactory { get; set; }</Pre>
 <p>对应 <code>IModbusClient</code> 实例方法如下</p>
 
 <ul class="ul-demo">
-    <li>线圈 (Coils) <code>ReadCoilsAsync</code> <code>WriteCoilAsync</code> <code>WriteMultipleCoilsAsync</code></li>
-    <li>离散输入 (Discrete Inputs) <code>ReadInputsAsync</code></li>
-    <li>输入寄存器 (Input Registers) <code>ReadInputRegistersAsync</code></li>
-    <li>保持寄存器 (Holding Registers) <code>ReadHoldingRegistersAsync</code> <code>WriteRegisterAsync</code> <code>WriteMultipleRegistersAsync</code></li>
+    <li>线圈 (Coils) <code>ReadCoilsAsync</code> <code>WriteCoilAsync</code> <code>WriteMultipleCoilsAsync</code> 最大读取数量 <code>2000</code> 最大写入数量 <code>1968</code></li>
+    <li>离散输入 (Discrete Inputs) <code>ReadInputsAsync</code> 最大读取数量 <code>2000</code></li>
+    <li>输入寄存器 (Input Registers) <code>ReadInputRegistersAsync</code> 最大读取数量 <code>125</code></li>
+    <li>保持寄存器 (Holding Registers) <code>ReadHoldingRegistersAsync</code> <code>WriteRegisterAsync</code> <code>WriteMultipleRegistersAsync</code> 最大读取数量 <code>125</code> 最大写入数量 <code>123</code></li>
 </ul>
 
-    <pre>Benchmark 结果如下：
-| Method            | Mean    | Error   | StdDev  | Gen0      | Allocated |
-|------------------ |--------:|--------:|--------:|----------:|----------:|
-| LongbowModbus     | 20.36 s | 0.404 s | 0.397 s | 1000.0000 |  15.81 MB |
-| NModbus           | 40.37 s | 0.806 s | 1.734 s | 2000.0000 |   29.6 MB |
-</pre>
+<p>项目包含 Benchmark 基准测试工程</p>
+
+<Pre>private const int NumberOfTask = 10;
+private const int TaskNumberOfClient = 10;
+private const int ClientCount = 10;
+
+private async Task InitLongbowModbus()
+{
+    var sc = new ServiceCollection();
+    sc.AddModbusFactory();
+
+    var provider = sc.BuildServiceProvider();
+    var factory = provider.GetRequiredService&lt;IModbusFactory&gt;();
+
+    for (var index = 0; index &lt; ClientCount; index++)
+    {
+        var client = factory.GetOrCreateTcpMaster();
+        await client.ConnectAsync("127.0.0.1", 502);
+        await client.ReadHoldingRegistersAsync(0x01, 0x00, 100);
+
+        _lgbModbusClients.Add(client);
+    }
+}
+
+[Benchmark]
+public async Task LongbowModbus()
+{
+    var tasks = _lgbModbusClients.SelectMany(c =>
+    {
+        var tasks = new List&lt;Task&gt;();
+        for (int i = 0; i &lt; TaskNumberOfClient; i++)
+        {
+            tasks.Add(Task.Run(async () =&gt;
+            {
+                for (int i = 0; i &lt; NumberOfTask; i++)
+                {
+                    var d = await c.ReadHoldingRegistersAsync(1, 0, 100);
+                }
+            }));
+        }
+        return tasks;
+    }).ToList();
+
+    await Task.WhenAll(tasks);
+}</Pre>
+
+<p>共 10 个 <code>Socket</code> 连接，每个连接 10 个并发任务，每个任务进行 10 次 <code>ReadHoldingRegistersAsync</code> 方法调用，没个方法读取 100 个地址数据</p>
+
+<p>Benchmark 结果如下：</p>
+
+    <Pre>| Method            | Mean    | Error    | StdDev   | Allocated |
+|------------------ |--------:|---------:|---------:|----------:|
+| LongbowModbus     | 2.458 s | 0.0488 s | 0.1007 s |   2.11 MB |
+| NModbus           | 4.752 s | 0.1544 s | 0.4552 s |    3.3 MB |
+</Pre>

--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -68,3 +68,10 @@ private IModbusFactory? ModbusFactory { get; set; }</Pre>
     <li>输入寄存器 (Input Registers) <code>ReadInputRegistersAsync</code></li>
     <li>保持寄存器 (Holding Registers) <code>ReadHoldingRegistersAsync</code> <code>WriteRegisterAsync</code> <code>WriteMultipleRegistersAsync</code></li>
 </ul>
+
+    <pre>Benchmark 结果如下：
+| Method            | Mean    | Error   | StdDev  | Gen0      | Allocated |
+|------------------ |--------:|--------:|--------:|----------:|----------:|
+| LongbowModbus     | 20.36 s | 0.404 s | 0.397 s | 1000.0000 |  15.81 MB |
+| NModbus           | 40.37 s | 0.806 s | 1.734 s | 2000.0000 |   29.6 MB |
+</pre>

--- a/src/BootstrapBlazor.Server/Components/Samples/Sockets/DataEntities.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Sockets/DataEntities.razor
@@ -75,12 +75,16 @@
     }
 }</Pre>
     <p>此处返回值会与参数 <code>Type = typeof(Foo)</code> 做数据合规检查，如果返回值无法转换为指定 <code>Type</code> 时不进行赋值操作，代码逻辑如下</p>
-    <Pre>var attr = p.GetCustomAttribute&lt;DataPropertyConverterAttribute&gt;(false) ?? GetPropertyConverterAttribute(p);
+    <Pre>var attr = p.GetCustomAttribute&lt;DataPropertyConverterAttribute&gt;(false);
 if (attr is { Type: not null })
 {
     var value = attr.ConvertTo(data);
     var valueType = value?.GetType();
-    if (p.PropertyType.IsAssignableFrom(valueType))
+    if (value == null && IsNullable(p.PropertyType))
+    {
+        p.SetValue(entity, null);
+    }
+    else if (p.PropertyType.IsAssignableFrom(valueType))
     {
         p.SetValue(entity, value);
     }


### PR DESCRIPTION
## Link issues
fixes #6752 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Document Modbus client limits and include a performance benchmark comparison, and enhance data conversion logic to support nullable properties.

Bug Fixes:
- Update DataPropertyConverter to set null on nullable properties when conversion returns null

Enhancements:
- Add max read/write quantity details for coils, discrete inputs, input registers, and holding registers in the Modbus sample documentation
- Include a Benchmark project with LongbowModbus sample code and performance comparison against NModbus

Documentation:
- Add benchmark results table and explanatory text to the ModbusFactories sample page

Tests:
- Add a Benchmark method simulating concurrent ReadHoldingRegistersAsync calls across multiple Tcp master clients