### PR TITLE
feat(TableToolbarPopConfirmButton): support TooltipText parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta10</Version>
+    <Version>10.6.1-beta11</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/TableToolbar.razor
+++ b/src/BootstrapBlazor/Components/Table/TableToolbar.razor
@@ -25,6 +25,8 @@
                         <PopConfirmButton AdditionalAttributes="pb.AdditionalAttributes" CustomClass="@pb.CustomClass"
                                           Color="@pb.Color" Icon="@pb.Icon" Text="@pb.Text" Size="pb.Size" ShowShadow="@pb.ShowShadow"
                                           IsAsync="@pb.IsAsync" IsDisabled="GetDisabled(pb)" IsBlock="@pb.IsBlock" IsOutline="@pb.IsOutline"
+                                          TooltipText="@pb.TooltipText" TooltipPlacement="@pb.TooltipPlacement"
+                                          TooltipTrigger="@pb.TooltipTrigger"
                                           OnBeforeClick="@pb.OnBeforeClick" OnClose="@pb.OnClose" OnConfirm="() => OnConfirm(pb)"
                                           ConfirmIcon="@pb.ConfirmIcon" ConfirmButtonColor="@pb.ConfirmButtonColor"
                                           ConfirmButtonText="@pb.ConfirmButtonText" CloseButtonColor="@pb.CloseButtonColor"

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -2683,6 +2683,9 @@ public class TableTest : BootstrapBlazorTestBase
                 {
                     builder.OpenComponent<TableToolbarPopConfirmButton<Foo>>(0);
                     builder.AddAttribute(1, nameof(TableToolbarPopConfirmButton<Foo>.Text), "test");
+                    builder.AddAttribute(5, nameof(TableToolbarPopConfirmButton<Foo>.TooltipText), "test-tooltip");
+                    builder.AddAttribute(6, nameof(TableToolbarPopConfirmButton<Foo>.TooltipPlacement), Placement.Bottom);
+                    builder.AddAttribute(7, nameof(TableToolbarPopConfirmButton<Foo>.TooltipTrigger), "hover");
                     builder.AddAttribute(3, nameof(TableToolbarPopConfirmButton<Foo>.OnClick), EventCallback.Factory.Create<MouseEventArgs>(this, e =>
                     {
                         clicked = true;
@@ -2703,6 +2706,9 @@ public class TableTest : BootstrapBlazorTestBase
         });
 
         var button = cut.FindComponent<PopConfirmButton>();
+        Assert.Equal("test-tooltip", button.Instance.TooltipText);
+        Assert.Equal(Placement.Bottom, button.Instance.TooltipPlacement);
+        Assert.Equal("hover", button.Instance.TooltipTrigger);
         await cut.InvokeAsync(() => button.Instance.OnConfirm!.Invoke());
         Assert.True(clickCallback);
         Assert.True(clicked);


### PR DESCRIPTION
## Link issues
fixes #7960 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add tooltip support to table toolbar pop-confirm buttons and cover it with tests.

New Features:
- Support configuring tooltip text, placement, and trigger on TableToolbarPopConfirmButton and pass them through to the underlying PopConfirmButton.

Tests:
- Extend the TableToolbarPopConfirmButton unit test to verify tooltip text, placement, and trigger are correctly applied to the underlying PopConfirmButton.