### PR TITLE
feat(ImagePreviewer): move the body end prevent blocked

### DIFF
--- a/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor.js
+++ b/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor.js
@@ -2,16 +2,18 @@
 import Viewer from "../../modules/viewer.js"
 
 export function init(id, prevList, config) {
-    const el = document.getElementById(id)
+    const el = document.getElementById(id);
     if (el === null) {
-        return
+        return;
     }
 
     const viewer = {
         el,
         viewer: Viewer.init(el, prevList, config)
-    }
-    Data.set(id, viewer)
+    };
+    Data.set(id, viewer);
+
+    document.body.appendChild(el);
 }
 
 export function update(id, prevList) {
@@ -29,6 +31,7 @@ export function dispose(id) {
     Data.remove(id)
 
     if (viewer) {
-        Viewer.dispose(viewer.viewer)
+        Viewer.dispose(viewer.viewer);
+        viewer.el.remove();
     }
 }


### PR DESCRIPTION
## Link issues
fixes #7033 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Append ImagePreviewer elements to document.body to prevent them from being blocked and ensure they are removed on disposal

Bug Fixes:
- Append the previewer container to document.body in init to avoid it being blocked by other elements

Enhancements:
- Remove the previewer element from the DOM on dispose to clean up after use