### PR TITLE
fix(Table): include padding in auto-fit column width

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -744,7 +744,10 @@ const autoFitColumnWidth = async (table, col) => {
 
     if (table.options.fitColumnWidthIncludeHeader) {
         const th = col.closest('th');
-        maxWidth = Math.max(maxWidth, calcCellWidth(th));
+        const span = th.querySelector('.table-cell');
+        const thStyle = getComputedStyle(th);
+        const margin = parseFloat(thStyle.getPropertyValue('padding-left')) + parseFloat(thStyle.getPropertyValue('padding-right'))
+        maxWidth = Math.max(maxWidth, calcCellWidth(span)) + margin;
     }
 
     if (table.options.autoFitColumnWidthCallback !== null) {


### PR DESCRIPTION
Updated autoFitColumnWidth to calculate the header cell width using the <th> element directly instead of querying for a child span. This ensures more accurate column width fitting when including the header.

## Link issues
fixes #6879 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Include header cell padding in auto-fit column width calculation to ensure accurate header sizing