### PR TITLE
feat(ThemeProvider): keep auto value

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.4</Version>
+    <Version>10.6.5-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -716,8 +716,8 @@ export function getAutoThemeValue() {
 }
 
 export function setTheme(theme, sync) {
-    if (theme === 'auto' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-        document.documentElement.setAttribute('data-bs-theme', 'dark')
+    if (theme === 'auto') {
+        document.documentElement.setAttribute('data-bs-theme', getAutoThemeValue())
     }
     else {
         document.documentElement.setAttribute('data-bs-theme', theme);

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -702,10 +702,7 @@ export function getTheme(useLocalstorage = true) {
         theme = document.documentElement.getAttribute('data-bs-theme');
     }
 
-    if (theme === null || theme === 'auto') {
-        theme = getAutoThemeValue();
-    }
-    return theme;
+    return theme == null ? 'auto' : theme;
 }
 
 export function saveTheme(theme) {


### PR DESCRIPTION
## Link issues
fixes #8063 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Preserve the explicit 'auto' theme value when reading and applying the current theme, aligning ThemeProvider behavior with automatic light/dark detection.

Enhancements:
- Adjust theme retrieval to return 'auto' when no theme is set instead of resolving it to a concrete theme.
- Update theme application logic to always delegate 'auto' to automatic light/dark resolution via the existing helper.