### PR TITLE
feat(Utiltiy): improve drag api

### DIFF
--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -327,27 +327,27 @@ const drag = (element, start, move, end) => {
     let dragging = false
 
     const addDocumentListeners = () => {
-        document.addEventListener('mousemove', handleDragMove, true)
-        document.addEventListener('touchmove', handleDragMove, true)
-        document.addEventListener('mouseup', handleDragEnd, true)
-        document.addEventListener('touchend', handleDragEnd, true)
-        document.addEventListener('touchcancel', handleDragEnd, true)
-        window.addEventListener('mouseup', handleDragEnd, true)
-        window.addEventListener('touchend', handleDragEnd, true)
-        window.addEventListener('touchcancel', handleDragEnd, true)
-        window.addEventListener('blur', handleDragEnd, true)
+        EventHandler.on(document, 'mousemove', handleDragMove)
+        EventHandler.on(document, 'touchmove', handleDragMove)
+        EventHandler.on(document, 'mouseup', handleDragEnd)
+        EventHandler.on(document, 'touchend', handleDragEnd)
+        EventHandler.on(document, 'touchcancel', handleDragEnd)
+        EventHandler.on(window, 'mouseup', handleDragEnd)
+        EventHandler.on(window, 'touchend', handleDragEnd)
+        EventHandler.on(window, 'touchcancel', handleDragEnd)
+        EventHandler.on(window, 'blur', handleDragEnd)
     }
 
     const removeDocumentListeners = () => {
-        document.removeEventListener('mousemove', handleDragMove, true)
-        document.removeEventListener('touchmove', handleDragMove, true)
-        document.removeEventListener('mouseup', handleDragEnd, true)
-        document.removeEventListener('touchend', handleDragEnd, true)
-        document.removeEventListener('touchcancel', handleDragEnd, true)
-        window.removeEventListener('mouseup', handleDragEnd, true)
-        window.removeEventListener('touchend', handleDragEnd, true)
-        window.removeEventListener('touchcancel', handleDragEnd, true)
-        window.removeEventListener('blur', handleDragEnd, true)
+        EventHandler.off(document, 'mousemove', handleDragMove)
+        EventHandler.off(document, 'touchmove', handleDragMove)
+        EventHandler.off(document, 'mouseup', handleDragEnd)
+        EventHandler.off(document, 'touchend', handleDragEnd)
+        EventHandler.off(document, 'touchcancel', handleDragEnd)
+        EventHandler.off(window, 'mouseup', handleDragEnd)
+        EventHandler.off(window, 'touchend', handleDragEnd)
+        EventHandler.off(window, 'touchcancel', handleDragEnd)
+        EventHandler.off(window, 'blur', handleDragEnd)
     }
 
     const handleDragStart = e => {

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -324,7 +324,37 @@ const insertAfter = (element, newEl) => {
 }
 
 const drag = (element, start, move, end) => {
+    let dragging = false
+
+    const addDocumentListeners = () => {
+        document.addEventListener('mousemove', handleDragMove, true)
+        document.addEventListener('touchmove', handleDragMove, true)
+        document.addEventListener('mouseup', handleDragEnd, true)
+        document.addEventListener('touchend', handleDragEnd, true)
+        document.addEventListener('touchcancel', handleDragEnd, true)
+        window.addEventListener('mouseup', handleDragEnd, true)
+        window.addEventListener('touchend', handleDragEnd, true)
+        window.addEventListener('touchcancel', handleDragEnd, true)
+        window.addEventListener('blur', handleDragEnd, true)
+    }
+
+    const removeDocumentListeners = () => {
+        document.removeEventListener('mousemove', handleDragMove, true)
+        document.removeEventListener('touchmove', handleDragMove, true)
+        document.removeEventListener('mouseup', handleDragEnd, true)
+        document.removeEventListener('touchend', handleDragEnd, true)
+        document.removeEventListener('touchcancel', handleDragEnd, true)
+        window.removeEventListener('mouseup', handleDragEnd, true)
+        window.removeEventListener('touchend', handleDragEnd, true)
+        window.removeEventListener('touchcancel', handleDragEnd, true)
+        window.removeEventListener('blur', handleDragEnd, true)
+    }
+
     const handleDragStart = e => {
+        if (dragging) {
+            handleDragEnd(e)
+        }
+
         let notDrag = false
         if (isFunction(start)) {
             notDrag = start(e) || false
@@ -336,16 +366,22 @@ const drag = (element, start, move, end) => {
             }
             e.stopPropagation()
 
-            document.addEventListener('mousemove', handleDragMove)
-            document.addEventListener('touchmove', handleDragMove)
-            document.addEventListener('mouseup', handleDragEnd)
-            document.addEventListener('touchend', handleDragEnd)
+            dragging = true
+            addDocumentListeners()
         }
     }
 
     const handleDragMove = e => {
+        if (!dragging) {
+            return
+        }
+
         if (e.touches && e.touches.length > 1) {
             return;
+        }
+
+        if (e.cancelable) {
+            e.preventDefault();
         }
 
         if (isFunction(move)) {
@@ -354,21 +390,20 @@ const drag = (element, start, move, end) => {
     }
 
     const handleDragEnd = e => {
+        if (!dragging) {
+            return
+        }
+
+        dragging = false
+        removeDocumentListeners()
+
         if (isFunction(end)) {
             end(e)
         }
-
-        const handler = window.setTimeout(() => {
-            window.clearTimeout(handler)
-            document.removeEventListener('mousemove', handleDragMove)
-            document.removeEventListener('touchmove', handleDragMove)
-            document.removeEventListener('mouseup', handleDragEnd)
-            document.removeEventListener('touchend', handleDragEnd)
-        }, 10)
     }
 
-    element.addEventListener('mousedown', handleDragStart)
-    element.addEventListener('touchstart', handleDragStart)
+    EventHandler.on(element, 'mousedown', handleDragStart)
+    EventHandler.on(element, 'touchstart', handleDragStart)
 }
 
 const getDescribedElement = (element, selector = 'aria-describedby', all = false) => {


### PR DESCRIPTION
## Link issues
fixes #7974 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve the shared drag utility to make pointer event handling more robust and easier to manage.

Bug Fixes:
- Ensure drag interactions are correctly stopped on mouseup/touchend/touchcancel/blur, preventing stuck drag state and event leaks.
- Avoid processing drag move/end callbacks when a drag is not active and ignore multi-touch gestures.

Enhancements:
- Refactor the drag utility to use centralized add/remove helpers for document-level event listeners and an explicit dragging state flag.
- Update drag move handling to call preventDefault when possible to reduce unwanted browser scrolling or selection during drags.
- Switch element listener registration to the existing EventHandler abstraction for consistency with other utilities.