### PR TITLE
feat(AutoFill): reuse AutoComplete clear-icon function

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.10.1</Version>
+    <Version>9.10.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
@@ -19,7 +19,7 @@
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>
     @if (GetClearable())
     {
-        <span class="@ClearClassString" @onclick="OnClearValue"><i class="@ClearIcon"></i></span>
+        <span class="@ClearClassString"><i class="@ClearIcon"></i></span>
     }
     <RenderTemplate @ref="_dropdown">
         @RenderDropdown

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -15,13 +15,6 @@ namespace BootstrapBlazor.Components;
 public partial class AutoFill<TValue>
 {
     /// <summary>
-    /// Gets the component style.
-    /// </summary>
-    private string? ClassString => CssBuilder.Default("auto-complete auto-fill")
-        .AddClass("is-clearable", IsClearable)
-        .Build();
-
-    /// <summary>
     /// Gets or sets the collection of items for the component.
     /// </summary>
     [Parameter]
@@ -142,6 +135,13 @@ public partial class AutoFill<TValue>
     private RenderTemplate? _dropdown = null;
 
     /// <summary>
+    /// Gets the component style.
+    /// </summary>
+    private string? ClassString => CssBuilder.Default("auto-complete auto-fill")
+        .AddClass("is-clearable", IsClearable)
+        .Build();
+
+    /// <summary>
     /// Gets the clear icon class string.
     /// </summary>
     private string? ClearClassString => CssBuilder.Default("clear-icon")
@@ -176,7 +176,6 @@ public partial class AutoFill<TValue>
     /// <returns></returns>
     protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, _displayText);
 
-
     private bool IsNullable() => !ValueType.IsValueType || NullableUnderlyingType != null;
 
     /// <summary>
@@ -184,30 +183,6 @@ public partial class AutoFill<TValue>
     /// </summary>
     /// <returns></returns>
     private bool GetClearable() => IsClearable && !IsDisabled && IsNullable();
-
-    /// <summary>
-    /// <inheritdoc/>
-    /// </summary>
-    /// <returns></returns>
-    private async Task OnClearValue()
-    {
-        // 使用脚本更新 input 值
-        await InvokeVoidAsync("setValue", Id, "");
-
-        if (OnClearAsync != null)
-        {
-            await OnClearAsync();
-        }
-        CurrentValue = default;
-        _displayText = null;
-        _filterItems = null;
-        _searchText = null;
-
-        if (OnQueryAsync != null)
-        {
-            await _virtualizeElement.RefreshDataAsync();
-        }
-    }
 
     /// <summary>
     /// Callback method when a candidate item is clicked.
@@ -255,6 +230,18 @@ public partial class AutoFill<TValue>
     [JSInvokable]
     public async Task TriggerFilter(string val)
     {
+        if (string.IsNullOrEmpty(val))
+        {
+            CurrentValue = default;
+            _filterItems = null;
+            _displayText = null;
+
+            if (OnClearAsync != null)
+            {
+                await OnClearAsync();
+            }
+        }
+
         if (OnQueryAsync != null)
         {
             _searchText = val;

--- a/test/UnitTest/Components/AutoFillTest.cs
+++ b/test/UnitTest/Components/AutoFillTest.cs
@@ -425,10 +425,9 @@ public class AutoFillTest : BootstrapBlazorTestBase
         Assert.Equal("2", searchText);
         Assert.Contains("<div>test2</div>", cut.Markup);
 
+        // 测试 Clear 清空逻辑
         query = false;
-        // 点击 Clear 按钮
-        var button = cut.Find(".clear-icon");
-        await cut.InvokeAsync(() => button.Click());
+        await cut.InvokeAsync(() => cut.Instance.TriggerFilter(""));
 
         Assert.True(query);
         Assert.True(cleared);
@@ -445,7 +444,7 @@ public class AutoFillTest : BootstrapBlazorTestBase
                 });
             });
         });
-        await cut.InvokeAsync(() => button.Click());
+        await cut.InvokeAsync(() => cut.Instance.TriggerFilter(""));
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #6762 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Reuse AutoComplete's clear-icon functionality in AutoFill by removing the custom clearing handler and delegating clear events to TriggerFilter, ensuring component state resets correctly when cleared.

Bug Fixes:
- Fix clear behavior in AutoFill to reset component state and invoke OnClearAsync when the filter value is emptied (fixes #6762)

Enhancements:
- Remove the custom OnClearValue method in AutoFill and leverage the shared AutoComplete clear-icon logic

Tests:
- Update unit tests to trigger clear logic via TriggerFilter("") instead of simulating clear-icon clicks