### PR TITLE
refactor(Table): restore AutoFitColumnWidthCallback invoke method

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta23</Version>
+    <Version>10.6.1-beta24</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1947,6 +1947,15 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         StateHasChanged();
     }
 
+    /// <summary>
+    /// <para lang="zh">列宽自适应回调方法 由 JavaScript 脚本调用</para>
+    /// <para lang="en">Auto Fit Column Width Callback called by JavaScript</para>
+    /// </summary>
+    [JSInvokable]
+    [Obsolete("已弃用，请使用 ResizeColumnCallback 代替；Deprecated. Please use ResizeColumnCallback instead.")]
+    [ExcludeFromCodeCoverage]
+    public async Task AutoFitColumnWidthCallback(string fieldName, TableColumnClientStatus columnState) => ResizeColumnCallback(fieldName, columnState);
+
     private void UpdateTableColumnState(TableColumnClientStatus columnState)
     {
         // 更新缓存数据中列宽度


### PR DESCRIPTION
## Link issues
fixes #8014 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Restore a JavaScript-invokable callback entry point for auto-fitting table column widths while directing callers toward the newer resize callback API.

Bug Fixes:
- Reintroduce the AutoFitColumnWidthCallback method to maintain compatibility with existing JavaScript code that relies on it.

Enhancements:
- Mark the restored AutoFitColumnWidthCallback as obsolete and excluded from code coverage, guiding migration to ResizeColumnCallback.