### PR TITLE
feat(Drawer): remove tabindex attribute

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta17</Version>
+    <Version>10.6.1-beta18</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Drawer/Drawer.razor
+++ b/src/BootstrapBlazor/Components/Drawer/Drawer.razor
@@ -1,14 +1,14 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @inherits BootstrapModuleComponentBase
 @attribute [BootstrapModuleAutoLoader(JSObjectReference = true)]
 
-<div @attributes="@AdditionalAttributes" tabindex="-1" class="@ClassString" style="@StyleString" id="@Id"
+<div @attributes="@AdditionalAttributes" class="@ClassString" style="@StyleString" id="@Id"
      data-bb-keyboard="@KeyboardString" data-bb-scroll="@BodyScrollString">
     @if (ShowBackdrop)
     {
         @RenderBackdrop()
     }
-    <div tabindex="-1" class="@DrawerClassString" style="@DrawerStyleString" @onclick:stopPropagation>
+    <div class="@DrawerClassString" style="@DrawerStyleString" @onclick:stopPropagation>
         <div class="drawer-content">
             <CascadingValue Name="BodyContext" Value="BodyContext" IsFixed="true">
                 <CascadingValue Value="Close" IsFixed=" true">

--- a/test/UnitTest/Components/DrawerTest.cs
+++ b/test/UnitTest/Components/DrawerTest.cs
@@ -18,6 +18,7 @@ public class DrawerTest : BootstrapBlazorTestBase
             pb.Add(a => a.Width, "");
         });
         Assert.DoesNotContain("--bb-drawer-width", cut.Markup);
+        Assert.DoesNotContain("tabindex", cut.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #7999 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove tabindex attributes from the Drawer component and update tests to reflect the new markup.

Bug Fixes:
- Eliminate unintended tabindex usage in the Drawer markup to avoid interfering with focus behavior.

Tests:
- Extend Drawer unit test to assert that no tabindex attribute is rendered in the component output.