### PR TITLE
feat(Reboot): increase reboot count down time

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Components/RebootCountDown.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/RebootCountDown.razor
@@ -1,3 +1,3 @@
 <div class="bb-reboot-clock">
-    <FlipClock ViewMode="FlipClockViewMode.CountDown" ShowHour="false" StartValue="TimeSpan.FromSeconds(180)"></FlipClock>
+    <FlipClock ViewMode="FlipClockViewMode.CountDown" ShowHour="false" StartValue="TimeSpan.FromSeconds(240)"></FlipClock>
 </div>


### PR DESCRIPTION
## Link issues
fixes #7334 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Adjust the FlipClock countdown start value from 140 to 240 seconds in the reboot UI component to extend the allowed reboot preparation time.