### PR TITLE
doc(AttributeTable): add badge for obsolete parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Components/AttributeTable.razor
+++ b/src/BootstrapBlazor.Server/Components/Components/AttributeTable.razor
@@ -13,7 +13,10 @@
                 <Template Context="v">
                     @if (v.Row.IsObsolete)
                     {
-                        <span class="text-decoration-line-through text-danger">@v.Value</span>
+                        <span class="text-decoration-line-through text-danger me-2">@v.Value</span>
+                        <Badge Color="Color.Danger" IsPill="true">
+                            @Localizer["Obsolete"]
+                        </Badge>
                     }
                     else
                     {

--- a/src/BootstrapBlazor.Server/Components/Components/AttributeTable.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Components/AttributeTable.razor.cs
@@ -58,7 +58,7 @@ public sealed partial class AttributeTable
         }
 
         var index = type.Name.IndexOf('`');
-        var typeName = type.Name.Substring(0, index);
+        var typeName = type.Name[..index];
         var genericArgs = string.Join(", ", type.GetGenericArguments().Select(i => i.Name));
         return $"{typeName}<{genericArgs}>";
     }

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -20,6 +20,7 @@
     "Type": "Type"
   },
   "BootstrapBlazor.Server.Components.Components.AttributeTable": {
+    "Obsolete": "Obsolete",
     "AutoGenerateColumns": "Automatically generated",
     "Total": "Total"
   },

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -20,6 +20,7 @@
     "Type": "类型"
   },
   "BootstrapBlazor.Server.Components.Components.AttributeTable": {
+    "Obsolete": "已弃用",
     "AutoGenerateColumns": "自动生成",
     "Total": "合计"
   },


### PR DESCRIPTION
## Link issues
fixes #7563 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Indicate obsolete attributes more clearly in the AttributeTable component UI and modernize related type formatting code.

Enhancements:
- Display a danger-colored badge labeled as obsolete next to obsolete attribute values in the AttributeTable component.
- Use range-based substring syntax when formatting generic type names for display in the AttributeTable.