### PR TITLE
test(Scss): fix variable check test

### DIFF
--- a/test/UniTest.Sass/VariableTest.cs
+++ b/test/UniTest.Sass/VariableTest.cs
@@ -7,15 +7,8 @@ using System.Text.RegularExpressions;
 
 namespace UniTest.Sass;
 
-public partial class VariableTest
+public partial class VariableTest(ITestOutputHelper testOutputHelper)
 {
-    private ITestOutputHelper _outputHelper;
-
-    public VariableTest(ITestOutputHelper testOutputHelper)
-    {
-        _outputHelper = testOutputHelper;
-    }
-
     [Fact]
     public void Variable_Ok()
     {
@@ -24,7 +17,7 @@ public partial class VariableTest
         var sassFilePath = Path.Combine(rootPath, "Components");
         Assert.True(Directory.Exists(sassFilePath));
 
-        var variableFile = Path.Combine(rootPath, "wwwroot/scss/theme/bootstrapblazor.scss");
+        var variableFile = Path.Combine(rootPath, "wwwroot/scss/variables.scss");
         Assert.True(File.Exists(variableFile));
 
         // 获取所有 Sass 文件所有变量
@@ -53,7 +46,7 @@ public partial class VariableTest
 
                     // #{$alert-icon-margin-right}
                     var matches = regex.Matches(item);
-                    if (matches.Any())
+                    if (matches.Count != 0)
                     {
                         var v = matches.Where(i => !variables.Contains(i.Groups[1].Value)).Select(i => i.Groups[1].Value);
                         if (v.Any())
@@ -72,7 +65,7 @@ public partial class VariableTest
                 var matches = mixRegex.Matches(item);
                 if (item.Contains("@mixin "))
                 {
-                    if (matches.Any())
+                    if (matches.Count != 0)
                     {
                         var groups = matches[0];
                         for (int index = 1; index < groups.Groups.Count; index++)


### PR DESCRIPTION
## Link issues
fixes #6814 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Fix SCSS variable unit test by aligning file paths, simplifying test helper injection, and correcting regex match conditions

Tests:
- Remove manual ITestOutputHelper field and constructor in VariableTest in favor of constructor parameter injection
- Update the SCSS variables file path to "wwwroot/scss/variables.scss"
- Replace matches.Any() with matches.Count != 0 to accurately detect regex matches