### PR TITLE
fix(Table): add filter table column state logic

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.2-beta02</Version>
+    <Version>10.6.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -842,17 +842,17 @@
 
     RenderFragment RenderPagination =>
         @<Pagination PageCount="@PageCount" PageIndex="@PageIndex" MaxPageLinkCount="MaxPageLinkCount"
-                         OnPageLinkClick="@OnPageLinkClick"
-                         ShowGotoNavigator="ShowGotoNavigator" GotoTemplate="GotoTemplate!"
-                         GotoNavigatorLabelText="@GotoNavigatorLabelText"
-                         ShowPageInfo="ShowPageInfo" PageInfoTemplate="InternalPageInfoTemplate"></Pagination>;
+                     OnPageLinkClick="@OnPageLinkClick"
+                     ShowGotoNavigator="ShowGotoNavigator" GotoTemplate="GotoTemplate!"
+                     GotoNavigatorLabelText="@GotoNavigatorLabelText"
+                     ShowPageInfo="ShowPageInfo" PageInfoTemplate="InternalPageInfoTemplate"></Pagination>;
 
     RenderFragment<TableColumnState> RenderColumnListItem => item =>
         @<div class="dropdown-item">
             <Checkbox ShowAfterLabel="true" DisplayText="@item.DisplayName"
-                        IsDisabled="@GetColumnsListState(item)"
-                        Value="@item.Visible"
-                        OnValueChanged="visible => OnToggleColumnVisible(item, visible)">
+                      IsDisabled="@GetColumnsListState(item)"
+                      Value="@item.Visible"
+                      OnValueChanged="visible => OnToggleColumnVisible(item, visible)">
             </Checkbox>
         </div>;
 
@@ -1080,7 +1080,7 @@
                     @if (GetShowRowCheckbox(item))
                     {
                         <Checkbox TValue="TItem" Value="@item" State="@RowCheckState(item)"
-                                    OnStateChanged="OnCheck" StopPropagation="true">
+                                  OnStateChanged="OnCheck" StopPropagation="true">
                         </Checkbox>
                     }
                 </div>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Toolbar.cs
@@ -554,27 +554,6 @@ public partial class Table<TItem>
     /// </summary>
     public List<ITableColumn> GetVisibleColumns() => _visibleColumnsCache;
 
