### PR TITLE
revert(SelectTable): revert Columns parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor.cs
@@ -13,7 +13,7 @@ namespace BootstrapBlazor.Components;
 /// </summary>
 /// <typeparam name="TItem"></typeparam>
 [CascadingTypeParameter(nameof(TItem))]
-public partial class SelectTable<TItem> where TItem : class, new()
+public partial class SelectTable<TItem> : IColumnCollection where TItem : class, new()
 {
     /// <summary>
     /// <para lang="zh">获得/设置 是否为多选模式，默认值为 false</para>
@@ -168,6 +168,12 @@ public partial class SelectTable<TItem> where TItem : class, new()
     [Inject]
     [NotNull]
     protected IIconTheme? IconTheme { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得表格列集合</para>
+    /// <para lang="en">Get Table Column Collection</para>
+    /// </summary>
+    public List<ITableColumn> Columns => _table.Columns;
 
     private string? ClassName => CssBuilder.Default("select select-table dropdown")
         .AddClass("disabled", IsDisabled)

--- a/test/UnitTest/Components/SelectTableTest.cs
+++ b/test/UnitTest/Components/SelectTableTest.cs
@@ -687,6 +687,39 @@ public class SelectTableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void Columns_Ok()
+    {
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var items = Foo.GenerateFoo(localizer);
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<SelectTable<Foo>>(pb =>
+            {
+                pb.Add(a => a.OnQueryAsync, options => OnFilterQueryAsync(options, items));
+                pb.Add(a => a.GetTextCallback, foo => foo.Name);
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Address");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.CloseComponent();
+                });
+            });
+        });
+
+        var table = cut.FindComponent<SelectTable<Foo>>();
+        Assert.Equal(2, table.Instance.Columns.Count);
+        Assert.Collection(table.Instance.Columns,
+            col => Assert.Equal(nameof(Foo.Name), col.GetFieldName()),
+            col => Assert.Equal(nameof(Foo.Address), col.GetFieldName()));
+    }
+
+    [Fact]
     public void ToolbarTemplate_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();


### PR DESCRIPTION
## Link issues
fixes #7969 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Expose the underlying table column collection from SelectTable and verify it via unit tests.

Bug Fixes:
- Restore access to SelectTable column metadata by implementing the column collection interface and exposing the Columns property.

Tests:
- Add a unit test to verify that configuring SelectTable.TableColumns correctly populates the Columns collection.