### PR TITLE
refactor(Table): update RebuildVisibleColumnsCache method

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -556,19 +556,6 @@ public partial class Table<TItem>
 
     private void RebuildVisibleColumnsCache()
     {
-        var cols = _tableColumnStateCache.Columns.Count != 0
-            ? _tableColumnStateCache.Columns
-            : [.. Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
-                .Select(i => new TableColumnState()
-                {
-                    Name = i.GetFieldName(),
-                    Visible = i.GetVisible(),
-                    DisplayName = i.GetDisplayName()
-                })
-            ];
-        _tableColumnStates.Clear();
-        _tableColumnStates.AddRange(cols);
-
         _visibleColumnsCache.Clear();
         for (var index = 0; index < _tableColumnStates.Count; index++)
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -557,6 +557,7 @@ public partial class Table<TItem>
     private void RebuildVisibleColumnsCache()
     {
         _visibleColumnsCache.Clear();
+
         for (var index = 0; index < _tableColumnStates.Count; index++)
         {
             var item = _tableColumnStates[index];

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -556,8 +556,20 @@ public partial class Table<TItem>
 
     private void RebuildVisibleColumnsCache()
     {
-        _visibleColumnsCache.Clear();
+        var cols = _tableColumnStateCache.Columns.Count != 0
+            ? _tableColumnStateCache.Columns
+            : [.. Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
+                .Select(i => new TableColumnState()
+                {
+                    Name = i.GetFieldName(),
+                    Visible = i.GetVisible(),
+                    DisplayName = i.GetDisplayName()
+                })
+            ];
+        _tableColumnStates.Clear();
+        _tableColumnStates.AddRange(cols);
 
+        _visibleColumnsCache.Clear();
         for (var index = 0; index < _tableColumnStates.Count; index++)
         {
             var item = _tableColumnStates[index];

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1860,10 +1860,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 _tableColumnStates.Remove(firstColumn);
                 _tableColumnStates.Insert(currentIndex, firstColumn);
 
-                // 更新缓存数据中列顺序
-                var columnVisibleState = _tableColumnStateCache.Columns;
-                columnVisibleState.Clear();
-                columnVisibleState.AddRange(_tableColumnStates);
+                if (!string.IsNullOrEmpty(ClientTableName))
+                {
+                    // 更新缓存数据中列顺序
+                    var columnVisibleState = _tableColumnStateCache.Columns;
+                    columnVisibleState.Clear();
+                    columnVisibleState.AddRange(_tableColumnStates);
+                }
 
                 if (OnDragColumnEndAsync != null)
                 {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1890,8 +1890,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             _resetColumns = true;
             _invoke = true;
 
-            RebuildVisibleColumnsCache();
-
             StateHasChanged();
         }
     }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1303,11 +1303,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private async Task BuildTableColumnsAsync()
     {
-        if (_resetColumns)
-        {
-            return;
-        }
-
         // 构建列信息
         var cols = GetTableColumns();
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1375,13 +1375,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         var cols = _tableColumnStateCache.Columns.Count != 0
             ? _tableColumnStateCache.Columns
             : [.. Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
-                        .Select(i => new TableColumnState()
-                        {
+                         .Select(i => new TableColumnState()
+                         {
                             Name = i.GetFieldName(),
                             Visible = i.GetVisible(),
                             DisplayName = i.GetDisplayName(),
                             Width = i.Width
-                        })
+                         })
             ];
         _tableColumnStates.Clear();
         _tableColumnStates.AddRange(cols);

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1303,6 +1303,11 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private async Task BuildTableColumnsAsync()
     {
+        if (_resetColumns)
+        {
+            return;
+        }
+
         // 构建列信息
         var cols = GetTableColumns();
 
@@ -1371,6 +1376,20 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 }
             }
         }
+
+        var cols = _tableColumnStateCache.Columns.Count != 0
+            ? _tableColumnStateCache.Columns
+            : [.. Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
+                        .Select(i => new TableColumnState()
+                        {
+                            Name = i.GetFieldName(),
+                            Visible = i.GetVisible(),
+                            DisplayName = i.GetDisplayName(),
+                            Width = i.Width
+                        })
+            ];
+        _tableColumnStates.Clear();
+        _tableColumnStates.AddRange(cols);
 
         RebuildVisibleColumnsCache();
     }
@@ -1875,6 +1894,8 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             }
             _resetColumns = true;
             _invoke = true;
+
+            RebuildVisibleColumnsCache();
 
             StateHasChanged();
         }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1355,49 +1355,24 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private void RebuildTableColumnFromCache()
     {
-        foreach (var col in Columns)
+        if (_tableColumnStateCache.Columns.Count != 0)
         {
-            var fieldName = col.GetFieldName();
+            foreach (var col in Columns)
+            {
+                var fieldName = col.GetFieldName();
 
-            // 设置列宽度与可见性
-            var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
-            if (column == null)
-            {
-                column = new TableColumnState()
+                // 设置列宽度与可见性
+                var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
+                if (column != null)
                 {
-                    Name = fieldName,
-                    Width = col.Width,
-                    Visible = col.GetVisible(),
-                    DisplayName = col.GetDisplayName()
-                };
-                _tableColumnStateCache.Columns.Add(column);
-            }
-            else
-            {
-                col.Width = column.Width;
-                col.Visible = column.Visible;
-                column.DisplayName = col.GetDisplayName();
+                    col.Width = column.Width;
+                    col.Visible = column.Visible;
+                    column.DisplayName = col.GetDisplayName();
+                }
             }
         }
 
-        // 设置可见列顺序
-        _tableColumnStates.Clear();
-        _tableColumnStates.AddRange(GetColumnStates(Columns));
-
         RebuildVisibleColumnsCache();
-    }
-
-    private List<TableColumnState> GetColumnStates(List<ITableColumn> cols)
-    {
-        // 开启客户端持久化后未设置列状态的列默认使用组件参数值
-        return _tableColumnStateCache.Columns.Count != 0
-            ? _tableColumnStateCache.Columns
-            : [.. cols.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize).Select(i => new TableColumnState()
-            {
-                Name = i.GetFieldName(),
-                Visible = i.GetVisible(),
-                DisplayName = i.GetDisplayName()
-            })];
     }
 
     private async Task OnTableRenderAsync(bool firstRender)


### PR DESCRIPTION
## Link issues
fixes #7984 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refine table column state reconstruction and visible columns caching to better respect client-side persistence and reset behavior.

Enhancements:
- Skip rebuilding table columns when a reset flag is active to avoid unnecessary work during column reset operations.
- Simplify and inline column-state reconstruction logic, using cached column states when available and deriving defaults from current columns otherwise.
- Restrict updates to the client-side column-order cache during drag operations to cases where a client table name is configured.
- Ensure visible columns cache is rebuilt after column drag operations to keep rendered state in sync with updated column ordering.