### PR TITLE
feat(transfer): should filter disabled item when click select all

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Transfers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Transfers.razor
@@ -113,6 +113,18 @@
               ShowSearch="true" />
 </DemoBlock>
 
+<DemoBlock Title="@Localizer["TransferDisabledCallbackTitle"]"
+           Introduction="@Localizer["TransferDisabledCallbackIntro"]"
+           Name="DisabledCallback">
+    <Transfer TValue="string"
+              Items="@Items7"
+              OnDisabledCallback="OnDisabledCallback"
+              LeftPanelText="@Localizer["LeftPanelText"]"
+              RightPanelText="@Localizer["RightPanelText"]"
+              LeftButtonText="@Localizer["LeftButtonText"]"
+              RightButtonText="@Localizer["RightButtonText"]" />
+</DemoBlock>
+
 <DemoBlock Title="@Localizer["TransferItemClassTitle"]"
            Introduction="@Localizer["TransferItemClassIntro"]"
            Name="ItemClass">

--- a/src/BootstrapBlazor.Server/Components/Samples/Transfers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Transfers.razor.cs
@@ -109,6 +109,7 @@ public sealed partial class Transfers : ComponentBase
 
     // 回调参数 item 为 null 时代表头部全选项，返回 false 保证可点击全选
     // 其余指定 Value 的选项返回 true 表示禁用，禁用项不可勾选且不参与全选操作
+    // 例如：左侧禁用 Value 为 2、4、6 的项，右侧禁用 Value 为 5 的项
     private static bool OnDisabledCallback(string source, SelectedItem? item) => source == "left"
         ? item?.Value is "2" or "4" or "6"
         : item?.Value is "5";

--- a/src/BootstrapBlazor.Server/Components/Samples/Transfers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Transfers.razor.cs
@@ -106,4 +106,10 @@ public sealed partial class Transfers : ComponentBase
         "8" => "bg-warning text-white",
         _ => null
     };
+
+    // 回调参数 item 为 null 时代表头部全选项，返回 false 保证可点击全选
+    // 其余指定 Value 的选项返回 true 表示禁用，禁用项不可勾选且不参与全选操作
+    private static bool OnDisabledCallback(string source, SelectedItem? item) => source == "left"
+        ? item?.Value is "2" or "4" or "6"
+        : item?.Value is "5";
 }

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -5704,6 +5704,8 @@
     "TransferCustomerTitle": "Customizable",
     "TransferDisableIntro": "When you set the <code>IsDisabled</code> property value to <code>true</code>, the component suppresses input",
     "TransferDisableTitle": "Disable",
+    "TransferDisabledCallbackIntro": "By setting the <code>OnDisabledCallback</code> callback method, you can control whether specific items are disabled based on the <code>SelectedItem</code> value. The <code>null</code> argument represents the header select-all option. Disabled items cannot be checked and are excluded from the select-all/deselect-all operations",
+    "TransferDisabledCallbackTitle": "Disable specific items",
     "TransferItemClassIntro": "By setting the <code>OnSetItemClass</code> callback method styles options based on the<code> values of </code>SelectedItem",
     "TransferItemClassTitle": "Set the Item style",
     "TransferMinMaxIntro": "By setting <code>Min</code> <code>Max</code> Parameter to limit the number of options",

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -5704,7 +5704,7 @@
     "TransferCustomerTitle": "Customizable",
     "TransferDisableIntro": "When you set the <code>IsDisabled</code> property value to <code>true</code>, the component suppresses input",
     "TransferDisableTitle": "Disable",
-    "TransferDisabledCallbackIntro": "By setting the <code>OnDisabledCallback</code> callback method, you can control whether specific items are disabled based on the <code>SelectedItem</code> value. The <code>null</code> argument represents the header select-all option. Disabled items cannot be checked and are excluded from the select-all/deselect-all operations",
+    "TransferDisabledCallbackIntro": "By setting the <code>OnDisabledCallback</code> callback method, you can control whether specific items are disabled. The first argument <code>target</code> identifies the current panel — <code>left</code> for the left panel and <code>right</code> for the right panel — so you can apply different disable rules to each side. The second argument is the <code>SelectedItem</code>, which is <code>null</code> for the header select-all option. In this example the left panel disables <code>2</code> <code>4</code> <code>6</code> and the right panel disables <code>5</code>. Disabled items cannot be checked and are excluded from the select-all/deselect-all operations",
     "TransferDisabledCallbackTitle": "Disable specific items",
     "TransferItemClassIntro": "By setting the <code>OnSetItemClass</code> callback method styles options based on the<code> values of </code>SelectedItem",
     "TransferItemClassTitle": "Set the Item style",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -5704,7 +5704,7 @@
     "TransferCustomerTitle": "可自定义",
     "TransferDisableIntro": "设置 <code>IsDisabled</code> 属性值为 <code>true</code> 时，组件禁止输入",
     "TransferDisableTitle": "禁用",
