### PR TITLE
refactor(Table): updateOnDragColumnEndAsync parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor
@@ -1,4 +1,4 @@
-﻿@page "/table/column/drag"
+@page "/table/column/drag"
 @inject IStringLocalizer<NavMenu> NavMenuLocalizer
 @inject IStringLocalizer<TablesColumnDrag> Localizer
 @inject IStringLocalizer<Foo> FooLocalizer
@@ -11,7 +11,8 @@
 <DemoBlock Title="@Localizer["AllowDragOrderTitle"]" Introduction="@Localizer["AllowDragOrderIntro"]" Name="AllowDragColumn">
     <section ignore>@((MarkupString)Localizer["AllowDragOrderDesc"].Value)</section>
     <Table TItem="Foo" ClientTableName="table-test"
-           IsPagination="true" PageItemsSource="@PageItemsSource" AllowDragColumn="true"
+           IsPagination="true" PageItemsSource="@PageItemsSource"
+           AllowDragColumn="true" AllowResizing="true"
            IsStriped="true" IsBordered="true" OnDragColumnEndAsync="OnDragColumnEndAsync"
            ShowToolbar="false" IsMultipleSelect="true" ShowExtendButtons="false"
            OnQueryAsync="@OnQueryAsync">

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor
@@ -13,8 +13,9 @@
     <Table TItem="Foo" ClientTableName="table-test"
            IsPagination="true" PageItemsSource="@PageItemsSource"
            AllowDragColumn="true" AllowResizing="true"
+           ShowToolbar="true" ShowColumnList="true"
            IsStriped="true" IsBordered="true" OnDragColumnEndAsync="OnDragColumnEndAsync"
-           ShowToolbar="false" IsMultipleSelect="true" ShowExtendButtons="false"
+           IsMultipleSelect="true" ShowExtendButtons="false"
            OnQueryAsync="@OnQueryAsync">
         <TableColumns>
             <TableColumn @bind-Field="@context.DateTime" Width="120" FormatString="yyyy-MM-dd" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Table/TablesColumnDrag.razor.cs
@@ -36,7 +36,7 @@ public partial class TablesColumnDrag
         Items = Foo.GenerateFoo(FooLocalizer);
     }
 
-    private Task OnDragColumnEndAsync(string? columnName, IEnumerable<ITableColumn> columns)
+    private Task OnDragColumnEndAsync(string? columnName, TableColumnClientStatus status)
     {
         Logger.Log($"Column: {columnName}");
         return Task.CompletedTask;

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta11</Version>
+    <Version>10.6.1-beta12</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/ITableColumn.cs
+++ b/src/BootstrapBlazor/Components/Table/ITableColumn.cs
@@ -225,6 +225,7 @@ public interface ITableColumn : IEditorItem
     /// <summary>
     /// <para lang="zh">获得/设置 当前编辑项是否可见，默认为 null，使用 true 值</para>
     /// <para lang="en">Gets or sets whether the current edit item is visible. Default is null, using true value</para>
+    /// <remark>可见性最终结果比较复杂，比如开启 ShowColumnList 实际由这里控制是否显示</remark>
     /// </summary>
     bool? Visible { get; set; }
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -251,7 +251,7 @@
             }
             @foreach (var col in GetVisibleColumns())
             {
-                <col style="@GetColWidthString(col.GetColumnFixedWidth(DefaultFixedColumnWidth))" />
+                <col @key="GetColumnKey(col)" style="@GetColWidthString(col.GetColumnFixedWidth(DefaultFixedColumnWidth))" />
             }
             @if (ShowExtendButtons && !IsExtendButtonsInRowHeader)
             {

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -844,33 +844,33 @@
                          GotoNavigatorLabelText="@GotoNavigatorLabelText"
                          ShowPageInfo="ShowPageInfo" PageInfoTemplate="InternalPageInfoTemplate"></Pagination>;
 
-            RenderFragment<TableColumnState> RenderColumnListItem => item =>
-                @<div class="dropdown-item">
-                    <Checkbox ShowAfterLabel="true" DisplayText="@item.DisplayName"
-                              IsDisabled="@GetColumnsListState(item)"
-                              Value="@item.Visible"
-                              OnValueChanged="visible => OnToggleColumnVisible(item, visible)">
-                    </Checkbox>
-                </div>;
+    RenderFragment<TableColumnState> RenderColumnListItem => item =>
+        @<div class="dropdown-item">
+            <Checkbox ShowAfterLabel="true" DisplayText="@item.DisplayName"
+                        IsDisabled="@GetColumnsListState(item)"
+                        Value="@item.Visible"
+                        OnValueChanged="visible => OnToggleColumnVisible(item, visible)">
+            </Checkbox>
+        </div>;
 
-            RenderFragment<TItem> RenderRowContentWithValidateForm => item =>
-                @<ValidateForm @ref="_inCellValidateForm" Model="EditModel" IsFormless="true" ShowLabel="false">
-                    @RenderRowContent(item)
-                </ValidateForm>;
+    RenderFragment<TItem> RenderRowContentWithValidateForm => item =>
+        @<ValidateForm @ref="_inCellValidateForm" Model="EditModel" IsFormless="true" ShowLabel="false">
+            @RenderRowContent(item)
+        </ValidateForm>;
 
-            RenderFragment<string> RenderLoader => cssString =>
-                @<div class="@cssString">
-                    @if (LoadingTemplate != null)
-                    {
-                        @LoadingTemplate
-                    }
-                    else
-                    {
-                        <Spinner Color="Color.Primary"></Spinner>
-                    }
-                </div>;
+    RenderFragment<string> RenderLoader => cssString =>
+        @<div class="@cssString">
+            @if (LoadingTemplate != null)
+            {
+                @LoadingTemplate
+            }
+            else
+            {
+                <Spinner Color="Color.Primary"></Spinner>
+            }
+        </div>;
 
-            RenderFragment RenderToolbar =>
+    RenderFragment RenderToolbar =>
         @<div class="table-toolbar">
             <TableToolbar GearIcon="@GearIcon" OnGetSelectedRows="@GetSelectedRows"
                           IsAutoCollapsedToolbarButton="IsAutoCollapsedToolbarButton"
@@ -1061,95 +1061,95 @@
             }
         </div>;
 
