### PR TITLE
fix(Table): not unload BootstrapBlazor_DynamicAssembly under IsExcel mode

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.5.1-beta10</Version>
+    <Version>10.5.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -280,9 +280,18 @@
                                         <label>@CheckboxDisplayText</label>
                                         @if (GetShowRowCheckbox(item))
                                         {
-                                            <Checkbox TValue="TItem" Value="@item" State="@RowCheckState(item)"
-                                                      OnStateChanged="OnCheck" StopPropagation="true">
-                                            </Checkbox>
+                                            if (item is IDynamicObject d)
+                                            {
+                                                <Checkbox Value="@d.DynamicObjectPrimaryKey" State="@RowCheckState(item)" ShowLabel="false"
+                                                          OnStateChanged="OnCheckGuid" StopPropagation="true">
+                                                </Checkbox>
+                                            }
+                                            else
+                                            {
+                                                <Checkbox Value="@item" State="@RowCheckState(item)" ShowLabel="false"
+                                                          OnStateChanged="OnCheck" StopPropagation="true">
+                                                </Checkbox>
+                                            }
                                         }
                                     </div>
                                 }
@@ -570,10 +579,20 @@
                 {
                     <th class="@MultiColumnClassString" style="@MultiColumnStyleString">
                         <div class="table-cell">
-                            <Checkbox TValue="TItem" DisplayText="@CheckboxDisplayTextString" ShowLabel="false"
-                                      ShowAfterLabel="@ShowCheckboxText"
-                                      State="@HeaderCheckState()" OnStateChanged="OnHeaderCheck">
-                            </Checkbox>
+                            @if (typeof(TItem).IsAssignableTo(typeof(IDynamicObject)))
+                            {
+                                <Checkbox TValue="Guid" DisplayText="@CheckboxDisplayTextString" ShowLabel="false"
+                                          ShowAfterLabel="@ShowCheckboxText"
+                                          State="@HeaderCheckState()" OnStateChanged="OnHeaderCheckGuid">
+                                </Checkbox>
+                            }
+                            else
+                            {
+                                <Checkbox TValue="TItem" DisplayText="@CheckboxDisplayTextString" ShowLabel="false"
+                                          ShowAfterLabel="@ShowCheckboxText"
+                                          State="@HeaderCheckState()" OnStateChanged="OnHeaderCheck">
+                                </Checkbox>
+                            }
                         </div>
                     </th>
                 }
@@ -757,9 +776,18 @@
                     <div class="table-cell">
                         @if (GetShowRowCheckbox(item))
                         {
-                            <Checkbox TValue="TItem" Value="@item" ShowLabel="false" State="RowCheckState(item)"
-                                      OnStateChanged="OnCheck" @onclick:stopPropagation>
-                            </Checkbox>
+                            if (item is IDynamicObject d)
+                            {
+                                <Checkbox Value="@d.DynamicObjectPrimaryKey" State="@RowCheckState(item)" ShowLabel="false"
+                                          OnStateChanged="OnCheckGuid" StopPropagation="true">
+                                </Checkbox>
+                            }
+                            else
+                            {
+                                <Checkbox Value="@item" State="@RowCheckState(item)" ShowLabel="false"
+                                          OnStateChanged="OnCheck" StopPropagation="true">
+                                </Checkbox>
+                            }
                         }
                     </div>
                 </td>
@@ -830,7 +858,7 @@
             {
                 <td>
                     <div class="table-cell">
-                        <Checkbox TValue="TItem" ShowLabel="false" State="CheckboxState.UnChecked"></Checkbox>
+                        <Checkbox TValue="bool" ShowLabel="false" State="CheckboxState.UnChecked"></Checkbox>
                     </div>
                 </td>
             }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
