### PR TITLE
chore(Robot): add auto approve action

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -15,7 +15,7 @@ jobs:
   auto_approve:
     name: auto approve
     runs-on: ubuntu-latest
-    # 仅对信任的作者自动审批，按需在列表中追加账号
+    # Only auto-approve PRs from trusted authors; add accounts to the list as needed
     if: |
       github.event.pull_request.draft == false &&
       contains(fromJSON('["ArgoZhang"]'), github.event.pull_request.user.login)

--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,38 @@
+name: Auto Approve PR(bot)
+
+on:
+  pull_request:
+    branches:
+      - master
+      - main
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+jobs:
+  auto_approve:
+    name: auto approve
+    runs-on: ubuntu-latest
+    # 仅对信任的作者自动审批，按需在列表中追加账号
+    if: |
+      github.event.pull_request.draft == false &&
+      contains(fromJSON('["ArgoZhang"]'), github.event.pull_request.user.login)
+
+    steps:
+      - name: Generate bb-auto token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.BB_AUTO_APP_ID }}
+          private-key: ${{ secrets.BB_AUTO_PRIVATE_KEY }}
+
+      - name: Approve pull request
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh pr review ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --approve \
+            --body "Auto approved by bb-auto"


### PR DESCRIPTION
## Issues
close #8109 

## Summary

Add an auto-approve workflow that uses the `bb-auto` GitHub App to automatically approve pull requests from trusted authors, satisfying the branch protection rule that requires PR approvals.

- Triggers on `opened` / `reopened` / `synchronize` / `ready_for_review` (re-approves after new pushes in case stale approvals are dismissed)
- Only runs for non-draft PRs authored by accounts in the trusted list (currently `ArgoZhang`)
- Generates an installation token via `actions/create-github-app-token` and approves with `gh pr review --approve`, so the approval comes from **bb-auto[bot]**

## Required configuration (already done)

- `bb-auto` app installed on this repository with **Pull requests: Read and write** permission
- Repository secrets: `BB_AUTO_APP_ID`, `BB_AUTO_PRIVATE_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Introduce an auto-approve workflow that triggers on specific pull request events for main/master branches and approves non-draft PRs from a configured list of trusted authors using the bb-auto app token.