### PR TITLE
fix(MultiSelect): keep last value when items is null

### DIFF
--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -210,8 +210,8 @@ public partial class MultiSelect<TValue>
             }
             else
             {
-                var list = _currentValue.Split(',', StringSplitOptions.RemoveEmptyEntries).ToHashSet();
-                SelectedItems.AddRange(Rows.Where(item => list.Contains(item.Value)));
+                var list = _currentValue.Split(',', StringSplitOptions.RemoveEmptyEntries);
+                SelectedItems.AddRange(Rows.Where(item => list.Any(i => i.Trim() == item.Value)));
             }
 
             if (SelectedItems.Count == 0)


### PR DESCRIPTION
## Link issues
fixes #6921 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Reset _lastSelectedValueString to an empty string when SelectedItems is empty in OnParametersSet.