### PR TITLE
chore(LLms): add llms.txt router

### DIFF
--- a/src/BootstrapBlazor.Server/Directory.Build.targets
+++ b/src/BootstrapBlazor.Server/Directory.Build.targets
@@ -1,6 +1,6 @@
 <Project>
 
-  <Target Name="LLMs" AfterTargets="Build" Condition="'$(TargetFramework)' == '$(RunTargetFramework)'">
+  <Target Name="LLMs" AfterTargets="Publish" Condition="'$(TargetFramework)' == '$(RunTargetFramework)'">
     <Message Text="LLMs documentation generating ..." Importance="high"></Message>
     <Exec Command="dotnet tool restore"></Exec>
     <Exec Command="dotnet llms-docs --root=$(MSBuildThisFileDirectory) --debug"></Exec>

--- a/src/BootstrapBlazor.Server/Extensions/WebApplicationExtensions.cs
+++ b/src/BootstrapBlazor.Server/Extensions/WebApplicationExtensions.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
@@ -18,6 +18,41 @@ static class WebApplicationExtensions
         {
             FileProvider = new PhysicalFileProvider(uploader),
             RequestPath = "/images/uploader"
+        });
+    }
+
+    public static void UseLLMsStaticFiles(this WebApplication app)
+    {
+        var llms = Path.Combine(app.Environment.WebRootPath, "llms");
+        Directory.CreateDirectory(llms);
+
+        app.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new PhysicalFileProvider(llms),
+            RequestPath = "/llms",
+            OnPrepareResponse = context =>
+            {
+                context.Context.Response.ContentType = "text/plain; charset=utf-8";
+            }
+        });
+
+        app.MapGet("/llms.txt", async context =>
+        {
+            context.Response.Headers.ContentType = "text/plain; charset=utf-8";
+            var filePath = Path.Combine(app.Environment.WebRootPath, "llms", "llms.txt");
+            if (File.Exists(filePath))
+            {
+                var fileInfo = new FileInfo(filePath);
+                context.Response.ContentLength = fileInfo.Length;
+
+                using var fileStream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read, bufferSize: 4096, useAsync: true);
+                await fileStream.CopyToAsync(context.Response.Body);
+                return;
+            }
+
+            var defaultContent = "no llms.txt";
+            context.Response.ContentLength = defaultContent.Length;
+            await context.Response.WriteAsync(defaultContent);
         });
     }
 }

--- a/src/BootstrapBlazor.Server/Program.cs
+++ b/src/BootstrapBlazor.Server/Program.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
@@ -37,6 +37,9 @@ if (!app.Environment.IsDevelopment())
 
 // 增加上传目录静态资源文件
 app.UseUploaderStaticFiles();
+
+// 增加 llms 静态资源文件
+app.UseLLMsStaticFiles();
 
 app.UseAntiforgery();
 app.UseBootstrapBlazor();


### PR DESCRIPTION
## Link issues
fixes #7470 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for serving llms-related static files and exposing an /llms.txt endpoint.

New Features:
- Serve static files from a new /llms directory under the web root.
- Expose an /llms.txt route that returns the configured llms.txt file or a default message if it is missing.