### PR TITLE
feat(InputUpload ): add IsConfirmDelete parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadCards.razor
@@ -74,7 +74,7 @@
     </section>
     <CardUpload TValue="string" IsMultiple="@_isMultiple" IsDirectory="@_isDirectory"
                 IsDisabled="@_isDisabled" IsUploadButtonAtFirst="@_isUploadButtonAtFirst"
-                ShowProgress="@_showProgress" ShowDeleteButton="@_showDeleteButton" ShowDeleteConfirmButton="@_showDeleteConfirmButton"
+                ShowProgress="@_showProgress" ShowDeleteButton="@_showDeleteButton" IsConfirmDelete="@_showDeleteConfirmButton"
                 ShowDownloadButton="@_showDownloadButton" ShowZoomButton="@_showZoomButton" OnChange="@OnCardUpload"></CardUpload>
 </DemoBlock>
 

--- a/src/BootstrapBlazor.Server/Components/Samples/UploadInputs.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/UploadInputs.razor
@@ -15,7 +15,7 @@
            Name="Normal">
     <div class="row g-3">
         <div class="col-12">
-            <InputUpload TValue="string" ShowDeleteButton="true" IsMultiple="true"
+            <InputUpload TValue="string" ShowDeleteButton="true" IsMultiple="true" IsConfirmDelete="true"
                          ShowLabel="true" DisplayText="@Localizer["UploadNormalLabelPhoto"]"
                          OnChange="@OnFileChange"></InputUpload>
         </div>

--- a/src/BootstrapBlazor/Components/Button/PopConfirmButton.razor
+++ b/src/BootstrapBlazor/Components/Button/PopConfirmButton.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @inherits PopConfirmButtonBase
 
 @if (_renderTooltip)
@@ -35,7 +35,8 @@ else
         </CascadingValue>
         <PopConfirmButtonContent Title="@Title" Content="@Content" Icon="@ConfirmIcon"
                                  CloseButtonColor="@CloseButtonColor" CloseButtonText="@CloseButtonText" CloseButtonIcon="@CloseButtonIcon"
