### PR TITLE
fix(AutoComplete): support bind-Value/OnValueChanged callback

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -159,7 +159,7 @@ public partial class AutoComplete
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new { Value, ChangedEventCallback = GetChangedEventCallbackName() });
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, Value, GetChangedEventCallbackName());
 
     private string? GetChangedEventCallbackName() => (OnValueChanged != null || ValueChanged.HasDelegate) ? nameof(TriggerChange) : null;
 

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -199,6 +199,20 @@ public partial class AutoComplete
         _dropdown.Render();
     }
 
+    /// <summary>
+    /// 支持双向绑定 由客户端 JavaScript 触发
+    /// </summary>
+    /// <param name="v"></param>
+    /// <returns></returns>
+    [JSInvokable]
+    public Task TriggerChange(string v)
+    {
+        _clientValue = v;
+        CurrentValueAsString = v;
+
+        return Task.CompletedTask;
+    }
+
     private List<string> GetFilterItemsByValue(string val)
     {
         var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -85,7 +85,7 @@ public partial class AutoComplete
     [NotNull]
     private RenderTemplate? _dropdown = null;
 
-    private string _clientValue = "";
+    private string? _clientValue;
 
     private string? ClassString => CssBuilder.Default("auto-complete")
         .AddClass("is-clearable", IsClearable)
@@ -133,7 +133,7 @@ public partial class AutoComplete
         Icon ??= IconTheme.GetIconByKey(ComponentIcons.AutoCompleteIcon);
         LoadingIcon ??= IconTheme.GetIconByKey(ComponentIcons.LoadingIcon);
 
-        _clientValue = Value ?? "";
+        _clientValue = Value;
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -119,8 +119,6 @@ public partial class AutoComplete
                 _filterItems = [.. _filterItems.Take(DisplayCount.Value)];
             }
         }
-
-        _clientValue = Value ?? "";
     }
 
     /// <summary>
@@ -134,6 +132,8 @@ public partial class AutoComplete
         PlaceHolder ??= Localizer[nameof(PlaceHolder)];
         Icon ??= IconTheme.GetIconByKey(ComponentIcons.AutoCompleteIcon);
         LoadingIcon ??= IconTheme.GetIconByKey(ComponentIcons.LoadingIcon);
+
+        _clientValue = Value ?? "";
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -159,7 +159,9 @@ public partial class AutoComplete
     /// <inheritdoc/>
     /// </summary>
     /// <returns></returns>
-    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, Value);
+    protected override Task InvokeInitAsync() => InvokeVoidAsync("init", Id, Interop, new { Value, ChangedEventCallback = GetChangedEventCallbackName() });
+
+    private string? GetChangedEventCallbackName() => (OnValueChanged != null || ValueChanged.HasDelegate) ? nameof(TriggerChange) : null;
 
     /// <summary>
     /// Gets whether show the clear button.

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -85,6 +85,8 @@ public partial class AutoComplete
     [NotNull]
     private RenderTemplate? _dropdown = null;
 
+    private string _clientValue = "";
+
     private string? ClassString => CssBuilder.Default("auto-complete")
         .AddClass("is-clearable", IsClearable)
         .Build();
@@ -117,6 +119,8 @@ public partial class AutoComplete
                 _filterItems = [.. _filterItems.Take(DisplayCount.Value)];
             }
         }
+
+        _clientValue = Value ?? "";
     }
 
     /// <summary>
@@ -130,6 +134,25 @@ public partial class AutoComplete
         PlaceHolder ??= Localizer[nameof(PlaceHolder)];
         Icon ??= IconTheme.GetIconByKey(ComponentIcons.AutoCompleteIcon);
         LoadingIcon ??= IconTheme.GetIconByKey(ComponentIcons.LoadingIcon);
