### PR TITLE
refactor(Empty): fix typo error

### DIFF
--- a/src/BootstrapBlazor/Components/Empty/Empty.razor
+++ b/src/BootstrapBlazor/Components/Empty/Empty.razor
@@ -1,10 +1,10 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @inherits BootstrapComponentBase
 
 <div @attributes="AdditionalAttributes" class="@ClassString">
     @if (Template != null)
     {
-        <div class="empty-telemplate">
+        <div class="empty-template">
             @Template
         </div>
     }

--- a/src/BootstrapBlazor/Components/Empty/Empty.razor.scss
+++ b/src/BootstrapBlazor/Components/Empty/Empty.razor.scss
@@ -1,4 +1,4 @@
-﻿@use "../../wwwroot/scss/variables" as *;
+@use "../../wwwroot/scss/variables" as *;
 
 .empty {
     --bb-empty-image-margin: #{$bb-empty-image-margin};
@@ -9,7 +9,7 @@
         margin: var(--bb-empty-image-margin);
     }
 
-    .empty-telemplate {
+    .empty-template {
         margin: var(--bb-empty-template-margin);
     }
 }

--- a/test/UnitTest/Components/SelectTableTest.cs
+++ b/test/UnitTest/Components/SelectTableTest.cs
@@ -603,7 +603,7 @@ public class SelectTableTest : BootstrapBlazorTestBase
             });
         });
 
-        cut.Contains("<div class=\"empty\"><div class=\"empty-telemplate\">empty-template</div></div>");
+        cut.Contains("<div class=\"empty\"><div class=\"empty-template\">empty-template</div></div>");
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #7669 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Correct the Empty component template CSS class name and align related styles and tests.

Bug Fixes:
- Fix misspelled Empty component template CSS class from `empty-telemplate` to `empty-template` to ensure consistent styling and markup.

Tests:
- Update unit test expectation to match the corrected Empty component template CSS class name.