-    private void ResetVisibleColumnsCache()
-    {
-        _visibleColumnsCache.Clear();
-
-        for (var index = 0; index < _tableColumnStates.Count; index++)
-        {
-            var item = _tableColumnStates[index];
-            var col = Columns.Find(c => c.GetFieldName() == item.Name);
-            if (col != null)
-            {
-                item.DisplayName = col.GetDisplayName();
-
-                if (item.Visible)
-                {
-                    // 增加到可见列缓存集合
-                    _visibleColumnsCache.Add(col);
-                }
-            }
-        }
-    }
-
     private bool GetColumnsListState(TableColumnState item)
     {
         var items = _tableColumnStates.Where(i => i.Visible).Select(a => a.Name).ToHashSet();

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1386,13 +1386,21 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             for (var i = _tableColumnStates.Count - 1; i >= 0; i--)
             {
                 var item = _tableColumnStates[i];
-                if (!columnMap.ContainsKey(item.Name))
+
+                // 移除不合格的列状态项
+                if (string.IsNullOrEmpty(item.Name))
                 {
                     _tableColumnStates.RemoveAt(i);
+                    continue;
+                }
+
+                if (columnMap.ContainsKey(item.Name))
+                {
+                    stateMap[item.Name] = item;
                 }
                 else
                 {
-                    stateMap[item.Name] = item;
+                    _tableColumnStates.RemoveAt(i);
                 }
             }
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1346,13 +1346,41 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private void ResetTableColumns()
     {
+        _visibleColumnsCache.Clear();
+
         if (_tableColumnStates.Count == 0)
         {
             // 重建缓存
-            _tableColumnStates.AddRange(Columns.Where(i => !i.GetIgnore()).Select(CreateTableColumnState));
+            for (var index = 0; index < Columns.Count; index++)
+            {
+                var col = Columns[index];
+                if (col.GetIgnore())
+                {
+                    continue;
+                }
+
+                var state = CreateTableColumnState(col);
+                _tableColumnStates.Add(state);
+
+                if (col.GetVisible(_screenSize))
+                {
+                    _visibleColumnsCache.Add(col);
+                }
+            }
         }
         else
         {
+            // 过滤掉 Columns 中不存在的列
+            // 注意由于多语言导致的相同列显示名称不同的情况
+            for (var i = _tableColumnStates.Count - 1; i >= 0; i--)
+            {
+                var item = _tableColumnStates[i];
+                if (!Columns.Exists(col => col.GetFieldName() == item.Name))
+                {
+                    _tableColumnStates.RemoveAt(i);
+                }
+            }
+
             foreach (var col in Columns)
             {
                 var item = _tableColumnStates.Find(i => i.Name == col.GetFieldName());
@@ -1368,12 +1396,17 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
                 if (item == null)
                 {
-                    _tableColumnStates.Add(CreateTableColumnState(col));
+                    item = CreateTableColumnState(col);
+                    _tableColumnStates.Add(item);
+                }
+
+                item.DisplayName = col.GetDisplayName();
+                if (col.GetVisible(_screenSize))
+                {
+                    _visibleColumnsCache.Add(col);
                 }
             }
         }
-
-        ResetVisibleColumnsCache();
     }
 
     private TableColumnState CreateTableColumnState(ITableColumn col) => new TableColumnState()

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1378,6 +1378,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
     private TableColumnState CreateTableColumnState(ITableColumn col) => new TableColumnState()
     {
+        DisplayName = col.GetDisplayName(),
         Name = col.GetFieldName(),
         Width = col.Width,
         Visible = col.GetVisible(_screenSize)

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1404,13 +1404,15 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 }
 
                 var name = col.GetFieldName();
-                if (!stateMap.TryGetValue(name, out var item))
+                if (stateMap.TryGetValue(name, out var item))
+                {
+                    item.DisplayName = col.GetDisplayName();
+                }
+                else
                 {
                     item = CreateTableColumnState(col);
                     _tableColumnStates.Add(item);
                 }
-
-                item.DisplayName = col.GetDisplayName();
             }
 
             // 根据 _tableColumnStates 顺序重建可见列顺序

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1428,8 +1428,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             {
                 var item = _tableColumnStates[index];
                 var col = columnMap[item.Name];
-                item.DisplayName = col.GetDisplayName();
-
                 if (item.Visible)
                 {
                     // 增加到可见列缓存集合

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1370,39 +1370,59 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         }
         else
         {
-            // 过滤掉 Columns 中不存在的列
+            // 过滤掉 Columns 中不存在或被忽略的列
             // 注意由于多语言导致的相同列显示名称不同的情况
+            // 通过字典缓存避免 Columns.Exists / _tableColumnStates.Find 的二次嵌套循环 O(N*M)
+            var columnMap = new Dictionary<string, ITableColumn>(Columns.Count, StringComparer.Ordinal);
+            foreach (var col in Columns)
+            {
+                if (!col.GetIgnore())
+                {
+                    columnMap[col.GetFieldName()] = col;
+                }
+            }
+
+            var stateMap = new Dictionary<string, TableColumnState>(_tableColumnStates.Count, StringComparer.Ordinal);
             for (var i = _tableColumnStates.Count - 1; i >= 0; i--)
             {
                 var item = _tableColumnStates[i];
-                if (!Columns.Exists(col => col.GetFieldName() == item.Name))
+                if (!columnMap.ContainsKey(item.Name))
                 {
                     _tableColumnStates.RemoveAt(i);
+                }
+                else
+                {
+                    stateMap[item.Name] = item;
                 }
             }
 
             foreach (var col in Columns)
             {
-                var item = _tableColumnStates.Find(i => i.Name == col.GetFieldName());
-
                 if (col.GetIgnore())
                 {
-                    if (item != null)
-                    {
-                        _tableColumnStates.Remove(item);
-                    }
                     continue;
                 }
 
-                if (item == null)
+                var name = col.GetFieldName();
+                if (!stateMap.TryGetValue(name, out var item))
                 {
                     item = CreateTableColumnState(col);
                     _tableColumnStates.Add(item);
                 }
 
                 item.DisplayName = col.GetDisplayName();
-                if (col.GetVisible(_screenSize))
+            }
+
+            // 根据 _tableColumnStates 顺序重建可见列顺序
+            for (var index = 0; index < _tableColumnStates.Count; index++)
+            {
+                var item = _tableColumnStates[index];
+                var col = columnMap[item.Name];
+                item.DisplayName = col.GetDisplayName();
+
+                if (item.Visible)
                 {
+                    // 增加到可见列缓存集合
                     _visibleColumnsCache.Add(col);
                 }
             }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -273,8 +273,8 @@ public class TableTest : BootstrapBlazorTestBase
         var table = cut.FindComponent<Table<Foo>>();
         await cut.InvokeAsync(() => table.Instance.ResetVisibleColumns(
         [
-            new TableColumnState() { Name = nameof(Foo.Name), Visible = true, DisplayName = "Name-Display" },
-            new TableColumnState() { Name = nameof(Foo.Address), Visible = false }
+            new TableColumnState() { Name = nameof(Foo.Name), Visible = true, Width = 120 },
+            new TableColumnState() { Name = nameof(Foo.Address), Visible = false, Width = 100 }
         ]));
 
         Assert.Single(table.Instance.GetVisibleColumns());
@@ -284,6 +284,9 @@ public class TableTest : BootstrapBlazorTestBase
         Assert.Equal(2, labels.Count);
         Assert.Equal("姓名", labels[0].TextContent);
         Assert.Equal("地址", labels[1].TextContent);
+
+        // 检查宽度设置
+        Assert.Contains("<col style=\"width: 120px;\" />", table.Markup);
     }
 
     [Fact]

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -7986,6 +7986,7 @@ public class TableTest : BootstrapBlazorTestBase
         });
 
         // 二次渲染触发 OnColumnCreating
