### PR TITLE
fix(Cascader): hide arrow icon when hover

### DIFF
--- a/src/BootstrapBlazor/Components/Cascader/Cascader.razor.cs
+++ b/src/BootstrapBlazor/Components/Cascader/Cascader.razor.cs
@@ -203,7 +203,7 @@ public partial class Cascader<TValue>
 
     private string? ClassString => CssBuilder.Default("select cascade menu dropdown")
         .AddClass("disabled", IsDisabled)
-        .AddClass("cls", IsClearable)
+        .AddClass("is-clearable", IsClearable)
         .AddClass(CssClass).AddClass(ValidCss)
         .Build();
 


### PR DESCRIPTION
## Link issues
fixes #6925 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Rename the CSS class for clearable Cascader from "cls" to "is-clearable" to properly hide the arrow icon on hover