### PR TITLE
feat(WebClientService): improve performance

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Client.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Client.razor.cs
@@ -1,4 +1,4 @@
-﻿// Licensed to the .NET Foundation under one or more agreements.
+// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone

--- a/src/BootstrapBlazor/Services/WebClientService.cs
+++ b/src/BootstrapBlazor/Services/WebClientService.cs
@@ -12,20 +12,13 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">WebClient 服务类</para>
 /// <para lang="en">WebClient Service Class</para>
 /// </summary>
-/// <param name="ipLocatorFactory"></param>
-/// <param name="options"></param>
-/// <param name="runtime"></param>
-/// <param name="navigation"></param>
-/// <param name="logger"></param>
 public class WebClientService(IIpLocatorFactory ipLocatorFactory,
     IOptionsMonitor<BootstrapBlazorOptions> options,
     IJSRuntime runtime,
     NavigationManager navigation,
     ILogger<WebClientService> logger) : IAsyncDisposable
 {
-    private TaskCompletionSource? _taskCompletionSource;
     private JSModule? _jsModule;
-    private DotNetObjectReference<WebClientService>? _interop;
     private ClientInfo? _client;
     private IIpLocatorProvider? _provider;
 
@@ -33,9 +26,8 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
     /// <para lang="zh">获得 ClientInfo 实例方法</para>
     /// <para lang="en">Get ClientInfo Instance Method</para>
     /// </summary>
-    public async Task<ClientInfo> GetClientInfo()
+    public async Task<ClientInfo> GetClientInfo(CancellationToken token = default)
     {
-        _taskCompletionSource = new TaskCompletionSource();
         _client = new ClientInfo()
         {
             RequestUrl = navigation.Uri
@@ -46,11 +38,12 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
             _jsModule ??= await runtime.LoadModuleByName("client");
             if (_jsModule != null)
             {
-                _interop ??= DotNetObjectReference.Create(this);
-                await _jsModule.InvokeVoidAsync("ping", "ip.axd", _interop, nameof(SetData));
-                // <para lang="zh">等待 SetData 方法执行完毕</para>
-                // <para lang="en">Wait for SetData method to complete</para>
-                await _taskCompletionSource.Task.WaitAsync(TimeSpan.FromSeconds(3));
+                var client = await _jsModule.InvokeAsync<ClientInfo>("ping", token, "ip.axd");
+                if (client != null)
+                {
+                    _client = client;
+                    _client.RequestUrl = navigation.Uri;
+                }
             }
         }
         catch (Exception ex)
@@ -58,8 +51,6 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
             logger.LogError(ex, "{GetClientInfo} throw exception", nameof(GetClientInfo));
         }
 
-        // <para lang="zh">补充 IP 地址信息</para>
-        // <para lang="en">Supplement IP address information</para>
         if (options.CurrentValue.WebClientOptions.EnableIpLocator && string.IsNullOrEmpty(_client.City))
         {
             _provider ??= ipLocatorFactory.Create(options.CurrentValue.IpLocatorOptions.ProviderName);
@@ -69,33 +60,13 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
     }
 
     /// <summary>
-    /// <para lang="zh">SetData 方法由 JS 调用</para>
-    /// <para lang="en">SetData method called by JS</para>
-    /// </summary>
-    /// <param name="client"></param>
-    [JSInvokable]
-    public void SetData(ClientInfo client)
-    {
-        _client = client;
-        _client.RequestUrl = navigation.Uri;
-        _taskCompletionSource?.TrySetResult();
-    }
-
-    /// <summary>
-    /// <para lang="zh">Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously</para>
+    /// <para lang="zh">资源销毁方法</para>
     /// <para lang="en">Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources asynchronously</para>
     /// </summary>
-    /// <param name="disposing"></param>
     protected virtual async ValueTask DisposeAsync(bool disposing)
     {
         if (disposing)
         {
-            // <para lang="zh">销毁 DotNetObjectReference 实例</para>
-            // <para lang="en">Dispose DotNetObjectReference instance</para>
-            _interop?.Dispose();
-
-            // <para lang="zh">销毁 JSModule</para>
-            // <para lang="en">Dispose JSModule</para>
             if (_jsModule != null)
             {
                 await _jsModule.DisposeAsync();

--- a/src/BootstrapBlazor/Services/WebClientService.cs
+++ b/src/BootstrapBlazor/Services/WebClientService.cs
@@ -26,7 +26,13 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
     /// <para lang="zh">获得 ClientInfo 实例方法</para>
     /// <para lang="en">Get ClientInfo Instance Method</para>
     /// </summary>
-    public async Task<ClientInfo> GetClientInfo(CancellationToken token = default)
+    public Task<ClientInfo> GetClientInfo() => GetClientInfo(CancellationToken.None);
+
+    /// <summary>
+    /// <para lang="zh">获得 ClientInfo 实例方法</para>
+    /// <para lang="en">Get ClientInfo Instance Method</para>
+    /// </summary>
+    public async Task<ClientInfo> GetClientInfo(CancellationToken token)
     {
         _client = new ClientInfo()
         {

--- a/src/BootstrapBlazor/Services/WebClientService.cs
+++ b/src/BootstrapBlazor/Services/WebClientService.cs
@@ -38,6 +38,7 @@ public class WebClientService(IIpLocatorFactory ipLocatorFactory,
             _jsModule ??= await runtime.LoadModuleByName("client");
             if (_jsModule != null)
             {
+                // token 超时无异常，返回 null
                 var client = await _jsModule.InvokeAsync<ClientInfo>("ping", token, "ip.axd");
                 if (client != null)
                 {

--- a/src/BootstrapBlazor/Utils/JSModule.cs
+++ b/src/BootstrapBlazor/Utils/JSModule.cs
@@ -29,7 +29,7 @@ public class JSModule(IJSObjectReference? jSObjectReference) : IAsyncDisposable
     /// <param name="args"></param>
     public virtual ValueTask InvokeVoidAsync(string identifier, TimeSpan timeout, params object?[]? args)
     {
-        using CancellationTokenSource? cancellationTokenSource = ((timeout == Timeout.InfiniteTimeSpan) ? null : new CancellationTokenSource(timeout));
+        using var cancellationTokenSource = ((timeout == Timeout.InfiniteTimeSpan) ? null : new CancellationTokenSource(timeout));
         CancellationToken cancellationToken = cancellationTokenSource?.Token ?? CancellationToken.None;
         return InvokeVoidAsync(identifier, cancellationToken, args);
     }

--- a/src/BootstrapBlazor/wwwroot/modules/client.js
+++ b/src/BootstrapBlazor/wwwroot/modules/client.js
@@ -1,9 +1,9 @@
 import browser from "./browser.min.mjs"
 import { execute } from "./ajax.js"
 
-export async function ping(url, invoke, method) {
+export async function ping(url) {
     const data = await getClientInfo(url);
-    await invoke.invokeMethodAsync(method, data)
+    return data;
 }
 
 export async function getClientInfo(url) {

--- a/test/UnitTest/Services/ConnectionHubTest.cs
+++ b/test/UnitTest/Services/ConnectionHubTest.cs
@@ -36,12 +36,6 @@ public class ConnectionHubTest
         var cut = context.Render<ConnectionHub>();
         await cut.InvokeAsync(async () =>
         {
-            _ = Task.Run(async () =>
-            {
-                await Task.Delay(100);
-                client.SetData(new ClientInfo() { Id = "test_id", Ip = "::1" });
-            });
-
             await cut.Instance.Callback(new ClientInfo { Id = "test_id", Ip = "::1" });
         });
         Assert.Equal(1, service.Count);
@@ -73,7 +67,6 @@ public class ConnectionHubTest
         cut = context.Render<ConnectionHub>();
         await cut.InvokeAsync(async () =>
         {
-            client.SetData(new ClientInfo() { Id = "test_id", Ip = "::1" });
             await cut.Instance.Callback(new ClientInfo { Id = "test_id", Ip = "::1" });
         });
 
@@ -84,7 +77,6 @@ public class ConnectionHubTest
         cut = context.Render<ConnectionHub>();
         await cut.InvokeAsync(async () =>
         {
-            client.SetData(new ClientInfo() { Id = "test_id", Ip = "::1" });
             await cut.Instance.Callback(new ClientInfo { Id = "test_id", Ip = "::1" });
         });
     }

--- a/test/UnitTest/Services/WebClientServiceTest.cs
+++ b/test/UnitTest/Services/WebClientServiceTest.cs
@@ -24,15 +24,10 @@ public class WebClientServiceTest : BootstrapBlazorTestBase
             Engine = "engine",
             UserAgent = "test_agent"
         };
+        Context.JSInterop.Setup<ClientInfo>("ping", _ => true).SetResult(mockData);
         var service = Context.Services.GetRequiredService<WebClientService>();
-        service.SetData(mockData);
-        ClientInfo? client = null;
-        _ = Task.Run(async () => client = await service.GetClientInfo());
-        while (client == null)
-        {
-            await Task.Delay(100);
-            service.SetData(mockData);
-        }
+        var client = await service.GetClientInfo();
+
         client.City = "test_city";
         client.RequestUrl = "test_url";
         Assert.Equal("test_id", client.Id);
@@ -62,33 +57,23 @@ public class WebClientServiceTest : BootstrapBlazorTestBase
     public async Task GetClientInfo_Error()
     {
         var service = Context.Services.GetRequiredService<WebClientService>();
-        var client = await service.GetClientInfo();
-
-        // TimeoutException
-        Assert.Null(client.Ip);
 
         // Exception
-        Context.JSInterop.SetupVoid("ping", _ => true).SetException(new Exception("test-exception"));
-        client = await service.GetClientInfo();
+        Context.JSInterop.Setup<ClientInfo>("ping", _ => true).SetException(new Exception("test-exception"));
+        var client = await service.GetClientInfo();
     }
 
     [Fact]
-    public async Task SetData_Ok()
+    public async Task GetClientInfo_CancellationToken_Ok()
     {
         var service = Context.Services.GetRequiredService<WebClientService>();
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
 
-        // 内部 ReturnTask 为空
-        var fieldInfo = service.GetType().GetField("_taskCompletionSource", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
-        fieldInfo!.SetValue(service, null);
+        var client = await service.GetClientInfo(cancellationTokenSource.Token);
 
-        service.SetData(new ClientInfo() { Id = "test" });
-        _ = Task.Run(async () =>
-        {
-            await Task.Delay(150);
-            service.SetData(new ClientInfo() { Id = "test-id", Ip = "192.168.0.1" });
-        });
-        var client = await service.GetClientInfo();
-        Assert.Equal("192.168.0.1", client.Ip);
+        Assert.NotNull(client);
+        Assert.Null(client.Ip);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8037 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refactor WebClientService client info retrieval to use direct JS interop return values instead of callback-based invocation and improve cancellation and timeout handling.

New Features:
- Allow GetClientInfo to accept a CancellationToken to support cooperative cancellation when fetching client data.

Bug Fixes:
- Remove reliance on JS-invokable callback and TaskCompletionSource to avoid race conditions and timeout issues when retrieving client info from the browser.

Enhancements:
- Simplify WebClientService by eliminating DotNetObjectReference usage and disposing only the JS module resource.
- Update client.js ping helper to return client info directly, aligning with the new WebClientService interaction pattern.
- Tighten JSModule timeout handling by using a scoped CancellationTokenSource variable declaration style.

Tests:
- Simplify WebClientService unit tests to use JSInterop return values instead of repeated SetData calls and polling loops.
- Add coverage for GetClientInfo cancellation token behavior and adjust existing tests to the new interaction model for client info retrieval.
- Remove now-obsolete ConnectionHub tests that depended on WebClientService.SetData.