### PR TITLE
feat(IZipArchiveService): add use current culture code page logic

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta03</Version>
+    <Version>10.6.1-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Services/DefaultZipArchiveService.cs
+++ b/src/BootstrapBlazor/Services/DefaultZipArchiveService.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using System.Globalization;
 using System.IO.Compression;
 using System.Text;
 
@@ -10,6 +11,13 @@ namespace BootstrapBlazor.Components;
 
 class DefaultZipArchiveService : IZipArchiveService
 {
+    static DefaultZipArchiveService()
+    {
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+    }
+
+    private static Encoding GetEntryEncoding(Encoding? encoding) => encoding ?? Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage);
+
     /// <summary>
     /// <inheritdoc cref="IZipArchiveService.ArchiveAsync(IEnumerable{string}, ArchiveOptions?)"/>
     /// </summary>
@@ -98,6 +106,8 @@ class DefaultZipArchiveService : IZipArchiveService
             {
                 Directory.CreateDirectory(folder);
             }
+
+            encoding = GetEntryEncoding(encoding);
 #if NET10_0_OR_GREATER
             await ZipFile.CreateFromDirectoryAsync(directoryName, archiveFile, compressionLevel, includeBaseDirectory, encoding, token);
 #else
@@ -120,6 +130,7 @@ class DefaultZipArchiveService : IZipArchiveService
             Directory.CreateDirectory(destinationDirectoryName);
         }
 
+        encoding = GetEntryEncoding(encoding);
 #if NET10_0_OR_GREATER
         await ZipFile.ExtractToDirectoryAsync(archiveFile, destinationDirectoryName, encoding, overwriteFiles, token);
 #else
@@ -137,7 +148,7 @@ class DefaultZipArchiveService : IZipArchiveService
     /// </summary>
     public ZipArchiveEntry? GetEntry(string archiveFile, string entryFile, bool overwriteFiles = false, Encoding? encoding = null)
     {
-        using var archive = ZipFile.Open(archiveFile, ZipArchiveMode.Read, encoding);
+        using var archive = ZipFile.Open(archiveFile, ZipArchiveMode.Read, GetEntryEncoding(encoding));
         return archive.GetEntry(Path.GetFileName(entryFile));
     }
 }

--- a/src/BootstrapBlazor/Services/IZipArchiveService.cs
+++ b/src/BootstrapBlazor/Services/IZipArchiveService.cs
@@ -58,7 +58,7 @@ public interface IZipArchiveService
     /// <param name="directoryName"><para lang="zh">要归档文件夹</para><para lang="en">Directory to archive</para></param>
     /// <param name="compressionLevel"><para lang="zh">压缩率</para><para lang="en">Compression Level</para></param>
     /// <param name="includeBaseDirectory"><para lang="zh">是否包含本目录 默认 false</para><para lang="en">Include base directory, default false</para></param>
-    /// <param name="encoding"><para lang="zh">编码方式 默认 null 内部使用 UTF-8</para><para lang="en">Encoding, default null, internal use UTF-8</para></param>
+    /// <param name="encoding"><para lang="zh">编码方式 默认 null 内部使用当前系统 ANSI 编码</para><para lang="en">Encoding, default null, internal use current system ANSI encoding</para></param>
     /// <param name="token"></param>
     Task ArchiveDirectoryAsync(string archiveFile, string directoryName, CompressionLevel compressionLevel = CompressionLevel.Optimal, bool includeBaseDirectory = false, Encoding? encoding = null, CancellationToken token = default);
 
@@ -69,7 +69,7 @@ public interface IZipArchiveService
     /// <param name="archiveFile"><para lang="zh">归档文件</para><para lang="en">归档文件</para></param>
     /// <param name="destinationDirectoryName"><para lang="zh">解压缩文件夹</para><para lang="en">Destination Directory</para></param>
     /// <param name="overwriteFiles"><para lang="zh">是否覆盖文件 默认 false 不覆盖</para><para lang="en">Overwrite files, default false</para></param>
-    /// <param name="encoding"><para lang="zh">编码方式 默认 null 内部使用 UTF-8</para><para lang="en">Encoding, default null, internal use UTF-8</para></param>
+    /// <param name="encoding"><para lang="zh">编码方式 默认 null 内部使用当前系统 ANSI 编码</para><para lang="en">Encoding, default null, internal use current system ANSI encoding</para></param>
     /// <param name="token"></param>
     Task<bool> ExtractToDirectoryAsync(string archiveFile, string destinationDirectoryName, bool overwriteFiles = false, Encoding? encoding = null, CancellationToken token = default);
 


### PR DESCRIPTION
## Link issues
fixes #7939 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Use the current system ANSI code page as the default encoding for zip archive operations when no encoding is specified.

Enhancements:
- Initialize the zip archive service with the code pages encoding provider and centralize selection of entry encoding based on the current culture ANSI code page.

Documentation:
- Update IZipArchiveService XML documentation to state that null encoding defaults to the current system ANSI encoding instead of UTF-8.