-            RenderFragment<TItem> RenderCardViewRow => item =>
-                @<DynamicElement @key="GetKeyByITem(item)"
-                                 class="@GetRowClassString(item, "table-row")" style="@GetRowStyleString(item)"
-                                 TriggerContextMenu="ContextMenuZone != null"
-                                 OnContextMenu="e => OnContextMenu(e, item)"
-                                 TriggerTouchStart="true" OnTouchStart="e => OnTouchStart(e, item)"
-                                 TriggerTouchEnd="true" OnTouchEnd="OnTouchEnd"
-                                 TriggerClick="@(ClickToSelect || OnClickRowCallback != null)"
-                                 OnClick="() => ClickRow(item)">
-                    @if (IsMultipleSelect)
+    RenderFragment<TItem> RenderCardViewRow => item =>
+        @<DynamicElement @key="GetKeyByITem(item)"
+                         class="@GetRowClassString(item, "table-row")" style="@GetRowStyleString(item)"
+                         TriggerContextMenu="ContextMenuZone != null"
+                         OnContextMenu="e => OnContextMenu(e, item)"
+                         TriggerTouchStart="true" OnTouchStart="e => OnTouchStart(e, item)"
+                         TriggerTouchEnd="true" OnTouchEnd="OnTouchEnd"
+                         TriggerClick="@(ClickToSelect || OnClickRowCallback != null)"
+                         OnClick="() => ClickRow(item)">
+            @if (IsMultipleSelect)
+            {
+                <div class="table-cell">
+                    <label>@CheckboxDisplayText</label>
+                    @if (GetShowRowCheckbox(item))
                     {
-                        <div class="table-cell">
-                            <label>@CheckboxDisplayText</label>
-                            @if (GetShowRowCheckbox(item))
-                            {
-                                <Checkbox TValue="TItem" Value="@item" State="@RowCheckState(item)"
-                                          OnStateChanged="OnCheck" StopPropagation="true">
-                                </Checkbox>
-                            }
-                        </div>
+                        <Checkbox TValue="TItem" Value="@item" State="@RowCheckState(item)"
+                                    OnStateChanged="OnCheck" StopPropagation="true">
+                        </Checkbox>
                     }
-                    @if (ShowLineNo)
+                </div>
+            }
+            @if (ShowLineNo)
+            {
+                <div class="table-cell">
+                    <label>@LineNoText</label>
+                    <span>@(Rows.IndexOf(item) + 1 + (PageIndex - 1) * _pageItems)</span>
+                </div>
+            }
+            @if (ShowExtendButtons && IsExtendButtonsInRowHeader)
+            {
+                @RenderExtendButtons(item)
+            }
+            @if (RowContentTemplate != null)
+            {
+                var columns = GetVisibleColumns();
+                @RowContentTemplate(new(item, columns, ActiveRenderMode))
+            }
+            else
+            {
+                @foreach (var col in GetVisibleColumns())
+                {
+                    var cellClass = "";
+                    string? value = null;
+                    RenderFragment? valueTemplate = null;
+                    var colClass = "table-cell";
+                    if (!string.IsNullOrEmpty(col.CssClass))
                     {
-                        <div class="table-cell">
-                            <label>@LineNoText</label>
-                            <span>@(Rows.IndexOf(item) + 1 + (PageIndex - 1) * _pageItems)</span>
-                        </div>
+                        colClass = $"table-cell {col.CssClass}";
                     }
-                    @if (ShowExtendButtons && IsExtendButtonsInRowHeader)
-                    {
-                        @RenderExtendButtons(item)
-                    }
-                    @if (RowContentTemplate != null)
-                    {
-                        var columns = GetVisibleColumns();
-                        @RowContentTemplate(new(item, columns, ActiveRenderMode))
-                    }
-                    else
-                    {
-                        @foreach (var col in GetVisibleColumns())
+                    <div class="@colClass">
+                        <label>
+                            @col.GetDisplayName()
+                        </label>
+                        @if (col.OnCellRender != null)
                         {
-                            var cellClass = "";
-                            string? value = null;
-                            RenderFragment? valueTemplate = null;
-                            var colClass = "table-cell";
-                            if (!string.IsNullOrEmpty(col.CssClass))
+                            var cell = new TableCellArgs
                             {
-                                colClass = $"table-cell {col.CssClass}";
-                            }
-                            <div class="@colClass">
-                                <label>
-                                    @col.GetDisplayName()
-                                </label>
-                                @if (col.OnCellRender != null)
-                                {
-                                    var cell = new TableCellArgs
-                                    {
-                                        Row = item,
-                                        ColumnName = col.GetFieldName()
-                                    };
-                                    col.OnCellRender(cell);
-                                    cellClass = cell.Class;
-                                    value = cell.Value;
-                                    valueTemplate = cell.ValueTemplate;
-                                }
-                                <span class="@cellClass">
-                                    @if (valueTemplate != null)
-                                    {
-                                        @valueTemplate
-                                    }
-                                    else if (value != null)
-                                    {
-                                        @value
-                                    }
-                                    else
-                                    {
-                                        @GetValue(col, item)
-                                    }
-                                </span>
-                            </div>
+                                Row = item,
+                                ColumnName = col.GetFieldName()
+                            };
+                            col.OnCellRender(cell);
+                            cellClass = cell.Class;
+                            value = cell.Value;
+                            valueTemplate = cell.ValueTemplate;
                         }
-                    }
-                    @if (ShowExtendButtons && !IsExtendButtonsInRowHeader)
-                    {
-                        @RenderExtendButtons(item)
-                    }
-                </DynamicElement>;
+                        <span class="@cellClass">
+                            @if (valueTemplate != null)
+                            {
+                                @valueTemplate
+                            }
+                            else if (value != null)
+                            {
+                                @value
+                            }
+                            else
+                            {
+                                @GetValue(col, item)
+                            }
+                        </span>
+                    </div>
+                }
+            }
+            @if (ShowExtendButtons && !IsExtendButtonsInRowHeader)
+            {
+                @RenderExtendButtons(item)
+            }
+        </DynamicElement>;
 
