### PR TITLE
feat(AutoRedirect): set Interval parameter default value to 10m

### DIFF
--- a/src/BootstrapBlazor/Components/AutoRedirect/AutoRedirect.cs
+++ b/src/BootstrapBlazor/Components/AutoRedirect/AutoRedirect.cs
@@ -27,11 +27,11 @@ public class AutoRedirect : BootstrapModuleComponentBase
     public bool IsForceLoad { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 自动锁屏间隔单位 秒 默认 null 内部使用 60000 毫秒</para>
-    /// <para lang="en">Gets or sets the auto lock interval in seconds. Default is null, internally uses 60000 milliseconds</para>
+    /// <para lang="zh">获得/设置 自动锁屏间隔单位 秒 默认 0 内部使用 60000 毫秒</para>
+    /// <para lang="en">Gets or sets the auto lock interval in seconds. Default is 0, internally uses 60000 milliseconds</para>
     /// </summary>
     [Parameter]
-    public int? Interval { get; set; }
+    public int Interval { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 地址跳转前回调方法 返回 true 时中止跳转</para>
@@ -60,7 +60,7 @@ public class AutoRedirect : BootstrapModuleComponentBase
     {
         base.OnParametersSet();
 
-        if (Interval is null)
+        if (Interval <= 0)
         {
             // 默认 10 分钟
             Interval = 10 * 60 * 1000;


### PR DESCRIPTION
## Link issues
fixes #7816 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Remove the hard-coded Interval default on AutoRedirect and apply a 10-minute fallback during parameter initialization when the interval is non-positive.