+    }
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    /// <param name="firstRender"></param>
+    /// <returns></returns>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (!firstRender)
+        {
+            if (Value != _clientValue)
+            {
+                _clientValue = Value;
+                await InvokeVoidAsync("setValue", Id, _clientValue);
+            }
+        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -5,12 +5,14 @@ import EventHandler from "../../modules/event-handler.js"
 import Input from "../../modules/input.js"
 import Popover from "../../modules/base-popover.js"
 
-export function init(id, invoke) {
+export function init(id, invoke, value) {
     const el = document.getElementById(id)
     const menu = el.querySelector('.dropdown-menu')
     const input = document.getElementById(`${id}_input`)
     const ac = { el, invoke, menu, input }
     Data.set(id, ac)
+
+    input.value = value;
 
     const isPopover = input.getAttribute('data-bs-toggle') === 'bb.dropdown';
     if (isPopover) {

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -67,7 +67,7 @@ export function init(id, invoke, options) {
 
     if (changedEventCallback) {
         EventHandler.on(input, 'change', e => {
-            invoke.invokeMethodAsync('TriggerChange', e.target.value);
+            invoke.invokeMethodAsync(changedEventCallback, e.target.value);
         });
     }
 

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -5,14 +5,13 @@ import EventHandler from "../../modules/event-handler.js"
 import Input from "../../modules/input.js"
 import Popover from "../../modules/base-popover.js"
 
-export function init(id, invoke, options) {
+export function init(id, invoke, value, changedEventCallback) {
     const el = document.getElementById(id)
     const menu = el.querySelector('.dropdown-menu')
     const input = document.getElementById(`${id}_input`)
     const ac = { el, invoke, menu, input }
     Data.set(id, ac)
 
-    const { value, changedEventCallback } = options;
     input.value = value;
 
     const isPopover = input.getAttribute('data-bs-toggle') === 'bb.dropdown';

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -64,6 +64,10 @@ export function init(id, invoke, value) {
         }
     });
 
+    EventHandler.on(input, 'change', e => {
+        invoke.invokeMethodAsync('TriggerChange', e.target.value);
+    });
+
     let filterDuration = duration;
     if (filterDuration === 0) {
         filterDuration = 200;

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -5,13 +5,14 @@ import EventHandler from "../../modules/event-handler.js"
 import Input from "../../modules/input.js"
 import Popover from "../../modules/base-popover.js"
 
-export function init(id, invoke, value) {
+export function init(id, invoke, options) {
     const el = document.getElementById(id)
     const menu = el.querySelector('.dropdown-menu')
     const input = document.getElementById(`${id}_input`)
     const ac = { el, invoke, menu, input }
     Data.set(id, ac)
 
+    const { value, changedEventCallback } = options;
     input.value = value;
 
     const isPopover = input.getAttribute('data-bs-toggle') === 'bb.dropdown';
@@ -64,9 +65,11 @@ export function init(id, invoke, value) {
         }
     });
 
-    EventHandler.on(input, 'change', e => {
-        invoke.invokeMethodAsync('TriggerChange', e.target.value);
-    });
+    if (changedEventCallback) {
+        EventHandler.on(input, 'change', e => {
+            invoke.invokeMethodAsync('TriggerChange', e.target.value);
+        });
+    }
 
     let filterDuration = duration;
     if (filterDuration === 0) {

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -55,6 +55,37 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task BindValue_Ok()
+    {
+        // 由于设置了双向绑定 Value 改变后触发 change 事件
+        var clientValue = "";
+        var cut = Context.RenderComponent<AutoComplete>(pb =>
+        {
+            pb.Add(a => a.Items, new List<string>() { "test1", "test12", "test123", "test1234" });
+            pb.Add(a => a.Value, "test12");
+            pb.Add(a => a.OnValueChanged, v =>
+            {
+                clientValue = v;
+                return Task.CompletedTask;
+            });
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.TriggerChange("test4"));
+        Assert.Equal("test4", clientValue);
+
+        cut.SetParametersAndRender(pb =>
+        {
+            pb.Add(a => a.OnValueChanged, null);
+            pb.Add(a => a.ValueChanged, v =>
+            {
+                clientValue = v;
+            });
+        });
+        await cut.InvokeAsync(() => cut.Instance.TriggerChange("test5"));
+        Assert.Equal("test5", clientValue);
+    }
+
+    [Fact]
     public void IsClearable_Ok()
     {
         var cut = Context.RenderComponent<AutoComplete>();


### PR DESCRIPTION
## Link issues
fixes #6787

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Support bind-value/OnValueChanged callback in AutoComplete by tracking client value, extending JS interop to handle change events, and synchronizing value updates between client and server

New Features:
- Enable two-way binding for AutoComplete via ValueChanged/OnValueChanged callbacks

Enhancements:
- Synchronize client-side input value with server-side Value property on re-render via OnAfterRenderAsync and setValue JS interop
- Enhance JS init to accept initial value and an optional change callback to invoke TriggerChange on input changes

Tests:
- Add unit test to verify BindValue functionality for both OnValueChanged and ValueChanged delegates