### PR TITLE
feat(Table): add auto width function

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.2-beta04</Version>
+    <Version>10.7.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Edit.cs
@@ -516,6 +516,12 @@ public partial class Table<TItem>
 
         if (shouldRender)
         {
+            // 数据渲染后触发脚本测量列内容最小宽度 用于固定表头(table-layout:fixed)窄容器下横向滚动兜底
+            if (IsFixedHeader)
+            {
+                _measureColumnMinWidth = true;
+                _invoke = true;
+            }
             StateHasChanged();
         }
     }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -522,6 +522,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     private bool _resetTable;
     private bool _resetColumnListPopover;
     private bool _resetColumns;
+    private bool _measureColumnMinWidth;
     private bool _updateSortTooltip;
     private bool _shouldScrollTop;
     private bool _invoke;
@@ -1151,6 +1152,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             var resetColumnListPopover = _resetColumnListPopover;
             var resetTable = _resetTable;
             var resetColumns = _resetColumns;
+            var measureColumnMinWidth = _measureColumnMinWidth;
             var updateSortTooltip = _updateSortTooltip;
             var scrollToTop = _shouldScrollTop;
 
@@ -1158,6 +1160,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             _resetColumnListPopover = false;
             _resetTable = false;
             _resetColumns = false;
+            _measureColumnMinWidth = false;
             _updateSortTooltip = false;
             _shouldScrollTop = false;
 
@@ -1167,6 +1170,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 ResetColumnListPopover = resetColumnListPopover,
                 ResetTable = resetTable,
                 ResetColumns = resetColumns,
+                MeasureColumnMinWidth = measureColumnMinWidth,
                 ColumnStates = _tableColumnStates,
                 AllowDragColumn,
                 UpdateSortTooltip = updateSortTooltip,
@@ -1463,6 +1467,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 FitColumnWidthIncludeHeader,
                 ResizeColumnCallback = nameof(ResizeColumnCallback),
                 ColumnMinWidth = ColumnMinWidth ?? Options.CurrentValue.TableSettings.ColumnMinWidth,
+                ColumnStates = _tableColumnStates,
                 ScrollWidth = ActualScrollWidth,
                 ShowColumnWidthTooltip,
                 ColumnWidthTooltipPrefix,

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -67,7 +67,10 @@ export async function reset(id) {
                     if (table.minWidthRaf) {
                         cancelAnimationFrame(table.minWidthRaf);
                     }
-                    table.minWidthRaf = requestAnimationFrame(() => applyColumnMinWidth(table));
+                    table.minWidthRaf = requestAnimationFrame(() => {
+                        table.minWidthRaf = null;
+                        applyColumnMinWidth(table);
+                    });
                 });
                 table.minWidthObserver.observe(table.body);
             }

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -26,6 +26,11 @@ export async function reset(id) {
         return;
     }
 
+    if (table.minWidthObserver) {
+        table.minWidthObserver.disconnect();
+        table.minWidthObserver = null;
+    }
+
     table.columns = [];
     table.tables = [];
     table.dragColumns = [];
@@ -51,6 +56,16 @@ export async function reset(id) {
                 const left = table.body.scrollLeft
                 table.thead.scrollTo(left, 0)
             });
