### PR TITLE
chore(editorconfig): remove csproj encoding config

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,10 +8,6 @@ trim_trailing_whitespace = true
 insert_final_newline = true
 spelling_exclusion_path = .\exclusion.dic
 
-[*.csproj]
-charset = utf-8
-insert_final_newline = true
-
 [*.{xml,config,csproj,nuspec,props,resx,targets,yml,tasks,json}]
 indent_size = 2
 


### PR DESCRIPTION
## Link issues
fixes #7282 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Clean up .editorconfig by dropping obsolete csproj encoding configuration.