### PR TITLE
fix(Table): use auto table layout when AllowResizing is enabled

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.2-beta02</Version>
+    <Version>10.7.2-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -90,7 +90,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         .AddClass("table-excel", IsExcel)
         .AddClass("table-bordered", IsBordered)
         .AddClass("table-striped table-hover", IsStriped)
-        .AddClass("table-layout-fixed", IsFixedHeader || AllowResizing)
+        .AddClass("table-layout-fixed", IsFixedHeader)
         .AddClass("table-draggable", AllowDragColumn)
         .Build();
 

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -1609,6 +1609,7 @@ public class TableTest : BootstrapBlazorTestBase
         });
         cut.Contains("table-fixed-header");
         cut.Contains("height: 200px;");
+        cut.Contains("table-layout-fixed");
     }
 
     [Theory]
@@ -1745,6 +1746,9 @@ public class TableTest : BootstrapBlazorTestBase
         {
             cut.DoesNotContain("is-resizable");
         }
+
+        // 开启列宽调整时仍使用 auto 布局保持初始列宽与未开启时一致
+        cut.DoesNotContain("table-layout-fixed");
     }
 
     [Theory]


### PR DESCRIPTION
Revert table-layout-fixed condition to IsFixedHeader only so that tables with AllowResizing keep content-based initial column widths as before v10.6.

## Link issues
fixes #8095 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Adjust table layout behavior so fixed layout applies only to fixed-header tables, preserving auto layout for resizable columns.

Bug Fixes:
- Restore content-based initial column widths when column resizing is enabled by avoiding forced fixed table layout in that mode.

Tests:
- Extend table header and resizing tests to assert the presence or absence of the fixed table layout class under the appropriate conditions.