### PR TITLE
feat(Transfer): make search icon align right

### DIFF
--- a/src/BootstrapBlazor/Components/Transfer/Transfer.razor.scss
+++ b/src/BootstrapBlazor/Components/Transfer/Transfer.razor.scss
@@ -96,8 +96,8 @@
     width: 100%;
     display: inline-block;
     border-radius: var(--bs-border-radius);
-    padding-right: 10px;
-    padding-left: 30px;
+    padding-inline-start: 10px;
+    padding-inline-end: 30px;
     border: 1px solid var(--bs-border-color);
     transition: border-color .2s cubic-bezier(.645,.045,.355,1);
     color: #606266;
@@ -112,7 +112,7 @@
     width: 30px;
     transition: all .3s;
     position: absolute;
-    left: 4px;
+    right: 4px;
     top: 0;
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Link issues
fixes #6958 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adjust Transfer component styling to align the search icon to the right and use logical CSS padding properties.

Bug Fixes:
- Align the search icon to the right side in the Transfer component search input.

Enhancements:
- Replace physical padding-left/padding-right with logical padding-inline-start/padding-inline-end in the Transfer component.