### PR TITLE
test(Table): add unload BootstrapBlazor_DynamicAssembly unit test

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -282,13 +282,15 @@
                                         {
                                             if (item is IDynamicObject d)
                                             {
-                                                <Checkbox Value="@d.DynamicObjectPrimaryKey" State="@RowCheckState(item)" ShowLabel="false"
+                                                <Checkbox Value="@d.DynamicObjectPrimaryKey"
+                                                          State="@RowCheckState(item)" ShowLabel="false"
                                                           OnStateChanged="OnCheckGuid" StopPropagation="true">
                                                 </Checkbox>
                                             }
                                             else
                                             {
-                                                <Checkbox Value="@item" State="@RowCheckState(item)" ShowLabel="false"
+                                                <Checkbox Value="@item"
+                                                          State="@RowCheckState(item)" ShowLabel="false"
                                                           OnStateChanged="OnCheck" StopPropagation="true">
                                                 </Checkbox>
                                             }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
+using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
 using System.Data;
 using System.Reflection;
@@ -6558,6 +6559,40 @@ public class TableTest : BootstrapBlazorTestBase
         var header = cut.FindComponents<Checkbox<Guid>>()[0];
         await cut.InvokeAsync(header.Instance.OnToggleClick);
         Assert.Single(selectedRows);
+    }
+
+
+    [Fact]
+    public async Task DynamicContext_ChangeDetection_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<DynamicObject>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.IsMultipleSelect, true);
+                pb.Add(a => a.DynamicContext, CreateDynamicContext(localizer));
+            });
+        });
+
+        cut.Dispose();
+
+        // 表格使用动态创建类型后，不能被 Blazor 底层 ChangeDetection 缓存，否则生成的动态 Assembly 无法被释放
+        // 通过反射查看是否被缓存
+        var type = typeof(ComponentBase).Assembly.GetType("Microsoft.AspNetCore.Components.ChangeDetection");
+        Assert.NotNull(type);
+
+        var fieldInfo = type.GetField("_immutableObjectTypesCache", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+        Assert.NotNull(fieldInfo);
+
+        IEnumerable<Type>? items = null;
+        if (fieldInfo.GetValue(null) is ConcurrentDictionary<Type, bool> cache)
+        {
+            items = cache.Keys.Where(i => i.Assembly.GetName().Name == "BootstrapBlazor_DynamicAssembly");
+        }
+        Assert.NotNull(items);
+        Assert.Empty(items);
     }
 
     [Fact]

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6475,6 +6475,62 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task DynamicContext_HeaderCheckGuid_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var selectedRows = new List<DynamicObject>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<DynamicObject>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.IsMultipleSelect, true);
+                pb.Add(a => a.DynamicContext, CreateDynamicContext(localizer));
+                pb.Add(a => a.SelectedRows, selectedRows);
+                pb.Add(a => a.SelectedRowsChanged, EventCallback.Factory.Create<List<DynamicObject>>(this, rows => selectedRows = rows));
+            });
+        });
+
+        // 无选中行
+        Assert.Empty(selectedRows);
+
+        // 点击表头全选，选中行为 2 行
+        var header = cut.FindComponents<Checkbox<Guid>>()[0];
+        await cut.InvokeAsync(header.Instance.OnToggleClick);
+        Assert.Equal(2, selectedRows.Count);
+
+        // 再次点击表头全选，取消全选
+        await cut.InvokeAsync(header.Instance.OnToggleClick);
+        Assert.Empty(selectedRows);
+    }
+
+    [Fact]
+    public async Task DynamicContext_HeaderCheckGuid_ShowRowCheckboxCallback_Ok()
+    {
+        // 测试包含无法选中行逻辑
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var selectedRows = new List<DynamicObject>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<DynamicObject>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.IsMultipleSelect, true);
+                pb.Add(a => a.DynamicContext, CreateDynamicContext(localizer));
+                pb.Add(a => a.ShowRowCheckboxCallback, row => Equals(row.GetValue("Id"), 0));
+                pb.Add(a => a.SelectedRows, selectedRows);
+                pb.Add(a => a.SelectedRowsChanged, EventCallback.Factory.Create<List<DynamicObject>>(this, rows => selectedRows = rows));
+            });
+        });
+
+        Assert.Equal(2, cut.FindComponents<Checkbox<Guid>>().Count);
+
+        var header = cut.FindComponents<Checkbox<Guid>>()[0];
+        await cut.InvokeAsync(header.Instance.OnToggleClick);
+        Assert.Single(selectedRows);
+    }
+
+    [Fact]
     public async Task DynamicContext_Add()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6475,6 +6475,36 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task DynamicContext_CardView_CheckGuid_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var selectedRows = new List<DynamicObject>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<DynamicObject>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.CardView);
+                pb.Add(a => a.IsMultipleSelect, true);
+                pb.Add(a => a.DynamicContext, CreateDynamicContext(localizer));
+                pb.Add(a => a.SelectedRows, selectedRows);
+                pb.Add(a => a.SelectedRowsChanged, EventCallback.Factory.Create<List<DynamicObject>>(this, rows => selectedRows = rows));
+            });
+        });
+
+        // CardView 模式无表头
+        // 共 2 行数据选中第一行数据
+        var input = cut.FindComponents<Checkbox<Guid>>()[0];
+        await cut.InvokeAsync(input.Instance.OnToggleClick);
+
+        Assert.Single(selectedRows);
+        Assert.Equal(0, selectedRows[0].GetValue("Id"));
+
+        // 取消选中
+        await cut.InvokeAsync(input.Instance.OnToggleClick);
+        Assert.Empty(selectedRows);
+    }
+
+    [Fact]
     public async Task DynamicContext_HeaderCheckGuid_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();


### PR DESCRIPTION
## Link issues
fixes #7908 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add unit tests to verify table behavior with dynamic contexts and ensure dynamic assemblies are not retained by Blazor change detection caching.

Enhancements:
- Tidy table checkbox markup to better distinguish dynamic-object and non-dynamic-object selection handling.

Tests:
- Add tests covering row selection in card view mode for dynamic objects using GUID-based checkboxes.
- Add tests for header checkbox selection and deselection with dynamic contexts, including filtering selectable rows via ShowRowCheckboxCallback.
- Add a test validating that dynamically generated types from BootstrapBlazor_DynamicAssembly are not cached in Blazor's change detection immutable types cache after table disposal.