### PR TITLE
doc(TreeView): update sample code prevent page not avaliable

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/TreeViews.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/TreeViews.razor.cs
@@ -35,6 +35,8 @@ public sealed partial class TreeViews
 
     private List<TreeViewItem<TreeFoo>> DraggableItems { get; set; } = [];
 
+    private List<TreeFoo> DraggableSourceItems { get; } = GetDraggableItems();
+
     private List<TreeViewItem<TreeFoo>> DisabledItems { get; } = GetDisabledItems();
 
     private List<TreeViewItem<TreeFoo>>? AccordionItems { get; } = TreeFoo.GetAccordionItems();
@@ -43,7 +45,7 @@ public sealed partial class TreeViews
 
     private List<TreeViewItem<TreeFoo>> CheckedItems { get; set; } = GetCheckedItems();
 
-    private static List<TreeViewItem<TreeFoo>> IconItems { get; set; } = TreeFoo.GetTreeItems();
+    private List<TreeViewItem<TreeFoo>> IconItems { get; } = TreeFoo.GetTreeItems();
 
     private List<TreeViewItem<TreeFoo>> ClickExpandItems { get; } = TreeFoo.GetTreeItems();
 
@@ -86,8 +88,7 @@ public sealed partial class TreeViews
     {
         base.OnInitialized();
 
-        var items = GetDraggableItems();
-        DraggableItems = TreeFoo.CascadingTree(items);
+        DraggableItems = TreeFoo.CascadingTree(DraggableSourceItems);
         DraggableItems[0].IsExpand = true;
         if (DraggableItems.Count > 1)
         {
@@ -109,11 +110,10 @@ public sealed partial class TreeViews
     {
         // 本例是使用静态数据模拟数据库操作的，实战中应该是更新节点的父级 Id 可能还需要更改排序字段等信息，然后重构 TreeView 数据源即可
         // 根据 context 处理原始数据
-        var items = GetDraggableItems();
-        var source = items.Find(i => i.Id == context.Source.Value.Id);
+        var source = DraggableSourceItems.Find(i => i.Id == context.Source.Value.Id);
         if (source != null)
         {
-            var target = items.Find(i => i.Id == context.Target.Value.Id);
+            var target = DraggableSourceItems.Find(i => i.Id == context.Target.Value.Id);
             if (target != null)
             {
                 source.ParentId = context.IsChildren ? target.Id : target.ParentId;
@@ -132,7 +132,7 @@ public sealed partial class TreeViews
                 }
             };
         }
-        DraggableItems = TreeFoo.CascadingTree(items, cb);
+        DraggableItems = TreeFoo.CascadingTree(DraggableSourceItems, cb);
         DraggableItems[0].IsExpand = true;
         if (DraggableItems.Count > 1)
         {
@@ -186,25 +186,20 @@ public sealed partial class TreeViews
         return Task.CompletedTask;
     }
 
-    private static List<TreeFoo>? _dragItems = null;
-    private static List<TreeFoo> GetDraggableItems()
-    {
-        _dragItems ??=
-        [
-            new() { Text = "Item A", Id = "1", Icon = "fa-solid fa-font-awesome" },
-            new() { Text = "Item D", Id = "4", ParentId = "1", Icon = "fa-solid fa-font-awesome" },
-            new() { Text = "Item E", Id = "5", ParentId = "1", Icon = "fa-solid fa-font-awesome" },
+    private static List<TreeFoo> GetDraggableItems() =>
+    [
+        new() { Text = "Item A", Id = "1", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item D", Id = "4", ParentId = "1", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item E", Id = "5", ParentId = "1", Icon = "fa-solid fa-font-awesome" },
 
-            new() { Text = "Item B", Id = "2", Icon = "fa-solid fa-font-awesome" },
-            new() { Text = "Item F", Id = "6", ParentId = "2", Icon = "fa-solid fa-font-awesome" },
-            new() { Text = "Item G", Id = "9", ParentId = "2", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item B", Id = "2", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item F", Id = "6", ParentId = "2", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item G", Id = "9", ParentId = "2", Icon = "fa-solid fa-font-awesome" },
 
-            new() { Text = "Item C", Id = "3", Icon = "fa-solid fa-font-awesome" },
-            new() { Text = "Item H", Id = "7", ParentId = "3", Icon = "fa-solid fa-font-awesome" },
-            new() { Text = "Item I", Id = "8", ParentId = "3", Icon = "fa-solid fa-font-awesome" }
-        ];
-        return _dragItems;
-    }
+        new() { Text = "Item C", Id = "3", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item H", Id = "7", ParentId = "3", Icon = "fa-solid fa-font-awesome" },
+        new() { Text = "Item I", Id = "8", ParentId = "3", Icon = "fa-solid fa-font-awesome" }
+    ];
 
     private static List<TreeViewItem<TreeFoo>> GetDisabledItems()
     {


### PR DESCRIPTION
## Link issues
fixes #7827 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure TreeView draggable sample uses an instance-level data source instead of shared static state to avoid cross-page interference.

Bug Fixes:
- Prevent TreeView draggable demo from sharing drag source data across pages by using an instance-local item collection as the data source.

Enhancements:
- Simplify TreeView sample data initialization and make IconItems instance-scoped for consistency with other demo item collections.