-    "TransferDisabledCallbackIntro": "通过设置 <code>OnDisabledCallback</code> 回调方法根据 <code>SelectedItem</code> 值控制指定选项是否禁用，回调参数为 <code>null</code> 时代表头部全选项。被禁用的选项不可勾选，且不参与全选/取消全选操作",
+    "TransferDisabledCallbackIntro": "通过设置 <code>OnDisabledCallback</code> 回调方法控制指定选项是否禁用。回调首个参数 <code>target</code> 用于标识当前面板，左侧面板为 <code>left</code>、右侧面板为 <code>right</code>，可据此对左右两侧分别设置禁用规则；第二个参数为 <code>SelectedItem</code>，为 <code>null</code> 时代表头部全选项。本例左侧面板禁用 <code>2</code> <code>4</code> <code>6</code>，右侧面板禁用 <code>5</code>。被禁用的选项不可勾选，且不参与全选/取消全选操作",
     "TransferDisabledCallbackTitle": "禁用指定选项",
     "TransferItemClassIntro": "通过设置 <code>OnSetItemClass</code> 回调方法根据 <code>SelectedItem</code> 值设置选项样式",
     "TransferItemClassTitle": "设置 Item 样式",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -5704,6 +5704,8 @@
     "TransferCustomerTitle": "可自定义",
     "TransferDisableIntro": "设置 <code>IsDisabled</code> 属性值为 <code>true</code> 时，组件禁止输入",
     "TransferDisableTitle": "禁用",
+    "TransferDisabledCallbackIntro": "通过设置 <code>OnDisabledCallback</code> 回调方法根据 <code>SelectedItem</code> 值控制指定选项是否禁用，回调参数为 <code>null</code> 时代表头部全选项。被禁用的选项不可勾选，且不参与全选/取消全选操作",
+    "TransferDisabledCallbackTitle": "禁用指定选项",
     "TransferItemClassIntro": "通过设置 <code>OnSetItemClass</code> 回调方法根据 <code>SelectedItem</code> 值设置选项样式",
     "TransferItemClassTitle": "设置 Item 样式",
     "TransferMinMaxIntro": "通过设置 <code>Min</code> <code>Max</code> 参数来限制选项个数",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.3-beta02</Version>
+    <Version>10.7.3-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Transfer/Transfer.razor
+++ b/src/BootstrapBlazor/Components/Transfer/Transfer.razor
@@ -10,7 +10,7 @@
     <TransferPanel Items="@LeftItems" Text="@LeftPanelText" IsDisabled="@IsDisabled"
                    ShowSearch="@ShowSearch" SearchPlaceHolderString="@LeftPanelSearchPlaceHolderString"
                    OnSelectedItemsChanged="@SelectedItemsChanged" OnSetItemClass="OnSetItemClass"
-                   OnDisabledCallback="OnDisabledCallback"
+                   OnDisabledCallback="OnLeftDisabledCallback"
                    HeaderTemplate="LeftHeaderTemplate" ItemTemplate="LeftItemTemplate">
     </TransferPanel>
     <div class="transfer-buttons">
@@ -28,7 +28,7 @@
     <TransferPanel Items="@RightItems" Text="@RightPanelText" IsDisabled="@IsDisabled" class="@ValidateClass" Id="@Id"
                    ShowSearch="@ShowSearch" SearchPlaceHolderString="@RightPanelSearchPlaceHolderString"
                    OnSelectedItemsChanged="@SelectedItemsChanged" OnSetItemClass="OnSetItemClass"
-                   OnDisabledCallback="OnDisabledCallback"
+                   OnDisabledCallback="OnRightDisabledCallback"
                    HeaderTemplate="RightHeaderTemplate" ItemTemplate="RightItemTemplate">
     </TransferPanel>
 </div>

--- a/src/BootstrapBlazor/Components/Transfer/Transfer.razor.cs
+++ b/src/BootstrapBlazor/Components/Transfer/Transfer.razor.cs
@@ -191,7 +191,7 @@ public partial class Transfer<TValue>
     /// <para>v<version>10.7.3</version></para>
     /// </summary>
     [Parameter]
-    public Func<SelectedItem?, bool>? OnDisabledCallback { get; set; }
+    public Func<string, SelectedItem?, bool>? OnDisabledCallback { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 左侧 Panel Header 模板</para>
@@ -425,4 +425,10 @@ public partial class Transfer<TValue>
     }
 
     private static bool GetButtonState(IEnumerable<SelectedItem> source) => !(source.Any(i => i.Active));