-            RenderFragment RenderCardViewFooter =>
+    RenderFragment RenderCardViewFooter =>
         @<div class="table-row table-footer">
             <CascadingValue Value="true" Name="IsMobileMode" IsFixed="true">
                 <CascadingValue Value="@Rows" Name="TableFooterContext">
@@ -1164,4 +1164,4 @@
                 </CascadingValue>
             </CascadingValue>
         </div>;
-        }
+}

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Checkbox.cs
@@ -156,39 +156,36 @@ public partial class Table<TItem>
         item.Visible = visible;
 
         // 设置列状态缓存中可见状态
-        if (!string.IsNullOrEmpty(ClientTableName))
+        var tableWidth = 0;
+        var useTableWidth = true;
+        for (var index = 0; index < _tableColumnStateCache.Columns.Count; index++)
         {
-            var tableWidth = 0;
-            var useTableWidth = true;
-            for (var index = 0; index < _tableColumnStateCache.Columns.Count; index++)
+            var column = _tableColumnStateCache.Columns[index];
+            if (column.Name == item.Name)
             {
-                var column = _tableColumnStateCache.Columns[index];
-                if (column.Name == item.Name)
-                {
-                    column.Visible = visible;
-                }
-
-                if (!column.Visible)
-                {
-                    continue;
-                }
-
-                // 重新计算表格宽度
-                if (column.Width.HasValue)
-                {
-                    tableWidth += column.Width.Value;
-                }
-                else
-                {
-                    // 未设置列宽表格自适应
-                    useTableWidth = false;
-                }
+                column.Visible = visible;
             }
 
-            _tableColumnStateCache.TableWidth = useTableWidth ? tableWidth : 0;
+            if (!column.Visible)
+            {
+                continue;
+            }
 
-            UpdateTableWidth();
+            // 重新计算表格宽度
+            if (column.Width.HasValue)
+            {
+                tableWidth += column.Width.Value;
+            }
+            else
+            {
+                // 未设置列宽表格自适应
+                useTableWidth = false;
+            }
         }
