### PR TITLE
refactor(Table): revert ResetVisibleColumns method logic

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.2-beta01</Version>
+    <Version>10.6.2-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1369,17 +1369,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 if (item == null)
                 {
                     _tableColumnStates.Add(CreateTableColumnState(col));
-                    continue;
-                }
-
-                if (!ShowColumnList)
-                {
-                    item.Visible = col.GetVisible(_screenSize);
-                }
-
-                if (!AllowResizing)
-                {
-                    item.Width = col.Width;
                 }
             }
         }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1461,7 +1461,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     /// <para lang="en">Set Column Visible Method</para>
     /// </summary>
     /// <param name="columns"></param>
-    public void ResetVisibleColumns(IEnumerable<TableColumnState> columns)
+    public void ResetVisibleColumns(IReadOnlyCollection<TableColumnState> columns)
     {
         foreach (var col in columns)
         {
@@ -1469,7 +1469,11 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             if (column != null)
             {
                 column.Visible = col.Visible;
-                column.Width = col.Width;
+
+                if (col.Width.HasValue)
+                {
+                    column.Width = col.Width;
+                }
             }
         }
 


### PR DESCRIPTION
## Link issues
fixes #8033 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Revert and adjust table column visibility and width reset behavior to restore previous logic while preserving column width updates when explicitly provided.

Enhancements:
- Simplify ResetTableColumns by removing conditional updates to column visibility and width tied to ShowColumnList and AllowResizing.
- Change ResetVisibleColumns to accept a read-only collection and only apply column width updates when a width value is present.