### PR TITLE
refactor(Table): updating column state persistence

### DIFF
--- a/src/BootstrapBlazor/Components/Table/ColumnVisibleItem.cs
+++ b/src/BootstrapBlazor/Components/Table/ColumnVisibleItem.cs
@@ -32,11 +32,4 @@ public class ColumnVisibleItem
     /// <para lang="en">Gets column visibility</para>
     /// </summary>
     public bool Visible { get; set; }
-
-    /// <summary>
-    /// <para lang="zh">获得 列可见性顺序</para>
-    /// <para lang="en">Gets column visibility order</para>
-    /// </summary>
-    [JsonIgnore]
-    public int Order { get; set; }
 }

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -963,18 +963,12 @@
                                 </div>
                                 <Divider />
                                 <div class="column-list-items">
-                                    @foreach (var item in _columnVisibleItems)
-                                    {
-                                        @RenderColumnListItem(item)
-                                    }
+                                    @RenderColumnList()
                                 </div>
                             }
                             else
                             {
-                                @foreach (var item in _columnVisibleItems)
-                                {
-                                    @RenderColumnListItem(item)
-                                }
+                                @RenderColumnList()
                             }
                         </div>
                     </div>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -1,5 +1,4 @@
 @namespace BootstrapBlazor.Components
-@using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TItem
 @inherits BootstrapModuleComponentBase
 @attribute [BootstrapModuleAutoLoader(JSObjectReference = true)]
