### PR TITLE
feat(Link):添加 `AddToHead` 参数

### DIFF
--- a/src/BootstrapBlazor/Components/HtmlTag/Link.razor
+++ b/src/BootstrapBlazor/Components/HtmlTag/Link.razor
@@ -1,7 +1,7 @@
 @namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
 @attribute [BootstrapModuleAutoLoader(JSObjectReference = false, AutoInvokeInit = false, AutoInvokeDispose = false)]
-@if (!IsAddToHead)
+@if (!AddToHead)
 {
     <link @attributes="AdditionalAttributes" href="@GetHref()" rel="@Rel" />
 }

--- a/src/BootstrapBlazor/Components/HtmlTag/Link.razor.cs
+++ b/src/BootstrapBlazor/Components/HtmlTag/Link.razor.cs
@@ -34,7 +34,7 @@ public partial class Link
     /// <para>同时在多个组件中使用同一个样式时可以添加到 head 中，减少 DOM 节点。</para>
     /// </summary>
     [Parameter]
-    public bool IsAddToHead { get; set; } = false;
+    public bool AddToHead { get; set; } = false;
 
     [Inject, NotNull]
     private IVersionService? VersionService { get; set; }
@@ -48,7 +48,7 @@ public partial class Link
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         await base.OnAfterRenderAsync(firstRender);
-        if (IsAddToHead && firstRender)
+        if (AddToHead && firstRender)
         {
             var obj = new { Href = GetHref(), Rel };
             await InvokeVoidAsync("init", obj);

--- a/src/BootstrapBlazor/Components/HtmlTag/Link.razor.js
+++ b/src/BootstrapBlazor/Components/HtmlTag/Link.razor.js
@@ -1,11 +1,10 @@
 export function init(options) {
-    const href = options.href;
-    const rel = options.rel;
+    const { href, rel } = options;
+    const nhref = new URL(href, document.baseURI);
     const links = document.head.getElementsByTagName("link");
     // 遍历所有link元素
     for (let i = 0; i < links.length; i++) {
         const hlink = links[i];
-        var nhref = hlink.baseURI + href;
         if (hlink.href == nhref && hlink.rel == rel) {
             return;
         }

--- a/test/UnitTest/Components/LinkTest.cs
+++ b/test/UnitTest/Components/LinkTest.cs
@@ -37,7 +37,7 @@ public class LinkTest : BootstrapBlazorTestBase
         {
             pb.Add(a => a.Href, "http://www.blazor.zone");
             pb.Add(a => a.Version, "20220202");
-            pb.Add(a => a.IsAddToHead, true);
+            pb.Add(a => a.AddToHead, true);
         });
         Assert.Equal(string.Empty, cut.Markup);
     }


### PR DESCRIPTION
#7091

## Link issues
fixes #{issue number}

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enable Link components to inject <link> tags into the page head through a new IsAddToHead parameter and a custom JS interop module, while preserving existing rendering behavior when the feature is not enabled.

New Features:
- Add IsAddToHead parameter to Link component to support injecting link tags into the document head
- Introduce a JS interop module to insert and deduplicate head link elements

Enhancements:
- Migrate Link component to BootstrapModuleComponentBase and apply BootstrapModuleAutoLoader for manual JS invocation

Tests:
- Add unit test verifying that Link suppresses direct markup when IsAddToHead is true