### PR TITLE
feat(AutoFill): auto select when item length equal 1

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -234,11 +234,3 @@ const scrollIntoView = (el, item) => {
 }
 
 export { handleKeyUp, select, selectAllByFocus, selectAllByEnter }
-
-export function getInputValue(id) {
-    const ac = Data.get(id);
-    if (ac && ac.input) {
-        return ac.input.value;
-    }
-    return "";
-}


### PR DESCRIPTION
input输入Enter时，如候选项唯一，直接选中
当焦点从AutoFill移出时，如GetDisplayText(Value)对应的内容与input中的内容不符则清空Value和Input显示内容

## Link issues
fixes #6948

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [x] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [x] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Add blur validation and auto-selection behavior to AutoFill: clear invalid inputs on blur with a configurable flag, support a blur event callback, and auto-select the only dropdown item when pressing Enter or NumpadEnter.

New Features:
- Introduce IsClearOnInvalid parameter to clear input and model on blur when the entered text does not match any item
- Automatically select the sole suggestion on Enter or NumpadEnter key press
- Invoke OnBlurAsync callback when the component loses focus

Enhancements:
- Add getInputValue JavaScript interop method
- Include NumpadEnter in key handling alongside Enter