### PR TITLE
fix(Table): reset columns after toggle visible (#7180)

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
@@ -144,6 +144,11 @@ public partial class Table<TItem>
     private bool _resetColumns;
 
     /// <summary>
+    /// 是否重置列拖拽事件 <see cref="OnAfterRenderAsync(bool)"/> 方法中重置为 false
+    /// </summary>
+    private bool _resetColDragListener;
+
+    /// <summary>
     /// 获得/设置 列改变显示状态回调方法
     /// </summary>
     [Parameter]
@@ -154,6 +159,10 @@ public partial class Table<TItem>
         if (AllowResizing)
         {
             _resetColumns = true;
+        }
+        if (AllowDragColumn && visible)
+        {
+            _resetColDragListener = true;
         }
         if (!string.IsNullOrEmpty(ClientTableName))
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1042,6 +1042,12 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             await InvokeVoidAsync("resetColumn", Id);
         }
 
+        if (_resetColDragListener)
+        {
+            _resetColDragListener= false;
+            await InvokeVoidAsync("resetColDragListener", Id);
+        }
+
         if (_bindResizeColumn)
         {
             _bindResizeColumn = false;

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -1,4 +1,4 @@
-﻿export { getResponsive } from '../../modules/responsive.js'
+export { getResponsive } from '../../modules/responsive.js'
 import { copy, drag, getDescribedElement, getOuterHeight, getWidth, isVisible } from '../../modules/utility.js'
 import '../../modules/browser.js'
 import Data from '../../modules/data.js'
@@ -177,6 +177,13 @@ export function resetColumn(id) {
     if (table) {
         setResizeListener(table)
         resetTableWidth(table)
+    }
+}
+
+export function resetColDragListener(id) {
+    const table = Data.get(id)
+    if (table) {
+        setDraggable(table)
     }
 }
 
@@ -924,6 +931,8 @@ const setDraggable = table => {
     let index = 0
     table.dragColumns = [...table.tables[0].querySelectorAll('thead > tr > th')].filter(i => i.draggable)
     table.dragColumns.forEach(col => {
+        disposeDragColumns(col);
+
         EventHandler.on(col, 'dragstart', e => {
             col.parentNode.classList.add('table-dragging')
             col.classList.add('table-drag')

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -8476,6 +8476,8 @@ public class TableTest : BootstrapBlazorTestBase
             {
                 pb.Add(a => a.RenderMode, TableRenderMode.Table);
                 pb.Add(a => a.AllowDragColumn, true);
+                pb.Add(a => a.ShowToolbar, true);
+                pb.Add(a => a.ShowColumnList, true);
                 pb.Add(a => a.ClientTableName, "table-unit-test");
                 pb.Add(a => a.OnQueryAsync, OnQueryAsync(localizer));
                 pb.Add(a => a.OnDragColumnEndAsync, (fieldName, columns) =>
@@ -8490,9 +8492,14 @@ public class TableTest : BootstrapBlazorTestBase
                     builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
                     builder.CloseComponent();
 
-                    builder.OpenComponent<TableColumn<Foo, string>>(0);
-                    builder.AddAttribute(3, "Field", "Address");
-                    builder.AddAttribute(4, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.OpenComponent<TableColumn<Foo, string>>(3);
+                    builder.AddAttribute(4, "Field", "Address");
+                    builder.AddAttribute(5, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, int>>(6);
+                    builder.AddAttribute(7, "Field", foo.Count);
+                    builder.AddAttribute(8, "FieldExpression", Utility.GenerateValueExpression(foo, "Count", typeof(int)));
                     builder.CloseComponent();
                 });
             });
@@ -8502,16 +8509,27 @@ public class TableTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(async () =>
         {
             await table.Instance.DragColumnCallback(1, 0);
-            Assert.Equal("Address", name);
         });
+        Assert.Equal("Address", name);
+
+        var columns = cut.FindAll("th");
+        Assert.Contains("地址", columns[0].InnerHtml);
+        Assert.Contains("姓名", columns[1].InnerHtml);
 
         await cut.InvokeAsync(async () =>
         {
-            var columns = cut.FindAll("th");
-            Assert.Contains("地址", columns[0].InnerHtml);
-            Assert.Contains("姓名", columns[1].InnerHtml);
-
             await table.Instance.DragColumnCallback(2, 3);
+        });
+
+        // 更改可见列
+        var checkbox = cut.Find(".dropdown-item .form-check-input");
+
+        await cut.InvokeAsync(() => checkbox.Click());
+        await cut.InvokeAsync(() => checkbox.Click());
+
+        await cut.InvokeAsync(async () =>
+        {
+            await table.Instance.DragColumnCallback(3, 4);
         });
     }
 


### PR DESCRIPTION
## Link issues
fixes #7176 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure table column drag behavior is correctly reset after toggling column visibility.

Bug Fixes:
- Reset the table column drag event listeners when columns are shown/hidden so drag-and-drop continues to work after visibility changes.

Tests:
- Extend the table drag-column unit test to cover scenarios with the column chooser toolbar and verify drag behavior after toggling column visibility.