### PR TITLE
feat(actions): add nuget trusted publishing

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
 
     steps:
     - uses: actions/checkout@v4
@@ -23,13 +24,13 @@ jobs:
 
     - name: NuGet login
       uses: NuGet/login@v1
-      id: nuget-login
+      id: login
       with:
         user: ${{ secrets.NUGET_USER }}
 
     - name: Publish to Nuget
       env:
-        NUGET_API_KEY: ${{steps.nuget-login.outputs.NUGET_API_KEY}}
+        NUGET_API_KEY: ${{steps.login.outputs.NUGET_API_KEY}}
         Bundle: True
 
       run: |

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   pack:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -19,9 +21,15 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
+    - name: NuGet login
+      uses: NuGet/login@v1
+      id: nuget-login
+      with:
+        user: ${{ secrets.NUGET_USER }}
+
     - name: Publish to Nuget
       env:
-        NUGET_API_KEY: ${{secrets.NUGET_API_KEY}}
+        NUGET_API_KEY: ${{steps.nuget-login.outputs.NUGET_API_KEY}}
         Bundle: True
 
       run: |

--- a/BootstrapBlazor.slnx
+++ b/BootstrapBlazor.slnx
@@ -1,4 +1,11 @@
 <Solution>
+  <Folder Name="/actions/">
+    <File Path=".github/workflows/auto-pull-request-checks.yml" />
+    <File Path=".github/workflows/build.yml" />
+    <File Path=".github/workflows/docker.yml" />
+    <File Path=".github/workflows/pack.yml" />
+    <File Path=".github/workflows/publish.yml" />
+  </Folder>
   <Folder Name="/configuration/">
     <File Path=".editorconfig" />
     <File Path=".gitignore" />


### PR DESCRIPTION
## Link issues

fixed #6791

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot

#### Motivation

As described in [the official announcement](https://devblogs.microsoft.com/dotnet/enhanced-security-is-here-with-the-new-trust-publishing-on-nuget-org/), the new **Trusted Publishing** feature greatly enhances package publishing security on NuGet.org.

We successfully tested this approach with our own NuGet library:

- [GitHub Actions run example](https://github.com/micheloliveira-com/ReactiveLock/actions/runs/18042183860/workflow)  
- [Corresponding commit](https://github.com/micheloliveira-com/ReactiveLock/blob/a9353d6ddc7cb45f386e816c6ab5ea2837bd1513/.github/workflows/k6-test-multi.yml)

#### Required changes in this repository

> **Recommendation followed from announcement:**  
> For security, always use a GitHub secret like `${{ secrets.NUGET_USER }}` for your NuGet.org username (profile name), **not your email address**.

- Add `secrets.NUGET_USER` to this repository, using the **NuGet.org username (profile name)** of the package owner (BootstrapBlazor in this case).  
- The old `secrets.NUGET_API_KEY` secret can be removed from this repository **and also from the NuGet.org account** if it was only used here.  

#### One-time configuration on NuGet.org

According to the documentation:

1. Sign in to NuGet.org.  
2. Open your user menu (top-right) → **Trusted Publishing** (next to “API Keys”).  
3. Create a policy:  
   - **Package owner:** you or your organization (e.g. `BootstrapBlazor`).  
   - **Repository owner:** your GitHub org/user (e.g. `dotnetcore`).  
   - **Repository name:** repository name (e.g. `BootstrapBlazor`).  
   - **Workflow file:** the YAML file under `.github/workflows/` (e.g. `pack.yml`).  
   - **Environment (optional):** specify if your workflow uses GitHub Actions environments.

This setup eliminates the need for long-lived API keys and improves the overall security of the publishing process.

## Regression?
- [ ] Yes
- [x] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [x] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Enable secure package publishing to NuGet.org by integrating the new Trusted Publishing workflow with id-token permissions and ephemeral credentials.

New Features:
- Add GitHub Actions support for NuGet Trusted Publishing

Enhancements:
- Grant id-token write permission for the workflow
- Introduce NuGet/login action with secrets.NUGET_USER to fetch an ephemeral API key
- Replace direct NUGET_API_KEY secret with the output from the login step