+
+        _tableColumnStateCache.TableWidth = useTableWidth ? tableWidth : 0;
+
+        UpdateTableWidth();
 
         // 触发 OnColumnVisibleChanged 回调
         if (OnColumnVisibleChanged != null)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -565,11 +565,16 @@ public partial class Table<TItem>
             var item = _tableColumnStates[index];
             if (item.Visible)
             {
-                var col = Columns.FirstOrDefault(c => c.GetFieldName() == item.Name);
+                var col = Columns.Find(c => c.GetFieldName() == item.Name);
                 if (col != null)
                 {
+                    // 更新显示名称
+                    item.DisplayName = col.GetDisplayName();
+
+                    // 恢复宽度
                     col.Width = item.Width;
 
+                    // 增加到可见列缓存集合
                     _visibleColumnsCache.Add(col);
                 }
             }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -544,7 +544,7 @@ public partial class Table<TItem>
     /// <para lang="zh">获得/设置 各列是否显示状态集合</para>
     /// <para lang="en">Gets or sets Columns Visibility Status Collection</para>
     /// </summary>
-    private List<TableColumnState> _tableColumnStates = [];
+    private List<TableColumnState> _tableColumnStates => _tableColumnStateCache.Columns;
 
     private List<ITableColumn> _visibleColumnsCache = [];
 
@@ -554,7 +554,9 @@ public partial class Table<TItem>
     /// </summary>
     public List<ITableColumn> GetVisibleColumns() => _visibleColumnsCache;
 
-    private void RebuildVisibleColumnsCache()
+    private string GetColumnKey(ITableColumn col) => $"{col.GetFieldName}-{_visibleColumnsCache.IndexOf(col)}";
+
+    private void ResetVisibleColumnsCache()
     {
         _visibleColumnsCache.Clear();
 
@@ -566,6 +568,8 @@ public partial class Table<TItem>
                 var col = Columns.FirstOrDefault(c => c.GetFieldName() == item.Name);
                 if (col != null)
                 {
+                    col.Width = item.Width;
+
                     _visibleColumnsCache.Add(col);
                 }
             }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -568,9 +568,6 @@ public partial class Table<TItem>
                 var col = Columns.Find(c => c.GetFieldName() == item.Name);
                 if (col != null)
                 {
-                    // 更新显示名称
-                    item.DisplayName = col.GetDisplayName();
-
                     // 恢复宽度
                     col.Width = item.Width;
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1324,7 +1324,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         }
 
         // 加载客户端持久化列状态
