### PR TITLE
fix(EditorForm): use GroupOrder group

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.1</Version>
+    <Version>10.6.2-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
+++ b/src/BootstrapBlazor/Components/EditorForm/EditorForm.razor.cs
@@ -232,7 +232,7 @@ public partial class EditorForm<TModel> : IShowLabel, IDisposable
 
     private IEnumerable<KeyValuePair<string, IOrderedEnumerable<IEditorItem>>> GroupItems => RenderItems
         .Where(i => !string.IsNullOrEmpty(i.GroupName) && i.IsVisible(ItemChangedType, IsSearch.Value))
-        .GroupBy(i => i.GroupName).OrderBy(i => i.Key)
+        .GroupBy(i => i.GroupOrder).OrderBy(i => i.Key)
         .Select(i => new KeyValuePair<string, IOrderedEnumerable<IEditorItem>>(i.First().GroupName!, i.OrderBy(x => x.Order)));
 
     private List<IEditorItem>? _itemsCache;

--- a/test/UnitTest/Components/EditorFormTest.cs
+++ b/test/UnitTest/Components/EditorFormTest.cs
@@ -587,7 +587,7 @@ public class EditorFormTest : BootstrapBlazorTestBase
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.Text), "Test-Text");
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.Order), 1);
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.GroupName), "Test-Group-1");
-                builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.GroupOrder), 1);
+                builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.GroupOrder), 2);
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.EditTemplate), new RenderFragment<Foo>(foo => builder => builder.AddContent(0, "Test")));
                 builder.CloseComponent();
 
@@ -597,7 +597,7 @@ public class EditorFormTest : BootstrapBlazorTestBase
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.Text), "Test-Address");
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.Order), 1);
                 builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.GroupName), "Test-Group-2");
-                builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.GroupOrder), 2);
+                builder.AddAttribute(index++, nameof(EditorItem<Foo, string>.GroupOrder), 1);
                 builder.CloseComponent();
 
                 builder.OpenComponent<EditorItem<Foo, bool>>(index++);
@@ -608,6 +608,11 @@ public class EditorFormTest : BootstrapBlazorTestBase
                 builder.CloseComponent();
             });
         });
+
+        var groups = cut.FindAll(".legend");
+        Assert.Equal(2, groups.Count);
+        Assert.Equal("Test-Group-2", groups[0].TextContent);
+        Assert.Equal("Test-Group-1", groups[1].TextContent);
     }
 
     private static RenderFragment<Foo> GenerateEditorItems(Foo foo) => f => builder =>


### PR DESCRIPTION
## Link issues
fixes #8029 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix incorrect editor form grouping sequence by using the group order value rather than the group name when generating grouped items.