+
+    private bool OnLeftDisabledCallback(SelectedItem? item) => TriggerDisabledCallback("left", item);
+
+    private bool OnRightDisabledCallback(SelectedItem? item) => TriggerDisabledCallback("right", item);
+
+    private bool TriggerDisabledCallback(string target, SelectedItem? item) => OnDisabledCallback?.Invoke(target, item) ?? false;
 }

--- a/src/BootstrapBlazor/Components/Transfer/Transfer.razor.cs
+++ b/src/BootstrapBlazor/Components/Transfer/Transfer.razor.cs
@@ -186,8 +186,8 @@ public partial class Transfer<TValue>
     public Func<SelectedItem, string?>? OnSetItemClass { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 组件是否被禁用回调方法，默认为 null</para>
-    /// <para lang="en">Gets or sets the callback method for whether the component is disabled. Default is null</para>
+    /// <para lang="zh">获得/设置 候选项是否被禁用回调方法，默认为 null</para>
+    /// <para lang="en">Gets or sets the callback method for whether the transfer item is disabled. Default is null</para>
     /// <para>v<version>10.7.3</version></para>
     /// </summary>
     [Parameter]

--- a/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor.cs
+++ b/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor.cs
@@ -179,11 +179,19 @@ public partial class TransferPanel
         {
             if (state == CheckboxState.Checked)
             {
-                GetShownItems().ForEach(i => i.Active = true);
+                GetShownItems().ForEach(i =>
+                {
+                    if (!i.IsDisabled)
+                        i.Active = true;
+                });
             }
             else
             {
-                GetShownItems().ForEach(i => i.Active = false);
+                GetShownItems().ForEach(i =>
+                {
+                    if (!i.IsDisabled)
+                        i.Active = false;
+                });
             }
 
             if (OnSelectedItemsChanged != null)

--- a/test/UnitTest/Components/TransferTest.cs
+++ b/test/UnitTest/Components/TransferTest.cs
@@ -274,6 +274,38 @@ public class TransferTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void OnDisabledCallback_Ok()
+    {
+        // 左侧面板仅禁用 Value 为 "1" 的项，右侧面板仅禁用 Value 为 "2" 的项
+        // 通过 target 参数区分左右面板，验证回调首参正确传入 "left"/"right"
+        var cut = Context.Render<Transfer<string>>(pb =>
+        {
+            pb.Add(a => a.Value, "2");
+            pb.Add(a => a.Items,
+            [
+                new("1", "Test1"),
+                new("2", "Test2")
+            ]);
+            pb.Add(a => a.OnDisabledCallback, (target, item) => target == "left"
+                ? item?.Value == "1"
+                : item?.Value == "2");
+        });
+
+        var panels = cut.FindComponents<TransferPanel>();
+
+        // 左侧面板：Header(null) 未禁用，候选项 Test1 被禁用
+        var leftCheckboxes = panels[0].FindComponents<Checkbox<SelectedItem>>();
+        Assert.False(leftCheckboxes[0].Instance.IsDisabled);
+        Assert.True(leftCheckboxes[1].Instance.IsDisabled);
+
+        // 右侧面板：Header(null) 未禁用，候选项 Test2 被禁用
+        // 若 target 未正确传入 "right"，则会走 "left" 分支按 Value == "1" 判断，Test2 将不会被禁用
+        var rightCheckboxes = panels[1].FindComponents<Checkbox<SelectedItem>>();
+        Assert.False(rightCheckboxes[0].Instance.IsDisabled);
+        Assert.True(rightCheckboxes[1].Instance.IsDisabled);
+    }
+
+    [Fact]
     public void IsWrapItem_Ok()
     {
         var cut = Context.Render<Transfer<string>>(pb =>


### PR DESCRIPTION
refactor:OnHeaderCheck方法中过滤IsDisabled=true的子元素

## Link issues
fixes #8146

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## 问题描述 / Problem Description
使用`LeftItemTemplate`和`RightItemTemplate`时单独控制某个元素`IsDisabled=true`时，在单击组件头部中的CheckBox时，Items中`IsDisabled=true`的元素状态还是会跟着改变为：选中或未选中

## 根本原因 / Root Cause
当子元素`IsDisabled=true`时，也就是禁用了，这时单击组件头部中的CheckBox时，被禁用的子元素状态不应改变

## 解决方案 / Solution
修改组件中`OnHeaderCheck`方法，过滤掉`IsDisabled=true`的子元素

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Prevent header checkbox selection from changing the Active state of items marked as disabled in transfer panels.