-        RebuildTableColumnFromCache();
+        ResetTableColumns();
     }
 
     private async Task GetTableColumnStatesFromBrowserAsync()
@@ -1339,18 +1339,55 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         }
     }
 
-    private void RebuildTableColumnFromCache()
+    private void ResetTableColumns()
     {
-        if (_tableColumnStateCache.Columns.Count == 0)
+        if (_tableColumnStates.Count == 0)
         {
             // 重建缓存
-            _tableColumnStateCache.Columns.AddRange(Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
+            _tableColumnStates.AddRange(Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
                 .Select(i => new TableColumnState()
                 {
                     Name = i.GetFieldName(),
                     Visible = i.GetVisible(),
                     Width = i.Width
                 }));
+        }
+        else
+        {
+            foreach (var col in Columns)
+            {
+                var item = _tableColumnStates.Find(i => i.Name == col.GetFieldName());
+                if (col.GetIgnore())
+                {
+                    if (item != null)
+                    {
+                        _tableColumnStates.Remove(item);
+                    }
+                    continue;
+                }
+
+                if (item == null)
+                {
+                    _tableColumnStates.Add(new TableColumnState()
+                    {
+                        Name = col.GetFieldName(),
+                        Width = col.Width,
+                        Visible = col.GetVisible(),
+                        DisplayName = col.GetDisplayName()
+                    });
+                    continue;
+                }
+
+                if (!ShowColumnList)
+                {
+                    item.Visible = col.GetVisible();
+                }
+
+                if (!AllowResizing)
+                {
+                    item.Width = col.Width;
+                }
+            }
         }
 
         ResetVisibleColumnsCache();

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1429,16 +1429,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     {
         foreach (var col in columns)
         {
-            var column = Columns.Find(i => i.GetFieldName() == col.Name);
+            var column = _tableColumnStates.Find(i => i.Name == col.Name);
             if (column != null)
             {
                 column.Visible = col.Visible;
                 column.Width = col.Width;
             }
         }
-
-        // 重置可见缓存
-        RebuildTableColumnFromCache();
 
         _resetColumns = true;
         _invoke = true;

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -90,7 +90,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         .AddClass("table-excel", IsExcel)
         .AddClass("table-bordered", IsBordered)
         .AddClass("table-striped table-hover", IsStriped)
-        .AddClass("table-layout-fixed", IsFixedHeader)
+        .AddClass("table-layout-fixed")
         .AddClass("table-draggable", AllowDragColumn)
         .Build();
 
@@ -1121,7 +1121,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             _firstRender = false;
 
             // 读取浏览器持久化列状态配置
-            await ReloadColumnStatesFromBrowserAsync();
+            await GetTableColumnStatesFromBrowserAsync();
 
             // 构建列信息
             await BuildTableColumnsAsync();
@@ -1327,56 +1327,34 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         RebuildTableColumnFromCache();
     }
 
-    private async Task ReloadColumnStatesFromBrowserAsync()
+    private async Task GetTableColumnStatesFromBrowserAsync()
     {
-        // 未开启客户端持久化功能直接返回
-        if (string.IsNullOrEmpty(ClientTableName))
+        if (!string.IsNullOrEmpty(ClientTableName))
         {
-            return;
-        }
-
-        var state = await InvokeAsync<TableColumnClientStatus>("getColumnStates", ClientTableName);
-        if (state == null)
-        {
-            state = new();
-
-            // 开启客户端持久化后未设置列状态的列默认使用组件参数值
-            state.Columns.AddRange(_columns.Where(i => !i.GetIgnore()).Select(i => new TableColumnState()
+            var state = await InvokeAsync<TableColumnClientStatus>("getColumnStates", ClientTableName);
+            if (state != null)
             {
-                Name = i.GetFieldName(),
-                Visible = i.GetVisible(),
-                DisplayName = i.GetDisplayName(),
-                Width = i.Width
-            }));
+                _tableColumnStateCache = state;
+            }
         }
-
-        _tableColumnStateCache = state;
     }
 
     private void RebuildTableColumnFromCache()
     {
-        if (_tableColumnStateCache.Columns.Count != 0)
+        if (_tableColumnStateCache.Columns.Count == 0)
         {
-            foreach (var col in Columns)
-            {
-                var fieldName = col.GetFieldName();
-
-                // 设置列宽度与可见性
-                var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
-                if (column != null)
+            // 重建缓存
+            _tableColumnStateCache.Columns.AddRange(Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
+                .Select(i => new TableColumnState()
                 {
-                    col.Width = column.Width;
-                    col.Visible = column.Visible;
-                    column.DisplayName = col.GetDisplayName();
-                }
-            }
+                    Name = i.GetFieldName(),
+                    Visible = i.GetVisible(),
+                    Width = i.Width,
+                    DisplayName = i.GetDisplayName()
+                }));
         }
 
-        // 设置可见列顺序
-        _tableColumnStates.Clear();
-        _tableColumnStates.AddRange(GetColumnStates(Columns));
-
-        RebuildVisibleColumnsCache();
+        ResetVisibleColumnsCache();
     }
 
     private List<TableColumnState> GetColumnStates(List<ITableColumn> cols)
