### PR TITLE
perf(CacheManager): remove Get/SetPropertyValue dynamic model cache

### DIFF
--- a/src/BootstrapBlazor/Services/CacheManager.cs
+++ b/src/BootstrapBlazor/Services/CacheManager.cs
@@ -548,7 +548,7 @@ internal class CacheManager : ICacheManager
         }
 
         var type = model.GetType();
-        Func<TModel, TResult>? invoker = null;
+        Func<TModel, TResult> invoker;
         if (type.Assembly.IsDynamic)
         {
             invoker = LambdaExtensions.GetPropertyValueLambda<TModel, TResult>(model, fieldName).Compile();
@@ -582,7 +582,7 @@ internal class CacheManager : ICacheManager
         }
 
         var type = model.GetType();
-        Action<TModel, TValue>? invoker = null;
+        Action<TModel, TValue> invoker;
         if (type.Assembly.IsDynamic)
         {
             invoker = LambdaExtensions.SetPropertyValueLambda<TModel, TValue>(model, fieldName).Compile();


### PR DESCRIPTION
## Link issues
fixes #7167 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Optimize CacheManager property access by avoiding caching for dynamic model assemblies while retaining cached delegates for static types.

Bug Fixes:
- Prevent unnecessary caching of compiled property accessors for dynamic model types in CacheManager.

Enhancements:
- Refactor GetPropertyValue and SetPropertyValue to use dedicated invoker helper methods and simplify cache key usage for static model types.