### PR TITLE
feat(ValidateForm): add UnregisterAsyncSubmitButton method

### DIFF
--- a/src/BootstrapBlazor/Components/Button/ButtonBase.cs
+++ b/src/BootstrapBlazor/Components/Button/ButtonBase.cs
@@ -3,6 +3,8 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Microsoft.AspNetCore.Components.Web;
+
 namespace BootstrapBlazor.Components;
 
 /// <summary>
@@ -63,7 +65,7 @@ public abstract class ButtonBase : TooltipWrapperBase
     /// <para lang="en">Gets or sets the OnClick event</para>
     /// </summary>
     [Parameter]
-    public EventCallback OnClick { get; set; }
+    public EventCallback<MouseEventArgs> OnClick { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 OnClick 事件不刷新父组件</para>
@@ -334,7 +336,7 @@ public abstract class ButtonBase : TooltipWrapperBase
         {
             if (OnClick.HasDelegate)
             {
-                OnClick = EventCallback.Empty;
+                OnClick = EventCallback<MouseEventArgs>.Empty;
             }
 
             if (IsAsync && ValidateForm != null)

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -577,6 +577,16 @@ public partial class ValidateForm
         AsyncSubmitButtons.Add(button);
     }
 
+    /// <summary>
+    /// <para lang="zh">注销提交按钮</para>
+    /// <para lang="en">Unregisters a submit button</para>
+    /// </summary>
+    /// <param name="button"></param>
+    internal void UnregisterAsyncSubmitButton(ButtonBase button)
+    {
+        AsyncSubmitButtons.Remove(button);
+    }
+
     private TaskCompletionSource<bool>? _tcs;
 
     private async Task OnValidSubmitForm(EditContext context)


### PR DESCRIPTION
## Link issues
fixes #7888 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add support for unregistering async submit buttons from ValidateForm and align button click handling with typed mouse event callbacks.

New Features:
- Introduce an UnregisterAsyncSubmitButton API on ValidateForm to allow removal of async submit buttons.

Enhancements:
- Change ButtonBase OnClick to use EventCallback<MouseEventArgs> and update its disposal to clear the typed callback.