@@ -1825,7 +1803,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     /// <para lang="en">Gets or sets Drag Column End Callback. Default null</para>
     /// </summary>
     [Parameter]
-    public Func<string, IEnumerable<ITableColumn>, Task>? OnDragColumnEndAsync { get; set; }
+    public Func<string, TableColumnClientStatus, Task>? OnDragColumnEndAsync { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 设置列宽回调方法</para>
@@ -1877,17 +1855,9 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 _tableColumnStates.Remove(firstColumn);
                 _tableColumnStates.Insert(currentIndex, firstColumn);
 
-                if (!string.IsNullOrEmpty(ClientTableName))
-                {
-                    // 更新缓存数据中列顺序
-                    var columnVisibleState = _tableColumnStateCache.Columns;
-                    columnVisibleState.Clear();
-                    columnVisibleState.AddRange(_tableColumnStates);
-                }
-
                 if (OnDragColumnEndAsync != null)
                 {
-                    await OnDragColumnEndAsync(firstColumn.Name, Columns);
+                    await OnDragColumnEndAsync(firstColumn.Name, _tableColumnStateCache);
                 }
             }
             _resetColumns = true;

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1355,28 +1355,20 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private void RebuildTableColumnFromCache()
     {
-        foreach (var col in Columns)
+        if (_tableColumnStateCache.Columns.Count != 0)
         {
-            var fieldName = col.GetFieldName();
+            foreach (var col in Columns)
+            {
+                var fieldName = col.GetFieldName();
 
-            // 设置列宽度与可见性
-            var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
-            if (column == null)
-            {
-                column = new TableColumnState()
+                // 设置列宽度与可见性
+                var column = _tableColumnStateCache.Columns.Find(i => i.Name == fieldName);
+                if (column != null)
                 {
-                    Name = fieldName,
-                    Width = col.Width,
-                    Visible = col.GetVisible(),
-                    DisplayName = col.GetDisplayName()
-                };
-                _tableColumnStateCache.Columns.Add(column);
-            }
-            else
-            {
-                col.Width = column.Width;
-                col.Visible = column.Visible;
-                column.DisplayName = col.GetDisplayName();
+                    col.Width = column.Width;
+                    col.Visible = column.Visible;
+                    column.DisplayName = col.GetDisplayName();
+                }
             }
         }
 
@@ -1885,10 +1877,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 _tableColumnStates.Remove(firstColumn);
                 _tableColumnStates.Insert(currentIndex, firstColumn);
 
-                // 更新缓存数据中列顺序
-                var columnVisibleState = _tableColumnStateCache.Columns;
-                columnVisibleState.Clear();
-                columnVisibleState.AddRange(_tableColumnStates);
+                if (!string.IsNullOrEmpty(ClientTableName))
+                {
+                    // 更新缓存数据中列顺序
+                    var columnVisibleState = _tableColumnStateCache.Columns;
+                    columnVisibleState.Clear();
+                    columnVisibleState.AddRange(_tableColumnStates);
+                }
 
                 if (OnDragColumnEndAsync != null)
                 {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1349,25 +1349,11 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 {
                     Name = i.GetFieldName(),
                     Visible = i.GetVisible(),
-                    Width = i.Width,
-                    DisplayName = i.GetDisplayName()
+                    Width = i.Width
                 }));
         }
 
         ResetVisibleColumnsCache();
