### PR TITLE
feat(Table): SelectedRows support dynamic object

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.1</Version>
+    <Version>10.7.2-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -724,10 +724,11 @@ public partial class Table<TItem>
 
             // 数据源可能重建行实例（如动态类型数据未启用缓存）导致引用比较失真
             // 使用 Equals 比较逻辑判断选中行集合是否真实发生变化，仅真实变化时触发回调防止与重新渲染形成死循环
-            var changed = selectedRows.Count != SelectedRows.Count
-                || selectedRows.Where((row, index) => !Equals(row, SelectedRows[index])).Any();
+            var changed = SelectedRowsChanged.HasDelegate
+                && (selectedRows.Count != SelectedRows.Count
+                    || selectedRows.Where((row, index) => !Equals(row, SelectedRows[index])).Any());
             SelectedRows = selectedRows;
-            if (changed && SelectedRowsChanged.HasDelegate)
+            if (changed)
             {
                 _ = SelectedRowsChanged.InvokeAsync(selectedRows);
             }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -721,13 +721,15 @@ public partial class Table<TItem>
         if (SelectedRows.Count > 0)
         {
             var selectedRows = items.Where(i => SelectedRows.Any(row => Equals(i, row))).ToList();
-            if (!selectedRows.SequenceEqual(SelectedRows))
+
+            // 数据源可能重建行实例（如动态类型数据未启用缓存）导致引用比较失真
+            // 使用 Equals 比较逻辑判断选中行集合是否真实发生变化，仅真实变化时触发回调防止与重新渲染形成死循环
+            var changed = selectedRows.Count != SelectedRows.Count
+                || selectedRows.Where((row, index) => !Equals(row, SelectedRows[index])).Any();
+            SelectedRows = selectedRows;
+            if (changed && SelectedRowsChanged.HasDelegate)
             {
-                SelectedRows = selectedRows;
-                if (SelectedRowsChanged.HasDelegate)
-                {
-                    _ = SelectedRowsChanged.InvokeAsync(selectedRows);
-                }
+                _ = SelectedRowsChanged.InvokeAsync(selectedRows);
             }
         }
     }

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -5726,11 +5726,12 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
-    public void SelectedRows_Bind()
+    public async Task SelectedRows_Bind()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
         var items = FooNoKeyTree.Generate(localizer);
         var selectedRows = new List<FooNoKeyTree>();
+        var changed = false;
         selectedRows.AddRange(items.Take(2));
         var cut = Context.Render<BootstrapBlazorRoot>(pb =>
         {
@@ -5747,6 +5748,11 @@ public class TableTest : BootstrapBlazorTestBase
                     return Task.FromResult(data);
                 });
                 pb.Add(a => a.SelectedRows, selectedRows);
+                pb.Add(a => a.SelectedRowsChanged, EventCallback.Factory.Create<List<FooNoKeyTree>>(this, rows =>
+                {
+                    selectedRows = rows;
+                    changed = true;
+                }));
                 pb.Add(a => a.IsMultipleSelect, true);
                 pb.Add(a => a.TableColumns, foo => builder =>
                 {
@@ -5757,6 +5763,18 @@ public class TableTest : BootstrapBlazorTestBase
                 });
             });
         });
+
+        // 初次查询选中行集合未发生变化 不触发 SelectedRowsChanged 回调
+        Assert.False(changed);
+        Assert.Equal(2, selectedRows.Count);
+
+        // 数据源移除一个选中行后重新查询 选中行集合发生变化触发 SelectedRowsChanged 回调
+        var table = cut.FindComponent<Table<FooNoKeyTree>>();
+        items = items.Skip(1).ToList();
+        await cut.InvokeAsync(() => table.Instance.QueryAsync());
+
+        Assert.True(changed);
+        Assert.Single(selectedRows);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8098 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve Table selected rows synchronization and change detection for dynamically rebuilt data sources.

Bug Fixes:
- Fix SelectedRowsChanged callback being skipped or causing potential loops when table data is rebuilt with new item instances by using logical equality to detect true selection changes.

Enhancements:
- Refine ResetSelectedRows to compare selections by value and only invoke SelectedRowsChanged when the effective selection actually changes.

Tests:
- Extend SelectedRows_Bind unit test to verify SelectedRowsChanged is not raised on initial query and is raised when the underlying data source changes and selection updates.