@@ -21,6 +20,8 @@
     }
     else
     {
+        BuildTableColumns();
+        RebuildVisibleColumnsCache();
         if (ShowSearch && SearchMode == SearchMode.Top)
         {
             @RenderSearch
@@ -38,10 +39,6 @@
 
         <RenderTemplate OnRenderAsync="OnTableRenderAsync">
             <div class="@WrapperClassName" style="@GetScrollStyleString(!IsFixedHeader)">
-                @{
-                    BuildTableColumns();
-                    RebuildVisibleColumnsCache();
-                }
                 @if (ActiveRenderMode == TableRenderMode.Table)
                 {
                     if (IsFixedHeader)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
@@ -196,6 +196,7 @@ public partial class Table<TItem>
             column.Visible = !column.Visible;
         }
 
+        // 如果全部列都不可见了，则至少显示第一列
         if (_columnVisibleItems.All(i => i.Visible == false))
         {
             _columnVisibleItems.First().Visible = true;

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -558,10 +558,9 @@ public partial class Table<TItem>
     {
         _visibleColumnsCache.Clear();
 
-        var columns = _columnVisibleItems.OrderBy(i => i.Order).ToList();
-        for (var index = 0; index < columns.Count; index++)
+        for (var index = 0; index < _columnVisibleItems.Count; index++)
         {
-            var item = columns[index];
+            var item = _columnVisibleItems[index];
             if (item.Visible)
             {
                 var col = Columns.FirstOrDefault(c => c.GetFieldName() == item.Name);

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1121,9 +1121,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             // 读取浏览器持久化列状态配置
             await ReloadColumnStatesFromBrowserAsync();
 
-            // 构建列信息
-            BuildTableColumns();
-
             // 列排序回调方法
             if (ColumnOrderCallback != null)
             {
@@ -1287,6 +1284,24 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         }
     }
 
+    private async Task ReloadColumnStatesFromBrowserAsync()
+    {
+        // 未开启客户端持久化功能直接返回
+        if (string.IsNullOrEmpty(ClientTableName))
+        {
+            return;
+        }
+
+        var state = await InvokeAsync<TableColumnLocalstorageStatus>("getColumnStates", ClientTableName);
+        if (state != null)
+        {
+            state.ColumnWidthState ??= new();
+            state.ColumnVisibleStates ??= new();
+
+            _tableColumnStateCache = state;
+        }
+    }
+
     private void BuildTableColumns()
     {
         // 动态列模式
@@ -1321,52 +1336,46 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private void RebuildTableColumnFromCache(List<ITableColumn> cols)
     {
-        foreach (var col in cols)
+        if (!string.IsNullOrEmpty(ClientTableName))
         {
-            // 设置列宽度
-            var column = _tableColumnStateCache.ColumnWidthState.ColumnWidths.Find(i => i.Name == col.GetFieldName());
-            if (column != null)
+            // 提高性能避免循环
+            foreach (var col in cols)
             {
-                col.Width = column.Width;
-            }
+                var fieldName = col.GetFieldName();
 
-            // 设置列可见性
-            var columnVisible = _tableColumnStateCache.ColumnVisibleStates.Find(i => i.Name == col.GetFieldName());
-            var order = 0;
-            if (columnVisible != null)
-            {
-                col.Visible = columnVisible.Visible;
-                order = _tableColumnStateCache.ColumnVisibleStates.IndexOf(columnVisible);
-            }
-
-            // 更新 _visibleColumns 中的列信息
-            var fieldName = col.GetFieldName();
-            var c = _columnVisibleItems.Find(i => i.Name == fieldName);
-            if (col.Ignore is true)
-            {
-                if (c != null)
+                // 设置列宽度
+                var column = _tableColumnStateCache.ColumnWidthState.ColumnWidths.Find(i => i.Name == fieldName);
+                if (column != null)
                 {
-                    _columnVisibleItems.Remove(c);
+                    col.Width = column.Width;
                 }
-                continue;
-            }
 
-            if (c == null)
-            {
-                _columnVisibleItems.Add(new ColumnVisibleItem()
+                // 设置列可见性
+                var columnVisible = _tableColumnStateCache.ColumnVisibleStates.Find(i => i.Name == fieldName);
+                if (columnVisible != null)
                 {
-                    Name = fieldName,
-                    Visible = col.Visible ?? true,
-                    DisplayName = col.GetDisplayName(),
-                    Order = order
-                });
-            }
-            else
-            {
-                c.Visible = col.Visible ?? true;
-                c.Order = order;
+                    col.Visible = columnVisible.Visible;
+                    columnVisible.DisplayName = col.GetDisplayName();
+                }
             }
         }
+
+        // 设置可见列顺序
+        _columnVisibleItems.Clear();
+        _columnVisibleItems.AddRange(GetColumnVisibleItems(cols));
+    }
+
+    private List<ColumnVisibleItem> GetColumnVisibleItems(List<ITableColumn> cols)
+    {
+        // 开启客户端持久化后未设置列状态的列默认使用组件参数值
+        return _tableColumnStateCache.ColumnVisibleStates.Count != 0
+            ? _tableColumnStateCache.ColumnVisibleStates
+            : [.. cols.Where(i => !i.GetIgnore()).Select(i => new ColumnVisibleItem()
+            {
+                Name = i.GetFieldName(),
+                Visible = i.GetVisible(),
+                DisplayName = i.GetDisplayName()
+            })];
     }
 
     private async Task OnTableRenderAsync(bool firstRender)
@@ -1429,24 +1438,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         var tableWidth = hasHeader ? width : width - ActualScrollWidth;
 
         return $"width: {tableWidth}px;";
-    }
-
-    private async Task ReloadColumnStatesFromBrowserAsync()
-    {
-        // 未开启客户端持久化功能直接返回
-        if (string.IsNullOrEmpty(ClientTableName))
-        {
-            return;
-        }
-
-        var state = await InvokeAsync<TableColumnLocalstorageStatus>("getColumnStates", ClientTableName);
-        if (state != null)
-        {
-            state.ColumnWidthState ??= new();
-            state.ColumnVisibleStates ??= new();
-
-            _tableColumnStateCache = state;
-        }
     }
 
     /// <summary>
@@ -1871,13 +1862,23 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 _columnVisibleItems.Remove(firstColumn);
                 _columnVisibleItems.Insert(currentIndex, firstColumn);
 
+                if (!string.IsNullOrEmpty(ClientTableName))
+                {
+                    // 更新缓存数据中列顺序
+                    var columnVisibleState = _tableColumnStateCache.ColumnVisibleStates;
+                    columnVisibleState.Clear();
+                    columnVisibleState.AddRange(_columnVisibleItems);
+                }
+
                 if (OnDragColumnEndAsync != null)
                 {
                     await OnDragColumnEndAsync(firstColumn.Name, Columns);
                 }
-
-                StateHasChanged();
             }
+            _resetColumns = true;
+            _invoke = true;
+
+            StateHasChanged();
         }
     }
 
@@ -1888,13 +1889,16 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     [JSInvokable]
     public async Task ResizeColumnCallback(string name, int columnWidth, int tableWidth)
     {
-        // 更新缓存数据中列宽度
-        var col = _tableColumnStateCache.ColumnWidthState.ColumnWidths.Find(i => i.Name == name);
-        if (col != null)
+        if (!string.IsNullOrEmpty(ClientTableName))
         {
-            col.Width = columnWidth;
+            // 更新缓存数据中列宽度
+            var col = _tableColumnStateCache.ColumnWidthState.ColumnWidths.Find(i => i.Name == name);
+            if (col != null)
+            {
+                col.Width = columnWidth;
 
-            _tableColumnStateCache.ColumnWidthState.TableWidth = tableWidth;
+                _tableColumnStateCache.ColumnWidthState.TableWidth = tableWidth;
+            }
         }
 
         // 触发回调
@@ -1980,6 +1984,15 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         if (ShowExtendButtons && !IsExtendButtonsInRowHeader)
         {
             builder.AddContent(2, RenderRowExtendButtons(item));
+        }
+    };
+
+    private RenderFragment RenderColumnList() => builder =>
+    {
+        for (int index = 0; index < _columnVisibleItems.Count; index++)
+        {
+            var column = _columnVisibleItems[index];
+            builder.AddContent(index, RenderColumnListItem(column));
         }
     };
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -525,9 +525,9 @@ const setResizeListener = table => {
                     colWidth = parseInt(width)
                 }
                 else {
-                    colWidth = getWidth(col.closest('th')) | 0;
+                    colWidth = getWidth(col.closest('th'));
                 }
-                tableWidth = getWidth(col.closest('table')) | 0;
+                tableWidth = getWidth(col.closest('table'));
                 originalX = e.clientX ?? e.touches[0].clientX
             },
             e => {
@@ -572,8 +572,8 @@ const setResizeListener = table => {
                 saveColumnWidth(table);
                 const field = col.getAttribute('data-bb-field');
                 const th = col.closest('th')
-                const width = getWidth(th) | 0;
-                const tableWidth = table.tables[0].offsetWidth | 0;
+                const width = getWidth(th);
+                const tableWidth = getWidth(table.tables[0]);
                 table.invoke.invokeMethodAsync(table.options.resizeColumnCallback, field, width, tableWidth);
             }
         )
