### PR TITLE
doc(Modbus): update IModbusResponse Buffer doc

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -81,7 +81,7 @@
     <PackageReference Include="BootstrapBlazor.VideoPlayer" Version="9.0.3" />
     <PackageReference Include="BootstrapBlazor.WinBox" Version="9.0.7" />
     <PackageReference Include="Longbow.Logging" Version="9.0.1" />
-    <PackageReference Include="Longbow.Modbus" Version="9.0.10" />
+    <PackageReference Include="Longbow.Modbus" Version="9.1.0" />
     <PackageReference Include="Longbow.Sockets" Version="9.0.4" />
     <PackageReference Include="Longbow.Tasks" Version="9.0.2" />
     <PackageReference Include="Longbow.TcpSocket" Version="9.0.12" />

--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -81,10 +81,10 @@
     <PackageReference Include="BootstrapBlazor.VideoPlayer" Version="9.0.3" />
     <PackageReference Include="BootstrapBlazor.WinBox" Version="9.0.7" />
     <PackageReference Include="Longbow.Logging" Version="9.0.1" />
-    <PackageReference Include="Longbow.Modbus" Version="9.0.9" />
+    <PackageReference Include="Longbow.Modbus" Version="9.0.10" />
     <PackageReference Include="Longbow.Sockets" Version="9.0.4" />
     <PackageReference Include="Longbow.Tasks" Version="9.0.2" />
-    <PackageReference Include="Longbow.TcpSocket" Version="9.0.11" />
+    <PackageReference Include="Longbow.TcpSocket" Version="9.0.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -83,7 +83,7 @@ private IModbusFactory? ModbusFactory { get; set; }</Pre>
 <Pre>public interface IModbusResponse
 {
   // 获得 原始数据
-  ReadOnlyMemory&lt;byte&gt; RawData { get; }
+  ReadOnlyMemory&lt;byte&gt; Buffer { get; }
 
   // 获得 Longbow.Modbus.IModbusMessageBuilder 实例
   IModbusMessageBuilder Builder { get; }
@@ -92,11 +92,11 @@ private IModbusFactory? ModbusFactory { get; set; }</Pre>
 <p>通过调用其扩展方法或者 <code>Builder</code> 属性 <code>IModbusMessageBuilder</code> 实例方法</p>
 
 <ul class="ul-demo">
-    <li><code>ReadBoolValues</code> 将 <code>IModbusResponse</code> 实例中 <code>RawData</code> 转换成布尔数组</li>
-    <li><code>ReadUShortValues</code> 将 <code>IModbusResponse</code> 实例中 <code>RawData</code> 转换成无符号短整型数组</li>
+    <li><code>ReadBoolValues</code> 将 <code>IModbusResponse</code> 实例中 <code>Buffer</code> 转换成布尔数组</li>
+    <li><code>ReadUShortValues</code> 将 <code>IModbusResponse</code> 实例中 <code>Buffer</code> 转换成无符号短整型数组</li>
 </ul>
 
-<p>通过接口 <code>IModbusResponse</code> 获得到其原始数据 <code>RawData</code> 可以通过自定义扩展非常方便的扩展出符合自己业务的数据类型。如通过连续 2 个寄存器存储的数据，得到遵循 IEEE 754 标准的 32 位 <b>浮点数</b></p>
+<p>通过接口 <code>IModbusResponse</code> 获得到其原始数据 <code>Buffer</code> 可以通过自定义扩展非常方便的扩展出符合自己业务的数据类型。如通过连续 2 个寄存器存储的数据，得到遵循 IEEE 754 标准的 32 位 <b>浮点数</b></p>
 
 <p><b>注意：</b>在将 <code>RawData</code> 转换为自定义类型（如 32 位浮点数）时，需要注意字节序（Endianness）。字节序会影响数据的解释方式，错误的字节序可能导致解析结果不正确。请根据实际设备或协议规范选择合适的字节序进行转换。</p>
 
@@ -152,6 +152,5 @@ public async Task LongbowModbus()
 
     <Pre>| Method            | Mean    | Error    | StdDev   | Allocated |
 |------------------ |--------:|---------:|---------:|----------:|
-| LongbowModbus     | 2.458 s | 0.0488 s | 0.1007 s |   2.11 MB |
-| NModbus           | 4.752 s | 0.1544 s | 0.4552 s |    3.3 MB |
-</Pre>
+| LongbowModbus     | 2.458 s | 0.0488 s | 0.1007 s |   1.32 MB |
+| NModbus           | 4.752 s | 0.1544 s | 0.4552 s |    3.3 MB |</Pre>

--- a/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Modbus/ModbusFactories.razor
@@ -98,7 +98,7 @@ private IModbusFactory? ModbusFactory { get; set; }</Pre>
 
 <p>通过接口 <code>IModbusResponse</code> 获得到其原始数据 <code>Buffer</code> 可以通过自定义扩展非常方便的扩展出符合自己业务的数据类型。如通过连续 2 个寄存器存储的数据，得到遵循 IEEE 754 标准的 32 位 <b>浮点数</b></p>
 
-<p><b>注意：</b>在将 <code>RawData</code> 转换为自定义类型（如 32 位浮点数）时，需要注意字节序（Endianness）。字节序会影响数据的解释方式，错误的字节序可能导致解析结果不正确。请根据实际设备或协议规范选择合适的字节序进行转换。</p>
+<p><b>注意：</b>在将 <code>Buffer</code> 转换为自定义类型（如 32 位浮点数）时，需要注意字节序（Endianness）。字节序会影响数据的解释方式，错误的字节序可能导致解析结果不正确。请根据实际设备或协议规范选择合适的字节序进行转换。</p>
 
 <p>项目包含 Benchmark 基准测试工程</p>
 


### PR DESCRIPTION
## Link issues
fixes #6779 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update the Modbus sample documentation and benchmarks to reflect renaming the IModbusResponse RawData property to Buffer and correct the reported memory allocation.

Enhancements:
- Adjust the sample benchmark table to show the reduced memory allocation for LongbowModbus

Documentation:
- Rename IModbusResponse.RawData to Buffer in code examples and descriptions
- Update documentation examples for ReadBoolValues and ReadUShortValues to reference Buffer
- Refresh the descriptive paragraph to use Buffer instead of RawData