+        // 虽然更改了 Visible 但是以持久化的为准，更改 visible 变量不影响渲染结果
         visible = true;
         creating = false;
         cut.Render();
@@ -7994,7 +7995,7 @@ public class TableTest : BootstrapBlazorTestBase
         {
             Assert.True(creating);
             var table = cut.FindComponent<Table<Foo>>();
-            Assert.Equal(2, table.Instance.GetVisibleColumns().Count);
+            Assert.Single(table.Instance.GetVisibleColumns());
         });
     }
 

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -8973,6 +8973,9 @@ public class TableTest : BootstrapBlazorTestBase
         state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Name), Visible = true, Width = 100, DisplayName = "Name-Display" });
         state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Address), Visible = false, Width = 120, DisplayName = "Address-Display" });
 
+        // 增加干扰列
+        state.Columns.Add(new TableColumnState() { Name = "", Visible = true });
+
         var loaded = false;
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var items = Foo.GenerateFoo(localizer, 2);

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -902,7 +902,9 @@ public class TableTest : BootstrapBlazorTestBase
         state.Columns = new List<TableColumnState>()
         {
             new TableColumnState() { Name = nameof(Foo.Name), Visible = false },
-            new TableColumnState() { Name = nameof(Foo.Address), Visible = true, Width = 120 }
+            new TableColumnState() { Name = nameof(Foo.Address), Visible = true, Width = 120 },
+            // 增加一列 Columns 中不存在的列
+            new TableColumnState() { Name = nameof(Foo.Count), Visible = true, Width = 120 }
         };
 
         Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test").SetResult(state);
@@ -945,6 +947,12 @@ public class TableTest : BootstrapBlazorTestBase
         cut.Contains("Test_Column_List");
         cut.DoesNotContain("dropdown-menu-popover");
 
+        // 过滤掉 Count 列只显示 Name 和 Address 列
+        var labels = cut.FindAll(".form-check-label");
+        Assert.Equal(2, labels.Count);
+        Assert.Equal("姓名", labels[0].TextContent);
+        Assert.Equal("地址", labels[1].TextContent);
+
         var item = cut.FindComponents<Checkbox<bool>>()[0];
         await cut.InvokeAsync(item.Instance.OnToggleClick);
         Assert.True(show);
@@ -981,7 +989,7 @@ public class TableTest : BootstrapBlazorTestBase
         cut.Contains("style=\"width: 340px;\"");
 
         // 检查 ShowColumnList 中的 DisplayName 是否正确
-        var labels = table.FindAll(".form-check-label");
+        labels = table.FindAll(".form-check-label");
         Assert.Equal(2, labels.Count);
         Assert.Equal("姓名", labels[0].TextContent);
         Assert.Equal("地址", labels[1].TextContent);


### PR DESCRIPTION
## Link issues
fixes #8035 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Synchronize table column state with current columns and visible column cache to correctly reflect filtering and visibility changes.

Bug Fixes:
- Ensure table column states are rebuilt and filtered to exclude ignored or removed columns while keeping display names in sync.
- Rebuild the visible columns cache directly from column states to maintain correct visible column ordering and contents.

Enhancements:
- Optimize table column state reconciliation using dictionary lookups instead of nested scans for improved performance on large tables.