@@ -158,7 +158,7 @@ public partial class Table<TItem>
     protected async Task OnCheckGuid(CheckboxState state, Guid val)
     {
         // 通过 Guid 找到选中行数据
-        var item = Rows.Cast<IDynamicObject>().FirstOrDefault(i => i.DynamicObjectPrimaryKey == val);
+        var item = Rows.OfType<IDynamicObject>().FirstOrDefault(i => i.DynamicObjectPrimaryKey == val);
         if (item != null)
         {
             await OnCheck(state, (TItem)(object)item);

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
@@ -115,6 +115,14 @@ public partial class Table<TItem>
     }
 
     /// <summary>
+    /// <para lang="zh">点击表头选择复选框时触发此方法</para>
+    /// <para lang="en">Header Checkbox Click Method</para>
+    /// </summary>
+    /// <param name="state"></param>
+    /// <param name="val"></param>
+    protected virtual Task OnHeaderCheckGuid(CheckboxState state, Guid val) => OnHeaderCheck(state, default!);
+
+    /// <summary>
     /// <para lang="zh">点击选择复选框时触发此方法</para>
     /// <para lang="en">Checkbox Click Method</para>
     /// </summary>
@@ -141,6 +149,20 @@ public partial class Table<TItem>
         ShowEditForm = false;
 
         await OnSelectedRowsChanged();
+    }
+
+    /// <summary>
+    /// <para lang="zh">点击选择复选框时触发此方法</para>
+    /// <para lang="en">Checkbox Click Method</para>
+    /// </summary>
+    protected async Task OnCheckGuid(CheckboxState state, Guid val)
+    {
+        // 通过 Guid 找到选中行数据
+        var item = Rows.Cast<IDynamicObject>().FirstOrDefault(i => i.DynamicObjectPrimaryKey == val);
+        if (item != null)
+        {
+            await OnCheck(state, (TItem)(object)item);
+        }
     }
 
     private bool _resetColumns;

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
@@ -146,7 +146,6 @@ public class DataTableDynamicContext : DynamicObjectContext
                     }
 
                     d.Row = row;
-                    d.DynamicObjectPrimaryKey = Guid.NewGuid();
                     _dataCache.TryAdd(d.DynamicObjectPrimaryKey, (d, row));
                     ret.Add(d);
                 }
@@ -204,7 +203,6 @@ public class DataTableDynamicContext : DynamicObjectContext
             DataTable.Rows.InsertAt(row, indexOfRow);
 
             // 新建动态类型属性赋值
-            dynamicObject.DynamicObjectPrimaryKey = Guid.NewGuid();
             foreach (DataColumn col in DataTable.Columns)
             {
                 if (col.DefaultValue != DBNull.Value)

--- a/src/BootstrapBlazor/Dynamic/DynamicObject.cs
+++ b/src/BootstrapBlazor/Dynamic/DynamicObject.cs
@@ -15,7 +15,7 @@ public class DynamicObject : IDynamicObject
     /// <inheritdoc/>
     /// </summary>
     [AutoGenerateColumn(Ignore = true)]
-    public Guid DynamicObjectPrimaryKey { get; set; }
+    public Guid DynamicObjectPrimaryKey { get; set; } = Guid.NewGuid();
 
     /// <summary>
     /// <para lang="zh">获得指定属性值方法</para>

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6469,7 +6469,7 @@ public class TableTest : BootstrapBlazorTestBase
         });
 
         // 选中行
-        var input = cut.FindComponents<Checkbox<DynamicObject>>()[1];
+        var input = cut.FindComponents<Checkbox<Guid>>()[1];
         await cut.InvokeAsync(input.Instance.OnToggleClick);
         Assert.True(compared);
     }
@@ -6531,7 +6531,7 @@ public class TableTest : BootstrapBlazorTestBase
         var table = cut.FindComponent<Table<DynamicObject>>();
 
         // 选中第一行数据
-        var input = cut.FindComponents<Checkbox<DynamicObject>>()[1];
+        var input = cut.FindComponents<Checkbox<Guid>>()[1];
         await cut.InvokeAsync(input.Instance.OnToggleClick);
         var selectedRow = table.Instance.SelectedRows.FirstOrDefault();
         Assert.NotNull(selectedRow);
@@ -6557,7 +6557,7 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var input = cut.FindComponents<Checkbox<DynamicObject>>()[1];
+        var input = cut.FindComponents<Checkbox<Guid>>()[1];
         await cut.InvokeAsync(input.Instance.OnToggleClick);
 
         var table = cut.FindComponent<MockDynamicTable>();
@@ -8536,7 +8536,7 @@ public class TableTest : BootstrapBlazorTestBase
             });
         });
 
-        var check = cut.FindComponents<Checkbox<DynamicObject>>().FirstOrDefault(i => i.Instance.State == CheckboxState.Checked);
+        var check = cut.FindComponents<Checkbox<Guid>>().FirstOrDefault(i => i.Instance.State == CheckboxState.Checked);
         Assert.NotNull(check);
 
         context = CreateDynamicContext(localizer);


### PR DESCRIPTION
## Link issues
fixes #7899 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve table row selection handling for dynamic objects by binding checkboxes to stable Guid keys and updating related selection logic and tests.

Bug Fixes:
- Fix table selection for dynamic rows to avoid unloading or mismatching dynamic assemblies when using Excel mode.

Tests:
- Update dynamic table tests to target Guid-based checkboxes for row selection instead of dynamic object instances.