-    }
-
-    private List<TableColumnState> GetColumnStates(List<ITableColumn> cols)
-    {
-        // 开启客户端持久化后未设置列状态的列默认使用组件参数值
-        return _tableColumnStateCache.Columns.Count != 0
-            ? _tableColumnStateCache.Columns
-            : [.. cols.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize).Select(i => new TableColumnState()
-            {
-                Name = i.GetFieldName(),
-                Visible = i.GetVisible(),
-                DisplayName = i.GetDisplayName()
-            })];
     }
 
     private async Task OnTableRenderAsync(bool firstRender)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1380,7 +1380,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
                 if (!ShowColumnList)
                 {
-                    item.Visible = col.GetVisible();
+                    item.Visible = col.GetVisible() && col.ShownWithBreakPoint <= _screenSize;
                 }
 
                 if (!AllowResizing)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1344,13 +1344,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         if (_tableColumnStates.Count == 0)
         {
             // 重建缓存
-            _tableColumnStates.AddRange(Columns.Where(i => !i.GetIgnore() && i.ShownWithBreakPoint <= _screenSize)
-                .Select(i => new TableColumnState()
-                {
-                    Name = i.GetFieldName(),
-                    Visible = i.GetVisible(),
-                    Width = i.Width
-                }));
+            _tableColumnStates.AddRange(Columns.Where(i => !i.GetIgnore()).Select(CreateTableColumnState));
         }
         else
         {
@@ -1368,19 +1362,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
                 if (item == null)
                 {
-                    _tableColumnStates.Add(new TableColumnState()
-                    {
-                        Name = col.GetFieldName(),
-                        Width = col.Width,
-                        Visible = GetColumnVisible(col),
-                        DisplayName = col.GetDisplayName()
-                    });
+                    _tableColumnStates.Add(CreateTableColumnState(col));
                     continue;
                 }
 
                 if (!ShowColumnList)
                 {
-                    item.Visible = GetColumnVisible(col);
+                    item.Visible = col.GetVisible(_screenSize);
                 }
 
                 if (!AllowResizing)
@@ -1393,7 +1381,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         ResetVisibleColumnsCache();
     }
 
-    private bool GetColumnVisible(ITableColumn col) => col.GetVisible() && col.ShownWithBreakPoint <= _screenSize;
+    private TableColumnState CreateTableColumnState(ITableColumn col) => new TableColumnState()
+    {
+        DisplayName = col.GetDisplayName(),
+        Name = col.GetFieldName(),
+        Width = col.Width,
+        Visible = col.GetVisible(_screenSize)
+    };
 
     private async Task OnTableRenderAsync(bool firstRender)
     {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1372,7 +1372,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                     {
                         Name = col.GetFieldName(),
                         Width = col.Width,
-                        Visible = col.GetVisible(),
+                        Visible = col.GetVisible() && col.ShownWithBreakPoint <= _screenSize,
                         DisplayName = col.GetDisplayName()
                     });
                     continue;

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1372,7 +1372,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                     {
                         Name = col.GetFieldName(),
                         Width = col.Width,
-                        Visible = col.GetVisible() && col.ShownWithBreakPoint <= _screenSize,
+                        Visible = GetColumnVisible(col),
                         DisplayName = col.GetDisplayName()
                     });
                     continue;
@@ -1380,7 +1380,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
                 if (!ShowColumnList)
                 {
-                    item.Visible = col.GetVisible() && col.ShownWithBreakPoint <= _screenSize;
+                    item.Visible = GetColumnVisible(col);
                 }
 
                 if (!AllowResizing)
@@ -1392,6 +1392,8 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
         ResetVisibleColumnsCache();
     }
