### PR TITLE
refactor(Table): update column list display name

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta12</Version>
+    <Version>10.6.1-beta13</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -568,6 +568,9 @@ public partial class Table<TItem>
                 var col = Columns.Find(c => c.GetFieldName() == item.Name);
                 if (col != null)
                 {
+                    // 更新显示名称
+                    item.DisplayName = col.GetDisplayName();
+
                     // 恢复宽度
                     col.Width = item.Width;
 

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -239,7 +239,7 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void ResetVisibleColumns_Ok()
+    public async Task ResetVisibleColumns_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var cut = Context.Render<BootstrapBlazorRoot>(pb =>
@@ -266,24 +266,24 @@ public class TableTest : BootstrapBlazorTestBase
                 });
                 pb.Add(a => a.AutoScrollLastSelectedRowToView, true);
                 pb.Add(a => a.AutoScrollVerticalAlign, ScrollToViewAlign.Center);
-                pb.Add(a => a.OnAfterRenderCallback, (table, firstRender) =>
-                {
-                    if (firstRender)
-                    {
-                        table.ResetVisibleColumns(
-                        [
-                            new TableColumnState() { Name = nameof(Foo.Name), Visible = true, DisplayName = "Name-Display" },
-                            new TableColumnState() { Name = nameof(Foo.Address), Visible = false }
-                        ]);
-                    }
-                    return Task.CompletedTask;
-                });
             });
         });
 
         // Address 不可见
         var table = cut.FindComponent<Table<Foo>>();
+        await cut.InvokeAsync(() => table.Instance.ResetVisibleColumns(
+        [
+            new TableColumnState() { Name = nameof(Foo.Name), Visible = true, DisplayName = "Name-Display" },
+            new TableColumnState() { Name = nameof(Foo.Address), Visible = false }
+        ]));
+
         Assert.Single(table.Instance.GetVisibleColumns());
+
+        // 检查 ShowColumnList 中的 DisplayName 是否正确
+        var labels = table.FindAll(".form-check-label");
+        Assert.Equal(2, labels.Count);
+        Assert.Equal("姓名", labels[0].TextContent);
+        Assert.Equal("地址", labels[1].TextContent);
     }
 
     [Fact]
@@ -899,8 +899,8 @@ public class TableTest : BootstrapBlazorTestBase
         // 设置客户端存储
         var state = new TableColumnClientStatus();
         state.TableWidth = 500;
-        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Name), Visible = false, DisplayName = "Name-Display" });
-        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Address), Visible = true, Width = 120, DisplayName = "Address-Display" });
+        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Name), Visible = false });
+        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Address), Visible = true, Width = 120 });
 
         Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test").SetResult(state);
         var show = false;
@@ -976,6 +976,12 @@ public class TableTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(item.Instance.OnToggleClick);
         Assert.True(show);
         cut.Contains("style=\"width: 340px;\"");
+
+        // 检查 ShowColumnList 中的 DisplayName 是否正确
+        var labels = table.FindAll(".form-check-label");
+        Assert.Equal(2, labels.Count);
+        Assert.Equal("姓名", labels[0].TextContent);
+        Assert.Equal("地址", labels[1].TextContent);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #7989 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure table column list uses the current column display names when restoring visibility state.

Bug Fixes:
- Fix table column visibility reset so that ShowColumnList displays up-to-date column display names instead of stale or client-stored labels.

Tests:
- Update and extend table tests to cover column display name behavior in ShowColumnList and ResetVisibleColumns, including async invocation and label assertions.