### PR TITLE
test(SelectTree): add OnSearchAsync test

### DIFF
--- a/test/UnitTest/Components/SelectTreeTest.cs
+++ b/test/UnitTest/Components/SelectTreeTest.cs
@@ -224,6 +224,35 @@ public class SelectTreeTest : BootstrapBlazorTestBase
         cut.Contains("tree-search-reset");
     }
 
+    [Fact]
+    public async Task OnSearchAsync_Ok()
+    {
+        var key = "";
+        var items = TreeFoo.GetTreeItems();
+        var cut = Context.Render<SelectTree<TreeFoo>>(builder =>
+        {
+            builder.Add(a => a.ShowSearch, true);
+            builder.Add(a => a.OnSearchAsync, new Func<string?, Task<List<TreeViewItem<TreeFoo>>?>>(v =>
+            {
+                key = v;
+                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>([new TreeViewItem<TreeFoo>(new TreeFoo()) { Text = v }]);
+            }));
+            builder.Add(a => a.Items, items);
+        });
+
+        var input = cut.FindComponent<BootstrapInput<string?>>();
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!("enter"));
+        Assert.Equal("enter", key);
+
+        var nodes = cut.FindAll(".tree-content");
+        Assert.Single(nodes);
+
+        // trigger esc key
+        await cut.InvokeAsync(() => input.Instance.OnEscAsync!(""));
+        nodes = cut.FindAll(".tree-content");
+        Assert.Equal(9, nodes.Count);
+    }
+
     private List<TreeViewItem<string>> BindItems { get; } =
     [
         new TreeViewItem<string>("Test1")


### PR DESCRIPTION
## Link issues
fixes #7906 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Tests:
- Add unit test verifying SelectTree invokes OnSearchAsync on enter and updates displayed tree nodes, restoring items on escape.