+
+    private bool GetColumnVisible(ITableColumn col) => col.GetVisible() && col.ShownWithBreakPoint <= _screenSize;
 
     private async Task OnTableRenderAsync(bool firstRender)
     {

--- a/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ITableColumnExtensions.cs
@@ -436,7 +436,7 @@ public static class IEditItemExtensions
 
     internal static bool GetTextEllipsis(this ITableColumn col) => col.TextEllipsis ?? false;
 
-    internal static bool GetVisible(this ITableColumn col) => col.Visible ?? true;
+    internal static bool GetVisible(this ITableColumn col, BreakPoint point = BreakPoint.None) => col.Visible ?? true && col.ShownWithBreakPoint <= point;
 
     internal static bool GetShowCopyColumn(this ITableColumn col) => col.ShowCopyColumn ?? false;
 

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -5256,6 +5256,33 @@ public class TableTest : BootstrapBlazorTestBase
         table = cut.FindComponent<Table<Foo>>();
         Assert.Equal(2, table.Instance.Columns.Count);
         Assert.Single(table.Instance.GetVisibleColumns());
+
+        // 更新 Ignore 值
+        table.Render(pb =>
+        {
+            pb.Add(a => a.TableColumns, foo => builder =>
+            {
+                builder.OpenComponent<TableColumn<Foo, string>>(0);
+                builder.AddAttribute(1, "Field", "Name");
+                builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                builder.CloseComponent();
+
+                builder.OpenComponent<TableColumn<Foo, string>>(0);
+                builder.AddAttribute(1, "Field", "Address");
+                builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                builder.AddAttribute(3, "Ignore", false);
+                builder.CloseComponent();
+
+                builder.OpenComponent<TableColumn<Foo, int>>(0);
+                builder.AddAttribute(1, "Field", 1);
+                builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, nameof(Foo.Count), typeof(int)));
+                builder.CloseComponent();
+            });
+        });
+
+        table = cut.FindComponent<Table<Foo>>();
+        Assert.Equal(3, table.Instance.Columns.Count);
+        Assert.Equal(3, table.Instance.GetVisibleColumns().Count);
     }
 
     [Theory]

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -5235,6 +5235,7 @@ public class TableTest : BootstrapBlazorTestBase
         Assert.Equal(2, table.Instance.Columns.Count);
         Assert.Equal(2, table.Instance.GetVisibleColumns().Count);
 
+        // 更新 Ignore 值
         table.Render(pb =>
         {
             pb.Add(a => a.TableColumns, foo => builder =>
@@ -5251,6 +5252,7 @@ public class TableTest : BootstrapBlazorTestBase
                 builder.CloseComponent();
             });
         });
+
         table = cut.FindComponent<Table<Foo>>();
         Assert.Equal(2, table.Instance.Columns.Count);
         Assert.Single(table.Instance.GetVisibleColumns());

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -945,7 +945,6 @@ public class TableTest : BootstrapBlazorTestBase
         var item = cut.FindComponents<Checkbox<bool>>()[0];
         await cut.InvokeAsync(item.Instance.OnToggleClick);
         Assert.True(show);
-        cut.Contains("<table class=\"table\">");
 
         await cut.InvokeAsync(item.Instance.OnToggleClick);
         Assert.False(show);

--- a/test/UnitTest/Services/BluetoothServiceTest.cs
+++ b/test/UnitTest/Services/BluetoothServiceTest.cs
@@ -35,6 +35,7 @@ public class BluetoothServiceTest : BootstrapBlazorTestBase
         Assert.Equal([0x31], val);
 
         var v = await device.GetBatteryValue();
+        Assert.NotNull(v);
         Assert.Equal(0x31, v.Value);
 
         var mi = device.GetType().GetMethod("OnError");
@@ -241,6 +242,7 @@ public class BluetoothServiceTest : BootstrapBlazorTestBase
 
         await device.Connect();
         var v = await device.GetCurrentTime();
+        Assert.NotNull(v);
         Assert.Equal("2024-10-10 10:05:10", v.Value.ToString("yyyy-MM-dd HH:mm:ss"));
         Assert.Equal(7, v.Value.Offset.TotalHours);
     }


### PR DESCRIPTION
## Link issues
fixes #7984 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refine table column state caching and visibility handling to better support column dragging and client-side persistence.

New Features:
- Expose a column key helper to provide stable @key values for generated column elements.

Enhancements:
- Simplify browser column state loading to only apply persisted state when available and rebuild default state from current columns when needed.
- Unify visible column tracking by backing the internal column state list directly with the cached client status object.
- Apply cached column widths and display names when rebuilding the visible columns cache, and always recompute table width when toggling column visibility.
- Change the drag-end callback to receive the full column status payload instead of the raw column list, and update the sample to match.
- Always enable fixed table layout styling on the table component.

Documentation:
- Clarify the semantics of the table column Visible property with an additional remark.