### PR TITLE
feat(Table): support Cancel use DataTableDynamicObject model

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -653,9 +653,7 @@ public partial class Table<TItem>
                 await ToggleLoading(true);
 
                 // 复制对象给编辑模型
-                EditModel = (IsTracking || DynamicContext is not DataTableDynamicContext)
-                    ? SelectedRows[0]
-                    : Utility.Clone(SelectedRows[0]);
+                EditModel = GetEditModel(SelectedRows[0]);
                 if (OnEditAsync != null)
                 {
                     await OnEditAsync(EditModel);
@@ -698,6 +696,16 @@ public partial class Table<TItem>
             var content = SelectedRows.Count == 0 ? EditButtonToastNotSelectContent : EditButtonToastMoreSelectContent;
             await ShowToastAsync(EditButtonToastTitle, content);
         }
+    }
+
+    private TItem GetEditModel(TItem item)
+    {
+        if (IsTracking)
+        {
+            return item;
+        }
+
+        return DynamicContext is DataTableDynamicContext ? Utility.Clone(item) : item;
     }
 
     private async Task ShowToastAsync(string title, string content, ToastCategory category = ToastCategory.Information)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -651,7 +651,11 @@ public partial class Table<TItem>
             else
             {
                 await ToggleLoading(true);
-                EditModel = (IsTracking || DynamicContext != null) ? SelectedRows[0] : Utility.Clone(SelectedRows[0]);
+
+                // 复制对象给编辑模型
+                EditModel = (IsTracking || DynamicContext is not DataTableDynamicContext)
+                    ? SelectedRows[0]
+                    : Utility.Clone(SelectedRows[0]);
                 if (OnEditAsync != null)
                 {
                     await OnEditAsync(EditModel);

--- a/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
+++ b/src/BootstrapBlazor/Dynamic/DataTableDynamicContext.cs
@@ -290,6 +290,9 @@ public class DataTableDynamicContext : DynamicObjectContext
         // 更新内部 DataRow
         if (_dataCache.TryGetValue(item.DynamicObjectPrimaryKey, out var cacheItem))
         {
+            // 更新动态类型数据
+            Utility.SetPropertyValue<object, object?>(cacheItem, column.GetFieldName(), val);
+
             // 更新原始 DataTable
             if (cacheItem.Row != null)
             {

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -220,10 +220,7 @@ public static class ObjectExtensions
     {
         if (item != null)
         {
-            var type = typeof(TModel);
-
-            // <para lang="zh">20200608 tian_teng@outlook.com 支持字段和只读属性</para>
-            // <para lang="en">20200608 tian_teng@outlook.com Support fields and read-only properties</para>
+            var type = item.GetType();
             foreach (var f in type.GetFields())
             {
                 var v = f.GetValue(item);

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -6687,6 +6687,37 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task DynamicContext_InCell_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer, 2);
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<DynamicObject>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.IsMultipleSelect, true);
+                pb.Add(a => a.EditMode, EditMode.InCell);
+                pb.Add(a => a.ShowToolbar, true);
+                pb.Add(a => a.ShowExtendButtons, true);
+                pb.Add(a => a.DynamicContext, CreateDynamicContext(localizer));
+            });
+        });
+
+        // 选中行
+        var input = cut.FindComponents<Checkbox<Guid>>()[1];
+        await cut.InvokeAsync(input.Instance.OnToggleClick);
+
+        // 点击编辑按钮
+        var editButton = cut.FindComponents<TableToolbarButton<DynamicObject>>()[1];
+        await cut.InvokeAsync(() => editButton.Instance.OnClick.InvokeAsync());
+
+        // 点击取消按钮
+        var cancelButton = cut.FindComponents<Button>().First(i => i.Instance.Text == "取消");
+        await cut.InvokeAsync(() => cancelButton.Instance.OnClick.InvokeAsync());
+    }
+
+    [Fact]
     public void DynamicContext_Pagination()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();


### PR DESCRIPTION
## Link issues
fixes #7916 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Support canceling edits when using the DataTableDynamicObject model by correctly cloning and syncing dynamic table data.

Bug Fixes:
- Fix editing behavior so dynamic table rows backed by DataTableDynamicContext are cloned instead of edited in place, enabling cancel operations to revert changes.
- Correct object cloning to use the runtime type of the instance, ensuring fields and read-only properties are copied properly.
- Ensure dynamic table cell changes are propagated back to the underlying cached data and DataRow when values are edited.