### PR TITLE
feat(Table): make sure TableColumnStateCache work without localstorage

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta09</Version>
+    <Version>10.6.1-beta10</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1355,20 +1355,28 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private void RebuildTableColumnFromCache()
     {
-        if (_tableColumnStateCache.Columns.Count != 0)
+        foreach (var col in Columns)
         {
-            foreach (var col in Columns)
-            {
-                var fieldName = col.GetFieldName();
+            var fieldName = col.GetFieldName();
 
-                // 设置列宽度与可见性
-                var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
-                if (column != null)
+            // 设置列宽度与可见性
+            var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
+            if (column == null)
+            {
+                column = new TableColumnState()
                 {
-                    col.Width = column.Width;
-                    col.Visible = column.Visible;
-                    column.DisplayName = col.GetDisplayName();
-                }
+                    Name = fieldName,
+                    Width = col.Width,
+                    Visible = col.GetVisible(),
+                    DisplayName = col.GetDisplayName()
+                };
+                _tableColumnStateCache.Columns.Add(column);
+            }
+            else
+            {
+                col.Width = column.Width;
+                col.Visible = column.Visible;
+                column.DisplayName = col.GetDisplayName();
             }
         }
 
@@ -1877,13 +1885,10 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 _tableColumnStates.Remove(firstColumn);
                 _tableColumnStates.Insert(currentIndex, firstColumn);
 
-                if (!string.IsNullOrEmpty(ClientTableName))
-                {
-                    // 更新缓存数据中列顺序
-                    var columnVisibleState = _tableColumnStateCache.Columns;
-                    columnVisibleState.Clear();
-                    columnVisibleState.AddRange(_tableColumnStates);
-                }
+                // 更新缓存数据中列顺序
+                var columnVisibleState = _tableColumnStateCache.Columns;
+                columnVisibleState.Clear();
+                columnVisibleState.AddRange(_tableColumnStates);
 
                 if (OnDragColumnEndAsync != null)
                 {


### PR DESCRIPTION
## Link issues
fixes #7980 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure table column state cache is kept in sync with table columns even when no persisted client-side storage is available.

New Features:
- Initialize column state cache entries from current table columns when no prior cached state exists.

Enhancements:
- Always update the in-memory column state cache when columns are reordered via drag-and-drop, independent of client-side table name configuration.