### PR TITLE
feat(Layout): compatible net10 when href is #

### DIFF
--- a/src/BootstrapBlazor/Components/Menu/MenuLink.razor
+++ b/src/BootstrapBlazor/Components/Menu/MenuLink.razor
@@ -10,7 +10,7 @@
 }
 else
 {
-    <NavLink @attributes="@AdditionalAttributes" @onclick:preventDefault="@PreventDefault" class="@ClassString" href="@HrefString" target="@TargetString" Match="@ItemMatch" style="@StyleClassString" aria-expanded="@AriaExpandedString">
+    <NavLink @attributes="@AdditionalAttributes" @onclick:preventDefault="@PreventDefault" class="@ClassString" href="@HrefString" target="@TargetString" Match="@Item.Match" style="@StyleClassString" aria-expanded="@AriaExpandedString">
         <div class="flex-fill">
             <i class="@IconString"></i>
             <span class="menu-text">@Item.Text</span>

--- a/src/BootstrapBlazor/Components/Menu/MenuLink.razor.cs
+++ b/src/BootstrapBlazor/Components/Menu/MenuLink.razor.cs
@@ -53,8 +53,6 @@ public sealed partial class MenuLink
     [NotNull]
     private IStringLocalizer<Menu>? Localizer { get; set; }
 
-    private NavLinkMatch ItemMatch => Item.Match;
-
     private string? IconString => CssBuilder.Default("menu-icon")
         .AddClass(Item.Icon)
         .Build();

--- a/src/BootstrapBlazor/Components/Menu/MenuLink.razor.cs
+++ b/src/BootstrapBlazor/Components/Menu/MenuLink.razor.cs
@@ -53,7 +53,7 @@ public sealed partial class MenuLink
     [NotNull]
     private IStringLocalizer<Menu>? Localizer { get; set; }
 
-    private NavLinkMatch ItemMatch => string.IsNullOrEmpty(Item.Url?.TrimStart('/')) ? NavLinkMatch.All : Item.Match;
+    private NavLinkMatch ItemMatch => Item.Match;
 
     private string? IconString => CssBuilder.Default("menu-icon")
         .AddClass(Item.Icon)


### PR DESCRIPTION
## Link issues
fixes #6793 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Remove special-case fallback to NavLinkMatch.All for empty URLs in MenuLink, ensuring consistent matching behavior when href is '#'