### PR TITLE
feat(PdfReader): add ShowToolbar parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/PdfReaders.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/PdfReaders.razor
@@ -10,6 +10,12 @@
     <section ignore class="row form-inline g-3" style="--bb-input-group-label-width: 176px;">
         <div class="col-12 col-sm-6">
             <BootstrapInputGroup>
+                <BootstrapInputGroupLabel>ShowToolbar</BootstrapInputGroupLabel>
+                <Switch @bind-Value="_showToolbar"></Switch>
+            </BootstrapInputGroup>
+        </div>
+        <div class="col-12 col-sm-6">
+            <BootstrapInputGroup>
                 <BootstrapInputGroupLabel>ShowDownload</BootstrapInputGroupLabel>
                 <Switch @bind-Value="_showDownload"></Switch>
             </BootstrapInputGroup>
@@ -34,6 +40,7 @@
         </div>
     </section>
     <PdfReader Url="@_url" EnableThumbnails="_enableThumbnails"
-               ShowTwoPagesOneView="_showTwoPagesOneView" ShowDownload="_showDownload" ShowPrint="_showPrint"
+               ShowTwoPagesOneView="_showTwoPagesOneView" ShowDownload="_showDownload"
+               ShowToolbar="_showToolbar" ShowPrint="_showPrint"
                ViewHeight="600px" OnDownloadAsync="OnDownloadAsync"></PdfReader>
 </DemoBlock>

--- a/src/BootstrapBlazor.Server/Components/Samples/PdfReaders.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/PdfReaders.razor.cs
@@ -20,6 +20,7 @@ public partial class PdfReaders
     private bool _showPrint = true;
     private bool _enableThumbnails = true;
     private bool _showDownload = true;
+    private bool _showToolbar = true;
     private string _url = "./samples/sample.pdf";
 
     private async Task OnDownloadAsync()


### PR DESCRIPTION
## Link issues
fixes #7202 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a configurable ShowToolbar option to the PdfReader sample and wire it to a new toggle in the demo UI.

New Features:
- Introduce a ShowToolbar parameter on the PdfReader sample component to control toolbar visibility from the demo page.

Enhancements:
- Extend the PdfReaders demo UI with a switch control for toggling the PdfReader toolbar at runtime.