### PR TITLE
fix(AutoComplete): shoud trigger ValueChanged after enter

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -1,4 +1,4 @@
-﻿import { debounce, registerBootstrapBlazorModule } from "../../modules/utility.js"
+import { debounce, registerBootstrapBlazorModule } from "../../modules/utility.js"
 import { handleKeyUp, select, selectAllByFocus, selectAllByEnter } from "../Input/BootstrapInput.razor.js"
 import Data from "../../modules/data.js"
 import EventHandler from "../../modules/event-handler.js"
@@ -153,18 +153,22 @@ const handlerKeydown = (ac, e) => {
     if (key === 'Enter') {
         const skipEnter = el.getAttribute('data-bb-skip-enter') === 'true';
         if (!skipEnter) {
+            let activeItem = null;
             const items = [...menu.querySelectorAll('.dropdown-item')];
             if (items.length === 1) {
-                const item = items[0];
-                item.click();
+                activeItem = items[0];
             }
             else {
-                const current = menu.querySelector('.active');
-                if (current !== null) {
-                    current.click();
-                }
+                activeItem = menu.querySelector('.active');
             }
-            invoke.invokeMethodAsync('EnterCallback');
+
+            const handler = setTimeout(async () => {
+                clearTimeout(handler);
+                if (activeItem !== null) {
+                    activeItem.click();
+                }
+                await invoke.invokeMethodAsync('EnterCallback');
+            }, 0);
         }
     }
     else if (key === 'Escape') {


### PR DESCRIPTION
## Link issues
fixes #7270 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix AutoComplete so that pressing Enter always invokes the value change callback after any pending item click is processed.