### PR TITLE
fix(AutoComplete): skip filter when set SkipMatch to true

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.3-beta01</Version>
+    <Version>10.7.3-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.2</Version>
+    <Version>10.7.3-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.7.3-beta02</Version>
+    <Version>10.7.3-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -237,6 +237,14 @@ public partial class AutoComplete
     [JSInvokable]
     public async Task TriggerFilter(string val)
     {
+        if (SkipMatch)
+        {
+            // 跳过匹配 候选项始终展示全部 Items 保持 _filterItems 为 null 以实时跟踪 Items 变化
+            _filterItems = null;
+            _dropdown.Render();
+            return;
+        }
+
         if (OnCustomFilter != null)
         {
             var items = await OnCustomFilter(val);

--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.cs
@@ -239,9 +239,6 @@ public partial class AutoComplete
     {
         if (SkipMatch)
         {
-            // 跳过匹配 候选项始终展示全部 Items 保持 _filterItems 为 null 以实时跟踪 Items 变化
-            _filterItems = null;
-            _dropdown.Render();
             return;
         }
 

--- a/test/UnitTest/Components/AutoCompleteTest.cs
+++ b/test/UnitTest/Components/AutoCompleteTest.cs
@@ -24,6 +24,23 @@ public class AutoCompleteTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task SkipMatch_AfterSelect_Ok()
+    {
+        var cut = Context.Render<AutoComplete>(pb =>
+        {
+            pb.Add(a => a.SkipMatch, true);
+            pb.Add(a => a.Items, new List<string>() { "test1", "test12", "test123", "test1234" });
+        });
+
+        // 选中候选项 test123 后 TriggerFilter 不应过滤候选项
+        // 否则再次输入时 SkipMatch 失效 候选项被锁定为上次选中值的过滤子集
+        await cut.InvokeAsync(() => cut.FindAll(".dropdown-item")[2].Click());
+
+        var items = cut.FindAll(".dropdown-item");
+        Assert.Equal(4, items.Count);
+    }
+
+    [Fact]
     public void Items_Ok()
     {
         var cut = Context.Render<AutoComplete>(pb =>


### PR DESCRIPTION
## Link issues
fixes #8148 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure AutoComplete respects the SkipMatch flag during filtering and add coverage for post-selection behavior.

Bug Fixes:
- Prevent AutoComplete from applying TriggerFilter when SkipMatch is set to true, including after an item is selected.

Tests:
- Add a unit test verifying that AutoComplete does not filter items after selection when SkipMatch is enabled.