@@ -586,7 +586,7 @@ const resizeNextFixedColumnWidth = (col, width) => {
         if (nextColumn.classList.contains('fixed')) {
             const right = parseFloat(col.style.getPropertyValue('right'));
             nextColumn.style.setProperty('right', `${right + width}px`);
-            resizeNextFixedColumnWidth(nextColumn, nextColumn.offsetWidth);
+            resizeNextFixedColumnWidth(nextColumn, getWidth(nextColumn));
         }
     }
     else if (col.classList.contains('fixed')) {
@@ -594,7 +594,7 @@ const resizeNextFixedColumnWidth = (col, width) => {
         if (nextColumn.classList.contains('fixed')) {
             const left = parseFloat(col.style.getPropertyValue('left'));
             nextColumn.style.setProperty('left', `${left + width}px`);
-            resizeNextFixedColumnWidth(nextColumn, nextColumn.offsetWidth);
+            resizeNextFixedColumnWidth(nextColumn, getWidth(nextColumn));
         }
     }
 }
@@ -631,7 +631,7 @@ const setColumnResizingListen = (table, col) => {
 }
 
 const getColumnTooltipTitle = (options, th) => {
-    return `${options.columnWidthTooltipPrefix}${th.offsetWidth}px`;
+    return `${options.columnWidthTooltipPrefix}${getWidth(th)}px`;
 }
 
 const indexOfCol = col => {
@@ -681,7 +681,7 @@ const autoFitColumnWidth = async (table, col) => {
 
         setTableDefaultWidth(table);
         const widthState = getColumnWidthStateObject(table);
-        await table.invoke.invokeMethodAsync(table.options.resizeColumnCallback, index, maxWidth | 0, widthState)
+        await table.invoke.invokeMethodAsync(table.options.resizeColumnCallback, index, maxWidth, widthState)
 
         resetColumnWidthTips(table, col);
     }
@@ -700,7 +700,7 @@ const calcCellWidth = cell => {
     document.body.appendChild(div);
 
     const cellStyle = getComputedStyle(cell);
-    return div.offsetWidth + parseFloat(cellStyle.getPropertyValue('padding-left')) + parseFloat(cellStyle.getPropertyValue('padding-right')) + parseFloat(cellStyle.getPropertyValue('border-left-width')) + parseFloat(cellStyle.getPropertyValue('border-right-width')) + 1;
+    return getWidth(div) + parseFloat(cellStyle.getPropertyValue('padding-left')) + parseFloat(cellStyle.getPropertyValue('padding-right')) + parseFloat(cellStyle.getPropertyValue('border-left-width')) + parseFloat(cellStyle.getPropertyValue('border-right-width')) + 1;
 }
 
 const closeAllTips = (columns, self) => {
@@ -929,10 +929,10 @@ const saveColumnWidth = table => {
 
 const getColumnWidthStateObject = table => {
     const cols = table.columns
-    const tableWidth = table.tables[0].offsetWidth | 0;
+    const tableWidth = getWidth(table.tables[0]);
     return {
         "cols": cols.map(col => {
-            return { "width": col.closest('th').offsetWidth | 0, "name": col.getAttribute('data-bb-field') }
+            return { "width": getWidth(col.closest('th')), "name": col.getAttribute('data-bb-field') }
         }),
         "table": tableWidth
     }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -424,7 +424,7 @@ const resetTableWidth = table => {
                 let colWidth = parseInt(col.style.width);
                 const index = [...group.children].indexOf(col);
                 if (isNaN(colWidth)) {
-                    colWidth = col.offsetWidth;
+                    colWidth = getWidth(col);
                 }
                 width += colWidth;
             })

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -422,8 +422,9 @@ const resetTableWidth = table => {
             let width = 0;
             [...group.children].forEach(col => {
                 let colWidth = parseInt(col.style.width);
+                const index = [...group.children].indexOf(col);
                 if (isNaN(colWidth)) {
-                    colWidth = 100;
+                    colWidth = col.offsetWidth;
                 }
                 width += colWidth;
             })
@@ -572,7 +573,7 @@ const setResizeListener = table => {
                 const field = col.getAttribute('data-bb-field');
                 const th = col.closest('th')
                 const width = getWidth(th) | 0;
-                const tableWidth =  table.tables[0].offsetWidth | 0;
+                const tableWidth = table.tables[0].offsetWidth | 0;
                 table.invoke.invokeMethodAsync(table.options.resizeColumnCallback, field, width, tableWidth);
             }
         )
@@ -641,7 +642,6 @@ const indexOfCol = col => {
 
 const autoFitColumnWidth = async (table, col) => {
     const field = col.getAttribute('data-bb-field');
-
     const index = indexOfCol(col);
     let rows = null;
     if (table.thead) {
@@ -823,11 +823,13 @@ const setDraggable = table => {
             })
             dragItem = null
         })
-        EventHandler.on(col, 'drop', e => {
+        EventHandler.on(col, 'drop', async e => {
             e.stopPropagation()
             e.preventDefault()
             if (table.options.dragColumnCallback) {
-                table.invoke.invokeMethodAsync(table.options.dragColumnCallback, index, table.dragColumns.indexOf(col))
+                const orginIndex = index;
+                const currentIndex = table.dragColumns.indexOf(col);
+                table.invoke.invokeMethodAsync(table.options.dragColumnCallback, orginIndex, currentIndex);
             }
             return false
         })
@@ -910,7 +912,7 @@ const getLocalStorageValue = key => {
     return result;
 }
 
-const saveColumnList = (tableName, columns) => {
+const saveColumnVisibleList = (tableName, columns) => {
     if (tableName) {
         const key = `bb-table-column-visible-${tableName}`
         localStorage.setItem(key, JSON.stringify(columns));
@@ -1011,7 +1013,7 @@ const resetColumns = (table, options) => {
     const { visibleColumns, allowDragColumn } = options;
     const { options: { tableName } } = table;
     if (tableName && visibleColumns) {
-        saveColumnList(tableName, visibleColumns);
+        saveColumnVisibleList(tableName, visibleColumns);
     }
 
     if (allowDragColumn) {

--- a/src/BootstrapBlazor/_Imports.razor
+++ b/src/BootstrapBlazor/_Imports.razor
@@ -1,8 +1,9 @@
-﻿@using BootstrapBlazor.Components
+@using BootstrapBlazor.Components
 @using Microsoft.AspNetCore.Authorization
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using System.Net.Http
 @using System.Threading.Tasks


### PR DESCRIPTION
## Link issues
fixes #7953 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refine table column persistence, sizing, and drag behavior, and streamline how visible columns are built and rendered.

Bug Fixes:
- Prevent all table columns from becoming invisible by forcing at least the first column to remain visible when toggling visibility.

Enhancements:
- Load client-side column state earlier in the lifecycle and rebuild visible columns from cache or current configuration as appropriate.
- Simplify and centralize visible-column list rendering and ordering, removing the explicit Order field from ColumnVisibleItem and using list position instead.
- Ensure drag-and-drop column reordering and column resizing update the persisted client-side state only when client persistence is enabled, and always trigger a table re-render.
- Standardize width calculations in the table JavaScript helpers using getWidth to avoid direct offsetWidth access and bitwise casts, improving consistency and robustness.
- Rename and clarify localStorage helpers for saving visible column lists and refine auto-fit and tooltip behavior based on computed widths.