### PR TITLE
feat(AutoComplete): add SkipMatch parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta15</Version>
+    <Version>10.6.1-beta16</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @inherits PopoverCompleteBase<string>
 
 @if (IsShowLabel)
@@ -12,6 +12,7 @@
            data-bb-auto-dropdown-focus="@ShowDropdownListOnFocusString" data-bb-debounce="@DurationString"
            data-bb-skip-esc="@SkipEscString" data-bb-skip-enter="@SkipEnterString" data-bb-blur="@TriggerBlurString"
            data-bb-scroll-behavior="@ScrollIntoViewBehaviorString" data-bb-trigger-delete="true"
+           data-bb-skip-match="@SkipMatchString"
            placeholder="@PlaceHolder" disabled="@Disabled" />
     <span class="form-select-append"><i class="@Icon"></i></span>
     <span class="form-select-append ac-loading"><i class="@LoadingIcon"></i></span>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -81,6 +81,7 @@ public partial class AutoComplete
     /// <summary>
     /// <para lang="zh">获得/设置 是否不进行匹配操作 默认为 false</para>
     /// <para lang="en">Gets or sets whether to skip matching operations, default is false</para>
+    /// <para>v<version>10.6.1</version></para>
     /// </summary>
     [Parameter]
     public bool SkipMatch { get; set; }

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -79,6 +79,13 @@ public partial class AutoComplete
     public bool ShowNoDataTip { get; set; } = true;
 
     /// <summary>
+    /// <para lang="zh">获得/设置 是否不进行匹配操作 默认为 false</para>
+    /// <para lang="en">Gets or sets whether to skip matching operations, default is false</para>
+    /// </summary>
+    [Parameter]
+    public bool SkipMatch { get; set; }
+
+    /// <summary>
     /// <para lang="zh">IStringLocalizer 服务实例</para>
     /// <para lang="en">IStringLocalizer service instance</para>
     /// </summary>
@@ -115,6 +122,8 @@ public partial class AutoComplete
 
     private string? TriggerBlurString => OnBlurAsync != null ? "true" : null;
 
+    private string? SkipMatchString => SkipMatch ? "true" : null;
+
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
@@ -126,7 +135,7 @@ public partial class AutoComplete
 
         Items ??= [];
 
-        if (!string.IsNullOrEmpty(Value))
+        if (!SkipMatch && !string.IsNullOrEmpty(Value))
         {
             _filterItems = GetFilterItemsByValue(Value);
             if (DisplayCount != null)

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -84,6 +84,11 @@ export function init(id, invoke, value, changedEventCallback) {
             ac.show();
         }
 
+        const skipMatch = el.getAttribute('data-bb-skip-match') === 'true';
+        if (skipMatch) {
+            return;
+        }
+
         el.classList.add('is-loading');
         filterCallback(v);
     });

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -84,7 +84,7 @@ export function init(id, invoke, value, changedEventCallback) {
             ac.show();
         }
 
-        const skipMatch = el.getAttribute('data-bb-skip-match') === 'true';
+        const skipMatch = input.getAttribute('data-bb-skip-match') === 'true';
         if (skipMatch) {
             return;
         }

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -8,6 +8,22 @@ namespace UnitTest.Components;
 public class AutoCompleteTest : BootstrapBlazorTestBase
 {
     [Fact]
+    public void SkipMatch_Ok()
+    {
+        var cut = Context.Render<AutoComplete>(pb =>
+        {
+            pb.Add(a => a.SkipMatch, true);
+            pb.Add(a => a.Items, new List<string>() { "test1", "test12", "test123", "test1234" });
+            pb.Add(a => a.Value, "test12");
+        });
+
+        // 开启 SkipMatch 候选项不过滤
+        cut.Contains("data-bb-skip-match=\"true\"");
+        var items = cut.FindAll(".dropdown-item");
+        Assert.Equal(4, items.Count);
+    }
+
+    [Fact]
     public void Items_Ok()
     {
         var cut = Context.Render<AutoComplete>(pb =>


### PR DESCRIPTION
## Link issues
fixes #7995 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add an option to bypass AutoComplete input matching and expose it to the client-side behavior.

New Features:
- Introduce a SkipMatch parameter on AutoComplete to allow disabling server-side filtering of items based on the current value.

Tests:
- Add a unit test verifying that enabling SkipMatch prevents filtering and renders all dropdown items.