### PR TITLE
perf(table): only call once OnQuery when set ScrollMode to Virtual

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.6.5-beta01</Version>
+    <Version>10.7.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1134,8 +1134,15 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 SortOrder = col.DefaultSortOrder;
             }
 
-            // 调用查询方法渲染 UI
-            await QueryAsync(true, 1, false, true, IsAutoQueryFirstRender);
+            if (ScrollMode == ScrollMode.None)
+            {
+                // 调用查询方法渲染 UI
+                await QueryAsync(true, 1, false, true, IsAutoQueryFirstRender);
+            }
+            else
+            {
+                StateHasChanged();
+            }
             return;
         }
 
@@ -1750,13 +1757,15 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     public Dictionary<string, IFilterAction> Filters { get; } = [];
     #endregion
 
+    private bool isFirstQuery = true;
     private async ValueTask<ItemsProviderResult<TItem>> LoadItems(ItemsProviderRequest request)
     {
         StartIndex = _shouldScrollTop ? 0 : request.StartIndex;
         _pageItems = request.Count;
 
         await ToggleLoading(true);
-        await QueryData();
+        await QueryData(triggerByPagination: false, firstQuery: isFirstQuery);
+        isFirstQuery = false;
         await ToggleLoading(false);
 
         return new ItemsProviderResult<TItem>(QueryItems, TotalCount);


### PR DESCRIPTION
## Link issues
fixes #8065

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Avoid duplicate data queries when using virtual scroll in the table component and ensure appropriate UI updates on initial render.

Bug Fixes:
- Prevent multiple initial data queries when the table scroll mode is virtual, avoiding redundant OnQuery invocations.

Enhancements:
- Trigger a simple state update instead of a full query on initial render when virtual scrolling is enabled to improve performance.