### PR TITLE
feat(Table): support virtualize on dynamic datatable mode

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta02</Version>
+    <Version>10.6.1-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -397,17 +397,17 @@
             <tbody>
             @if (ScrollMode == ScrollMode.Virtual)
             {
-                @if (Items != null)
+                @if (OnQueryAsync != null)
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="@OverscanCount" Items="@Items.ToList()"
-                                ChildContent="RenderRow">
+                    <Virtualize @ref="_virtualizeElement"
+                                ItemSize="RowHeight" OverscanCount="@OverscanCount" ItemsProvider="LoadItems"
+                                ItemContent="RenderRow" Placeholder="RenderPlaceholderRow">
                     </Virtualize>
                 }
                 else
                 {
-                    <Virtualize @ref="_virtualizeElement"
-                                ItemSize="RowHeight" OverscanCount="@OverscanCount" Placeholder="RenderPlaceholderRow"
-                                ItemsProvider="LoadItems" ItemContent="RenderRow">
+                    <Virtualize ItemSize="RowHeight" OverscanCount="@OverscanCount" Items="@Rows"
+                                ChildContent="RenderRow">
                     </Virtualize>
                 }
             }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -8422,6 +8422,8 @@ public class TableTest : BootstrapBlazorTestBase
     [Fact]
     public void PlaceHolder_Ok()
     {
+        // 占位符仅在 OnQueryAsync 不为空时生效
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var cut = Context.Render<BootstrapBlazorRoot>(pb =>
         {
             pb.AddChildContent<MockTable>(pb =>
@@ -8438,6 +8440,7 @@ public class TableTest : BootstrapBlazorTestBase
                     builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
                     builder.CloseComponent();
                 });
+                pb.Add(a => a.OnQueryAsync, OnQueryAsync(localizer));
             });
         });
 


### PR DESCRIPTION
## Link issues
fixes #7937 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adjust table virtualization behavior to correctly support virtual scrolling in dynamic (OnQueryAsync) data mode and update tests accordingly.

New Features:
- Enable virtualized scrolling when the table is in dynamic data mode driven by OnQueryAsync.

Bug Fixes:
- Ensure placeholders are only used during virtualization when OnQueryAsync is configured, preventing incorrect placeholder behavior with static data.

Tests:
- Update the table placeholder unit test to cover virtualization behavior when OnQueryAsync is set.