### PR TITLE
fix(Modal): support backdrop on multiple dialog mode

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>9.11.0-beta01</Version>
+    <Version>9.11.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Dialog/Dialog.razor
+++ b/src/BootstrapBlazor/Components/Dialog/Dialog.razor
@@ -5,6 +5,11 @@
        OnShownAsync="@_onShownAsync" OnCloseAsync="@_onCloseAsync" class="@ClassString">
     @for (var index = 0; index < DialogParameters.Keys.Count; index++)
     {
+        if (index != 0 && index == DialogParameters.Keys.Count - 1)
+        {
+            <div class="modal-backdrop fade show"></div>
+        }
+
         @RenderDialog(index, DialogParameters.Keys.ElementAt(index))
     }
 </Modal>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.scss
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.scss
@@ -82,22 +82,25 @@
     width: 100vw !important;
 }
 
+.modal-multiple {
+    --bb-backdrop-zindex: 1050;
+}
+
 .modal-multiple .modal-dialog {
     position: fixed;
     inset: 0;
-
-    &:last-child:before {
-        content: "";
-        position: fixed;
-        inset: 0;
-        background-color: #000;
-        opacity: 0.3;
-        pointer-events: auto;
-    }
 }
 
 .modal-multiple ~ .modal-backdrop {
     display: none;
+}
+
+.modal-multiple .modal-backdrop {
+    z-index: var(--bb-backdrop-zindex);
+}
+
+.modal-multiple .modal-backdrop + .modal-dialog {
+    z-index: var(--bb-backdrop-zindex);
 }
 
 @media print {


### PR DESCRIPTION
## Link issues
fixes #6730 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for backdrops in multiple-dialog mode by injecting a backdrop element for secondary dialogs and adjusting CSS stacking via a custom z-index property.

Bug Fixes:
- Restore backdrop display for additional modals when multiple dialogs are open.

Enhancements:
- Add .modal-multiple CSS rules with a --bb-backdrop-zindex variable to manage backdrop and dialog stacking.
- Render an extra <div class="modal-backdrop"/> before the last dialog instance in Dialog.razor.