### PR TITLE
test(Sass): remove ITestOutputHelper parameter

### DIFF
--- a/test/UniTest.Sass/VariableTest.cs
+++ b/test/UniTest.Sass/VariableTest.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
@@ -7,7 +7,7 @@ using System.Text.RegularExpressions;
 
 namespace UniTest.Sass;
 
-public partial class VariableTest(ITestOutputHelper testOutputHelper)
+public partial class VariableTest
 {
     [Fact]
     public void Variable_Ok()


### PR DESCRIPTION
## Link issues
fixes #7109 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove ITestOutputHelper dependency from the Sass VariableTest class

Bug Fixes:
- Remove ITestOutputHelper constructor parameter from the VariableTest class in UniTest.Sass to resolve issue #7109

Enhancements:
- Normalize the license header comment formatting