### PR TITLE
fix(AutoComplete): append icon wrong place

### DIFF
--- a/src/BootstrapBlazor/Components/Select/Select.razor.scss
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.scss
@@ -125,7 +125,7 @@
 
 .select,
 .auto-complete {
-    --bb-select-append-right: 0;
+    --bb-select-append-right: #{$bb-select-append-right};
 
     .clear-icon {
         position: absolute;

--- a/src/BootstrapBlazor/wwwroot/scss/variables.scss
+++ b/src/BootstrapBlazor/wwwroot/scss/variables.scss
@@ -534,6 +534,7 @@ $bb-select-search-icon-top: 18px;
 $bb-select-search-height: 52px;
 $bb-select-append-width: 30px;
 $bb-select-append-color: #c0c4cc;
+$bb-select-append-right: 0;
 
 // Multiple-Select
 $bb-multi-select-min-height: 35px;


### PR DESCRIPTION
## Link issues
fixes #7716 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Introduce a shared SCSS variable for the select/auto-complete append icon horizontal offset and apply it to both components.