+
+            if (window.ResizeObserver) {
+                table.minWidthObserver = new ResizeObserver(() => {
+                    if (table.minWidthRaf) {
+                        cancelAnimationFrame(table.minWidthRaf);
+                    }
+                    table.minWidthRaf = requestAnimationFrame(() => applyColumnMinWidth(table));
+                });
+                table.minWidthObserver.observe(table.body);
+            }
         }
         else {
             table.isExcel = shim.firstElementChild.classList.contains('table-excel')
@@ -91,6 +106,10 @@ export async function reset(id) {
         table.loopCheckHeightHandler = requestAnimationFrame(() => check(table));
         return;
     }
+
+    if (table.thead) {
+        setColSize(table, table.options);
+    }
 }
 
 export async function switchCardView(id) {
@@ -112,6 +131,13 @@ const destroyTable = table => {
     if (table) {
         if (table.loopCheckHeightHandler) {
             cancelAnimationFrame(table.loopCheckHeightHandler);
+        }
+        if (table.minWidthObserver) {
+            table.minWidthObserver.disconnect();
+            table.minWidthObserver = null;
+        }
+        if (table.minWidthRaf) {
+            cancelAnimationFrame(table.minWidthRaf);
         }
         if (table.thead) {
             EventHandler.off(table.body, 'scroll')
@@ -1062,6 +1088,9 @@ export async function updateTableState(id, options) {
         if (options.resetColumns) {
             resetColumns(table, options);
         }
+        else if (options.measureColumnMinWidth) {
+            setColSize(table, options);
+        }
 
         if (options.resetColumnListPopover) {
             resetColumnListPopover(table);
@@ -1121,18 +1150,57 @@ const resetColumns = (table, options) => {
 }
 
 const setColSize = (table, options) => {
-    var zeroWidthColumns = options.columnStates.filter(i => i.width === null && i.visible === true);
-    zeroWidthColumns.forEach(col => {
-        const headerCollection = [...table.tables[0].querySelectorAll('thead > tr > th')];
-        const th = headerCollection.find(i => i.getAttribute('data-bb-field') === col.name);
-        if (th.offsetWidth === 0) {
-            const width = getCellWidth(th);
-            const colIndex = headerCollection.indexOf(th);
-            col.width = Math.max(width, getColumnMaxCellWidth(table, colIndex));
-            table.tables.forEach(table => {
-                table.querySelectorAll('colgroup col')[colIndex].style.width = `${col.width}px`;
-            });
+    if (!table.tables || table.tables.length === 0) {
+        return;
+    }
+    const headerCollection = [...table.tables[0].querySelectorAll('thead > tr > th')];
+    const columnMinWidth = table.options.columnMinWidth || 0;
+    const autoColumns = [];
+    options.columnStates.forEach(col => {
+        if (col.width != null || col.visible === false) {
+            return;
         }
+        const th = headerCollection.find(i => i.getAttribute('data-bb-field') === col.name);
+        if (th === void 0) {
+            return;
+        }
+        const colIndex = headerCollection.indexOf(th);
+        const minWidth = Math.max(getCellWidth(th) + getHeaderIconsWidth(th), getColumnMaxCellWidth(table, colIndex), columnMinWidth) | 0;
+        autoColumns.push({ colIndex, minWidth });
+    });
+    table.autoColumns = autoColumns;
+    applyColumnMinWidth(table);
+}
+
+const getHeaderIconsWidth = th => {
+    let width = 0;
+    th.querySelectorAll('.sort-icon, .filter-icon, .toolbox-icon, .col-copy').forEach(icon => {
+        width += getWidth(icon);
+    });
+    return width;
+}
+
+const applyColumnMinWidth = table => {
+    if (!table.thead || !table.body || !table.autoColumns || table.autoColumns.length === 0) {
+        return;
+    }
+    setAutoColWidths(table, true);
+    const compact = table.body.scrollWidth > table.body.clientWidth + 1;
+    if (!compact) {
+        setAutoColWidths(table, false);
+    }
+}
+
+const setAutoColWidths = (table, apply) => {
+    const colgroups = table.tables.map(t => t.querySelectorAll('colgroup col'));
+    table.autoColumns.forEach(({ colIndex, minWidth }) => {
+        const width = apply ? `${minWidth}px` : '';
+        colgroups.forEach(cols => {
+            const colEl = cols[colIndex];
+            if (colEl) {
+                colEl.style.width = width;
+            }
+        });
     });
 }
 

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -30,6 +30,11 @@ export async function reset(id) {
         table.minWidthObserver.disconnect();
         table.minWidthObserver = null;
     }
+    if (table.minWidthRaf) {
+        cancelAnimationFrame(table.minWidthRaf);
+        table.minWidthRaf = null;
+    }
+    table.autoColumns = [];
 
     table.columns = [];
     table.tables = [];


### PR DESCRIPTION
## Link issues
fixes #8125 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add automatic column minimum width measurement for fixed-header tables and integrate it into the table lifecycle and JS interop options.

New Features:
- Measure column content minimum width on render for fixed-header tables and apply it to auto-sized columns to improve layout in narrow, horizontally scrollable containers.

Enhancements:
- Integrate a ResizeObserver-driven mechanism to recompute and apply column minimum widths when the table body resizes, with proper cleanup on table reset and destroy.
- Extend table JS interop options and state to carry column state and a measureColumnMinWidth flag used to trigger width recalculation.