-                                 ConfirmButtonColor="@ConfirmButtonColor" ConfirmButtonText="@ConfirmButtonText" ConfirmButtonIcon="@ConfirmButtonIcon"
+                                 ConfirmButtonColor="@ConfirmButtonColor"
+                                 ConfirmButtonText="@ConfirmButtonText" ConfirmButtonIcon="@ConfirmButtonIcon"
                                  ShowCloseButton="@ShowCloseButton" OnClose="@OnClose"
                                  ShowConfirmButton="@ShowConfirmButton" OnConfirm="@OnClickConfirm" ChildContent="@BodyTemplate" />
     </DynamicElement>;

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor
@@ -67,7 +67,7 @@
                     </div>
                     @if (ShowDeleteButton)
                     {
-                        @if (ShowDeleteConfirmButton)
+                        @if (IsConfirmDelete)
                         {
                             <PopConfirmButton Placement="Placement.Top" class="btn btn-sm btn-outline-danger"
                                               ConfirmIcon="@DeleteConfirmButtonIcon"
@@ -76,14 +76,15 @@
                                               CloseButtonText="@DeleteCloseButtonText"
                                               Content="@DeleteConfirmContent"
                                               Icon="@RemoveIcon"
+                                              IsKeepDisabled="true"
                                               IsAsync="true"
-                                              OnConfirm="@(async ()=> await OnCardFileDelete(item))" />
+                                              OnConfirm="@(()=> OnCardFileDelete(item))" />
                         }
                         else
                         {
                             <button type="button" class="btn btn-sm btn-outline-danger"
                                     disabled="@GetDeleteButtonDisabledString(item)" aria-label="delete"
-                                    @onclick="() => OnCardFileDelete(item)">
+                                    @onclick="@(() => OnCardFileDelete(item))">
                                 <i class="@RemoveIcon"></i>
                             </button>
                         }

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
@@ -165,7 +165,16 @@ public partial class CardUpload<TValue>
     /// <para lang="en">Gets or sets whether to display a confirmation dialog before deletion. Only takes effect when the ShowDeleteButton property is true</para>
     /// </summary>
     [Parameter]
-    public bool ShowDeleteConfirmButton { get; set; }
+    [Obsolete("已弃用，请使用 IsConfirmDelete 参数。Deprecated, please use the IsConfirmDelete parameter")]
+    [ExcludeFromCodeCoverage]
+    public bool ShowDeleteConfirmButton { get => IsConfirmDelete; set => IsConfirmDelete = value; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除按钮否显示确认对话框，依赖 ShowDeleteButton 属性为 true 时有效</para>
+    /// <para lang="en">Gets or sets whether to display a confirmation dialog before deletion. Only takes effect when the ShowDeleteButton property is true</para>
+    /// </summary>
+    [Parameter]
+    public bool IsConfirmDelete { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 删除确认弹窗中确认按钮颜色，默认 Color.Danger</para>

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor
@@ -23,8 +23,9 @@
                                   Text="@DeleteButtonText"
                                   Icon="@DeleteButtonIcon"
                                   IsDisabled="@IsDeleteButtonDisabled"
+                                  IsKeepDisabled="true"
                                   IsAsync="true"
-                                  OnConfirm="@(async ()=> await TriggerDeleteFile())" />
+                                  OnConfirm="@TriggerDeleteFile" />
             }
             else
             {

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor
@@ -16,7 +16,7 @@
             {
                 <PopConfirmButton Placement="Placement.Top" class="@RemoveButtonClassString"
                                   ConfirmIcon="@DeleteConfirmButtonIcon"
-                                  ConfirmButtonColor="DeleteConfirmButtonColor"
+                                  ConfirmButtonColor="@DeleteConfirmButtonColor"
                                   ConfirmButtonText="@DeleteConfirmButtonText"
                                   CloseButtonText="@DeleteCloseButtonText"
                                   Content="@DeleteConfirmContent"

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @typeparam TValue
 @inherits UploadBase<TValue>
 
@@ -12,9 +12,27 @@
                placeholder="@PlaceHolder" value="@CurrentValueAsString" />
         @if (ShowDeleteButton)
         {
-            <Button class="@RemoveButtonClassString" IsDisabled="@IsDeleteButtonDisabled"
-                    Icon="@DeleteButtonIcon" Text="@DeleteButtonText" Color="Color.None"
-                    OnClick="@TriggerDeleteFile"></Button>
+            @if (ShowDeleteConfirmButton)
+            {
+                <PopConfirmButton Placement="Placement.Top" class="@RemoveButtonClassString"
+                                  ConfirmIcon="@DeleteConfirmButtonIcon"
+                                  ConfirmButtonColor="DeleteConfirmButtonColor"
+                                  ConfirmButtonText="@DeleteConfirmButtonText"
+                                  CloseButtonText="@DeleteCloseButtonText"
+                                  Content="@DeleteConfirmContent"
+                                  Text="@DeleteButtonText"
+                                  Icon="@DeleteButtonIcon"
+                                  IsDisabled="@IsDeleteButtonDisabled"
+                                  IsAsync="true"
+                                  OnConfirm="@(async ()=> await TriggerDeleteFile())" />
+            }
+            else
+            {
+                <Button class="@RemoveButtonClassString" IsDisabled="@IsDeleteButtonDisabled"
+                        Icon="@DeleteButtonIcon" Text="@DeleteButtonText" Color="Color.None"
+                        OnClick="@TriggerDeleteFile"></Button>
+            }
+            
         }
         <Button class="@BrowserButtonClassString" IsDisabled="@CheckStatus()" Icon="@BrowserButtonIcon"
                 Text="@BrowserButtonText" Color="Color.None"></Button>

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor
@@ -12,7 +12,7 @@
                placeholder="@PlaceHolder" value="@CurrentValueAsString" />
         @if (ShowDeleteButton)
         {
-            @if (ShowDeleteConfirmButton)
+            @if (IsConfirmDelete)
             {
                 <PopConfirmButton Placement="Placement.Top" class="@RemoveButtonClassString"
                                   ConfirmIcon="@DeleteConfirmButtonIcon"

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor.cs
@@ -160,6 +160,5 @@ public partial class InputUpload<TValue>
             var item = Files[index - 1];
             await OnFileDelete(item);
         }
-        CurrentValue = default;
     }
 }

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor.cs
@@ -47,7 +47,7 @@ public partial class InputUpload<TValue>
     /// <para lang="en">Gets or sets the delete button icon</para>
     /// </summary>
     [Parameter]
-    public string? DeleteButtonIcon { get; set; }
+    public string? DeleteButtonIcon { get; set; }    
 
     /// <summary>
     /// <para lang="zh">获得/设置 删除按钮显示文字</para>
@@ -63,6 +63,48 @@ public partial class InputUpload<TValue>
     /// </summary>
     [Parameter]
     public bool ShowDeleteButton { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除前是否显示确认对话框，依赖 ShowDeleteButton 属性为 true 时有效</para>
+    /// <para lang="en">Gets or sets whether to display a confirmation dialog before deletion. Only takes effect when the ShowDeleteButton property is true</para>
+    /// </summary>
+    [Parameter]
+    public bool ShowDeleteConfirmButton { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除确认弹窗中确认按钮图标，默认 null</para>
+    /// <para lang="en">Gets or sets the confirmation button icon in the delete confirmation dialog. Default is null</para>
+    /// </summary>
+    [Parameter]
+    public string? DeleteConfirmButtonIcon { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除确认弹窗中确认按钮颜色，默认 Color.Danger</para>
+    /// <para lang="en">Gets or sets the color of the confirmation button in the delete confirmation dialog. Default is Color.Danger</para>
+    /// </summary>
+    [Parameter]
+    public Color DeleteConfirmButtonColor { get; set; } = Color.Danger;
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除确认弹窗中确认按钮显示文字，默认 null</para>
+    /// <para lang="en">Gets or sets the confirmation button display text in the delete confirmation dialog. Default is null</para>
+    /// </summary>
+    [Parameter]
+    public string? DeleteConfirmButtonText { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除确认弹窗中取消按钮显示文字，默认 null</para>
+    /// <para lang="en">Gets or sets the cancel button display text in the delete confirmation dialog. Default is null</para>
+    /// </summary>
+    [Parameter]
+    public string? DeleteCloseButtonText { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 删除确认弹窗中确认文本内容，默认 null 使用资源文件中内置文字</para>
+    /// <para lang="en">Gets or sets the confirmation text content in the delete confirmation dialog. Default is null (uses built-in text from resource file)</para>
+    /// </summary>
+    [Parameter]
+    public string? DeleteConfirmContent { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 PlaceHolder 占位符文本</para>

--- a/src/BootstrapBlazor/Components/Upload/InputUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/InputUpload.razor.cs
@@ -47,7 +47,7 @@ public partial class InputUpload<TValue>
     /// <para lang="en">Gets or sets the delete button icon</para>
     /// </summary>
     [Parameter]
-    public string? DeleteButtonIcon { get; set; }    
+    public string? DeleteButtonIcon { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 删除按钮显示文字</para>
@@ -65,11 +65,11 @@ public partial class InputUpload<TValue>
     public bool ShowDeleteButton { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 删除前是否显示确认对话框，依赖 ShowDeleteButton 属性为 true 时有效</para>
+    /// <para lang="zh">获得/设置 删除按钮否显示确认对话框，依赖 ShowDeleteButton 属性为 true 时有效</para>
     /// <para lang="en">Gets or sets whether to display a confirmation dialog before deletion. Only takes effect when the ShowDeleteButton property is true</para>
     /// </summary>
     [Parameter]
-    public bool ShowDeleteConfirmButton { get; set; }
+    public bool IsConfirmDelete { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 删除确认弹窗中确认按钮图标，默认 null</para>

--- a/src/BootstrapBlazor/Components/Upload/UploadBase.cs
+++ b/src/BootstrapBlazor/Components/Upload/UploadBase.cs
@@ -224,7 +224,7 @@ public abstract class UploadBase<TValue> : ValidateBase<TValue>, IUpload
         }
         else if (ValueType == typeof(IBrowserFile))
         {
-            CurrentValue = (TValue)items[0].File!;
+            CurrentValue = items.Count != 0 ? (TValue?)items[0].File : default;
         }
         else if (ValueType == typeof(string))
         {

--- a/test/UnitTest/Components/UploadCardTest.cs
+++ b/test/UnitTest/Components/UploadCardTest.cs
@@ -324,7 +324,7 @@ public class UploadCardTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public async Task ShowConfirmButton_Ok()
+    public async Task IsConfirmDelete_Ok()
     {
         var cut = Context.Render<CardUpload<string>>(pb =>
         {
@@ -333,7 +333,7 @@ public class UploadCardTest : BootstrapBlazorTestBase
                 new() { FileName = "test.png" }
             ]);
             pb.Add(a => a.ShowDeleteButton, true);
-            pb.Add(a => a.ShowDeleteConfirmButton, true);
+            pb.Add(a => a.IsConfirmDelete, true);
             pb.Add(a => a.DeleteConfirmButtonColor, Color.Danger);
             pb.Add(a => a.DeleteConfirmButtonIcon, "icon-delete");
             pb.Add(a => a.DeleteConfirmContent, "content-delete");

--- a/test/UnitTest/Components/UploadInputTest.cs
+++ b/test/UnitTest/Components/UploadInputTest.cs
@@ -81,6 +81,31 @@ public class UploadInputTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task ShowConfirmButton_Ok()
+    {
+        var cut = Context.Render<InputUpload<string>>(pb =>
+        {
+            pb.Add(a => a.DefaultFileList,
+            [
+                new() { FileName = "test.png" }
+            ]);
+            pb.Add(a => a.ShowDeleteButton, true);
+            pb.Add(a => a.ShowDeleteConfirmButton, true);
+            pb.Add(a => a.DeleteConfirmButtonColor, Color.Danger);
+            pb.Add(a => a.DeleteConfirmButtonIcon, "icon-delete");
+            pb.Add(a => a.DeleteConfirmContent, "content-delete");
+            pb.Add(a => a.DeleteConfirmButtonText, "confirm");
+            pb.Add(a => a.DeleteCloseButtonText, "cancel");
+        });
+
+        var button = cut.FindComponent<PopConfirmButton>();
+        Assert.NotNull(button);
+        Assert.NotNull(button.Instance.OnConfirm);
+
+        await cut.InvokeAsync(button.Instance.OnConfirm);
+    }
+
+    [Fact]
     public async Task InputUpload_ValidateForm_Ok()
     {
         var invalid = false;
@@ -208,6 +233,7 @@ public class UploadInputTest : BootstrapBlazorTestBase
         await cut.InvokeAsync(() => cut.Instance.Reset());
         Assert.DoesNotContain("test5.png;test6.png", cut.Markup);
     }
+
 
     [Fact]
     public void InputUpload_IsMultiple()

--- a/test/UnitTest/Components/UploadInputTest.cs
+++ b/test/UnitTest/Components/UploadInputTest.cs
@@ -90,7 +90,7 @@ public class UploadInputTest : BootstrapBlazorTestBase
                 new() { FileName = "test.png" }
             ]);
             pb.Add(a => a.ShowDeleteButton, true);
-            pb.Add(a => a.ShowDeleteConfirmButton, true);
+            pb.Add(a => a.IsConfirmDelete, true);
             pb.Add(a => a.DeleteConfirmButtonColor, Color.Danger);
             pb.Add(a => a.DeleteConfirmButtonIcon, "icon-delete");
             pb.Add(a => a.DeleteConfirmContent, "content-delete");

--- a/test/UnitTest/Components/UploadInputTest.cs
+++ b/test/UnitTest/Components/UploadInputTest.cs
@@ -81,14 +81,11 @@ public class UploadInputTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public async Task ShowConfirmButton_Ok()
+    public async Task IsConfirmDelete_Ok()
     {
-        var cut = Context.Render<InputUpload<string>>(pb =>
+        var file = new MockBrowserFile();
+        var cut = Context.Render<InputUpload<IBrowserFile>>(pb =>
         {
-            pb.Add(a => a.DefaultFileList,
-            [
-                new() { FileName = "test.png" }
-            ]);
             pb.Add(a => a.ShowDeleteButton, true);
             pb.Add(a => a.IsConfirmDelete, true);
             pb.Add(a => a.DeleteConfirmButtonColor, Color.Danger);
@@ -98,11 +95,19 @@ public class UploadInputTest : BootstrapBlazorTestBase
             pb.Add(a => a.DeleteCloseButtonText, "cancel");
         });
 
+        var input = cut.FindComponent<InputFile>();
+        await cut.InvokeAsync(() => input.Instance.OnChange.InvokeAsync(new InputFileChangeEventArgs(new List<MockBrowserFile>()
+        {
+            new()
+        })));
+
         var button = cut.FindComponent<PopConfirmButton>();
         Assert.NotNull(button);
         Assert.NotNull(button.Instance.OnConfirm);
+        Assert.DoesNotContain("pop-confirm disabled", button.Markup);
 
         await cut.InvokeAsync(button.Instance.OnConfirm);
+        Assert.Contains("pop-confirm disabled", button.Markup);
     }
 
     [Fact]


### PR DESCRIPTION
feat(InputUpload ): 增加删除前确认属性ShowDeleteConfirmButton

## Link issues
fixes #8027

## 问题描述 / Problem Description
`InputUpload`组件目前删除时，没有提示是否确认删除，会直接执行删除回调代码，通过新增`ShowDeleteConfirmButton`后控制在删除前给予确认提示？（原则上，任何删除前必须给予用户确认交互，以防止误点删除）

## 解决方案 / Solution
新增`ShowDeleteConfirmButton`给予用户确认交互，该属性依赖于`ShowDeleteButton`属性，当`ShowDeleteButton`属性为`true`时`ShowDeleteConfirmButton`属性才会生交

## 影响范围 / Impact
对老版本用户无任何影响

## Summary by Sourcery

Add optional delete confirmation support to the InputUpload component to prevent accidental file removal.

New Features:
- Introduce a ShowDeleteConfirmButton option on InputUpload to show a confirmation dialog before deleting files.
- Allow customization of the delete confirmation dialog button icons, colors, texts, and content for InputUpload.

Tests:
- Add unit test coverage for the new delete confirmation behavior on InputUpload.