### PR TITLE
feat(TableExport): update MiniExcel version to 1.42.0

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -73,7 +73,7 @@
     <PackageReference Include="BootstrapBlazor.Splitting" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.SvgEditor" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.SummerNote" Version="10.0.0" />
-    <PackageReference Include="BootstrapBlazor.TableExport" Version="10.0.0" />
+    <PackageReference Include="BootstrapBlazor.TableExport" Version="10.0.1" />
     <PackageReference Include="BootstrapBlazor.Tasks.Dashboard" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.Topology" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.UniverIcon" Version="10.0.0" />


### PR DESCRIPTION
## Link issues
fixes #7153 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update MiniExcel library to version 1.42.0 in project dependencies to address export issues.

Bug Fixes:
- Fix table export issue #7153 by updating MiniExcel

Enhancements:
- Bump MiniExcel NuGet package to 1.42.0