### PR TITLE
feat(OctIcons): bump version 10.0.3

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -61,7 +61,7 @@
     <PackageReference Include="BootstrapBlazor.Middleware" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.MindMap" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.MouseFollower" Version="10.0.0" />
-    <PackageReference Include="BootstrapBlazor.OctIcon" Version="10.0.2" />
+    <PackageReference Include="BootstrapBlazor.OctIcon" Version="10.0.3" />
     <PackageReference Include="BootstrapBlazor.OfficeViewer" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.OnScreenKeyboard" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.OpcDa" Version="10.0.0" />


### PR DESCRIPTION
## Link issues
fixes #8066 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bump the OctIcons dependency version in the BootstrapBlazor.Server project file.

Enhancements:
- Align the server project with OctIcons package version 10.0.3 for updated icons support.

Build:
- Update BootstrapBlazor.Server.csproj package reference to use OctIcons 10.0.3.