### PR TITLE
fix(Table): column DefaultSortOrder only work on first render

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.4-beta01</Version>
+    <Version>10.6.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1126,6 +1126,14 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             // 构建列信息
             await BuildTableColumnsAsync();
 
+            // set default sortName
+            var col = Columns.Find(i => i is { Sortable: true, DefaultSort: true });
+            if (col != null)
+            {
+                SortName = col.GetFieldName();
+                SortOrder = col.DefaultSortOrder;
+            }
+
             // 调用查询方法渲染 UI
             await QueryAsync(true, 1, false, true, IsAutoQueryFirstRender);
             return;
@@ -1314,14 +1322,6 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
         Columns.Clear();
         Columns.AddRange(cols.OrderFunc());
-
-        // set default sortName
-        var col = Columns.Find(i => i is { Sortable: true, DefaultSort: true });
-        if (col != null)
-        {
-            SortName = col.GetFieldName();
-            SortOrder = col.DefaultSortOrder;
-        }
 
         // 加载客户端持久化列状态
         ResetTableColumns();

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -3487,6 +3487,59 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task DefaultSortOrder_FirstRenderQuery_Ok()
+    {
+        var sortName = string.Empty;
+        var sortOrder = SortOrder.Unset;
+        var isFirstQuery = false;
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.OnQueryAsync, option =>
+                {
+                    sortName = option.SortName;
+                    sortOrder = option.SortOrder;
+                    isFirstQuery = option.IsFirstQuery;
+                    var items = Foo.GenerateFoo(localizer, 5);
+                    return Task.FromResult(new QueryData<Foo>()
+                    {
+                        Items = items,
+                        TotalCount = items.Count,
+                        IsAdvanceSearch = true,
+                        IsFiltered = true,
+                        IsSearch = true,
+                        IsSorted = true
+                    });
+                });
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.AddAttribute(3, "Sortable", true);
+                    builder.AddAttribute(4, "DefaultSort", true);
+                    builder.AddAttribute(5, "DefaultSortOrder", SortOrder.Desc);
+                    builder.CloseComponent();
+                });
+            });
+        });
+
+        Assert.True(isFirstQuery);
+        Assert.Equal(nameof(Foo.Name), sortName);
+        Assert.Equal(SortOrder.Desc, sortOrder);
+
+        // 模拟点击表头排序
+        var th = cut.Find("th");
+        await cut.InvokeAsync(() => th.Click());
+        Assert.False(isFirstQuery);
+        Assert.Equal(nameof(Foo.Name), sortName);
+        Assert.Equal(SortOrder.Unset, sortOrder);
+    }
+
+    [Fact]
     public async Task OnSort_Ok()
     {
         // 外部未排序，组件内部自动排序


### PR DESCRIPTION
## Link issues
fixes #8053 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Fix table columns so the DefaultSortOrder configuration consistently applies rather than only on the initial render.