### PR TITLE
refactor(Table): remove observeHeight method

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1-beta24</Version>
+    <Version>10.6.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1405,7 +1405,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 FitColumnWidthIncludeHeader,
                 ResizeColumnCallback = nameof(ResizeColumnCallback),
                 ColumnMinWidth = ColumnMinWidth ?? Options.CurrentValue.TableSettings.ColumnMinWidth,
-                ColumnStates = _tableColumnStates,
                 ScrollWidth = ActualScrollWidth,
                 ShowColumnWidthTooltip,
                 ColumnWidthTooltipPrefix,

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -953,12 +953,25 @@ const getLocalStorageValue = key => {
 
 const getColumnStateObject = table => {
     const cols = table.options.columnStates;
+    if (cols !== void 0) {
+        return {
+            cols: cols.map(col => {
+                return {
+                    name: col.name,
+                    width: getColumnWidth(col, table.columns),
+                    visible: col.visible
+                }
+            }),
+            table: getTableWidth(table.tables[0])
+        };
+    }
+
     return {
-        cols: cols.map(col => {
+        cols: table.columns.map(col => {
             return {
-                name: col.name,
-                width: getColumnWidth(col, table.columns),
-                visible: col.visible
+                name: col.getAttribute('data-bb-field'),
+                width: getWidth(col.closest('th')) | 0,
+                visible: true
             }
         }),
         table: getTableWidth(table.tables[0])

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -175,7 +175,6 @@ const check = table => {
             cancelAnimationFrame(table.loopCheckHeightHandler);
             delete table.loopCheckHeightHandler;
         }
-        observeHeight(table);
     }
 };
 


### PR DESCRIPTION
## Link issues
fixes #8025 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refine table column state persistence and remove unused height observation logic.

Enhancements:
- Adjust column state serialization to fall back to DOM-derived column metadata when explicit column states are unavailable.
- Stop invoking the removed height observation behavior in the table height check logic.
- Stop passing server-side column state configuration into the JavaScript table initialization.