### PR TITLE
feat(Transfer): add OnDisabledCallback parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Transfer/Transfer.razor
+++ b/src/BootstrapBlazor/Components/Transfer/Transfer.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @typeparam TValue
 @inherits ValidateBase<TValue>
 
@@ -10,7 +10,8 @@
     <TransferPanel Items="@LeftItems" Text="@LeftPanelText" IsDisabled="@IsDisabled"
                    ShowSearch="@ShowSearch" SearchPlaceHolderString="@LeftPanelSearchPlaceHolderString"
                    OnSelectedItemsChanged="@SelectedItemsChanged" OnSetItemClass="OnSetItemClass"
-                   HeaderTemplate="LeftHeaderTemplate!" ItemTemplate="LeftItemTemplate!">
+                   OnDisabledCallback="OnDisabledCallback"
+                   HeaderTemplate="LeftHeaderTemplate" ItemTemplate="LeftItemTemplate">
     </TransferPanel>
     <div class="transfer-buttons">
         <Button Color="@Color.Primary" IsDisabled="@GetButtonState(RightItems)"
@@ -27,6 +28,7 @@
     <TransferPanel Items="@RightItems" Text="@RightPanelText" IsDisabled="@IsDisabled" class="@ValidateClass" Id="@Id"
                    ShowSearch="@ShowSearch" SearchPlaceHolderString="@RightPanelSearchPlaceHolderString"
                    OnSelectedItemsChanged="@SelectedItemsChanged" OnSetItemClass="OnSetItemClass"
-                   HeaderTemplate="RightHeaderTemplate!" ItemTemplate="RightItemTemplate!">
+                   OnDisabledCallback="OnDisabledCallback"
+                   HeaderTemplate="RightHeaderTemplate" ItemTemplate="RightItemTemplate">
     </TransferPanel>
 </div>

--- a/src/BootstrapBlazor/Components/Transfer/Transfer.razor.cs
+++ b/src/BootstrapBlazor/Components/Transfer/Transfer.razor.cs
@@ -186,6 +186,14 @@ public partial class Transfer<TValue>
     public Func<SelectedItem, string?>? OnSetItemClass { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 组件是否被禁用回调方法，默认为 null</para>
+    /// <para lang="en">Gets or sets the callback method for whether the component is disabled. Default is null</para>
+    /// <para>v<version>10.7.3</version></para>
+    /// </summary>
+    [Parameter]
+    public Func<SelectedItem?, bool>? OnDisabledCallback { get; set; }
+
+    /// <summary>
     /// <para lang="zh">获得/设置 左侧 Panel Header 模板</para>
     /// <para lang="en">Gets or sets the left Panel Header template</para>
     /// </summary>

--- a/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor
+++ b/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor
@@ -1,11 +1,12 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @inherits BootstrapComponentBase
 
 <div @attributes="@AdditionalAttributes" class="@PanelClassString">
     <div class="transfer-panel-header">
         @if(HeaderTemplate == null)
         {
-            <Checkbox TValue="SelectedItem" DisplayText="@Text" IsDisabled="@IsDisabled" ShowAfterLabel="true" ShowLabel="false"
+            <Checkbox TValue="SelectedItem" DisplayText="@Text" IsDisabled="@GetDisableState(null)"
+                      ShowAfterLabel="true" ShowLabel="false"
                       State="@HeaderCheckState()" OnStateChanged="@OnHeaderCheck" />
         }
         else
@@ -30,7 +31,7 @@
                 if(ItemTemplate == null)
                 {
                     var state = item.Active ? CheckboxState.Checked : CheckboxState.UnChecked;
-                    <Checkbox TValue="SelectedItem" IsDisabled="@IsDisabled" class="@GetItemClass(item)"
+                    <Checkbox TValue="SelectedItem" IsDisabled="@GetDisableState(item)" class="@GetItemClass(item)"
                               DisplayText="@item.Text" Value="item" ShowAfterLabel="true" ShowLabel="false"
                               State="@state" OnStateChanged="@OnStateChanged"></Checkbox>
                 }

--- a/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor.cs
+++ b/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor.cs
@@ -115,6 +115,14 @@ public partial class TransferPanel
     public bool IsDisabled { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 组件是否被禁用回调方法，默认为 null</para>
+    /// <para lang="en">Gets or sets the callback method for whether the component is disabled. Default is null</para>
+    /// <para>v<version>10.7.3</version></para>
+    /// </summary>
+    [Parameter]
+    public Func<SelectedItem?, bool>? OnDisabledCallback { get; set; }
+
+    /// <summary>
     /// <para lang="zh">获得/设置 Header 模板</para>
     /// <para lang="en">Gets or sets the header template</para>
     /// </summary>
@@ -248,4 +256,8 @@ public partial class TransferPanel
     private List<SelectedItem> GetShownItems() => (string.IsNullOrEmpty(SearchText)
         ? Items
         : Items.Where(i => i.Text.Contains(SearchText, StringComparison.OrdinalIgnoreCase)).ToList());
+
+    private bool GetDisableState(SelectedItem? item) => OnDisabledCallback != null
+        ? OnDisabledCallback(item)
+        : IsDisabled;
 }

--- a/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor.cs
+++ b/src/BootstrapBlazor/Components/Transfer/TransferPanel.razor.cs
@@ -165,11 +165,14 @@ public partial class TransferPanel
     protected CheckboxState HeaderCheckState()
     {
         var ret = CheckboxState.Indeterminate;
-        if (Items.Count > 0 && Items.All(i => i.Active))
+
+        // 全选状态仅根据未被 OnDisabledCallback 禁用的项进行计算
+        var items = Items.Where(i => !IsItemDisabled(i)).ToList();
+        if (items.Count > 0 && items.All(i => i.Active))
         {
             ret = CheckboxState.Checked;
         }
-        else if (!Items.Any(i => i.Active))
+        else if (!items.Any(i => i.Active))
         {
             ret = CheckboxState.UnChecked;
         }
@@ -185,14 +188,9 @@ public partial class TransferPanel
     {
         if (Items != null)
         {
-            if (state == CheckboxState.Checked)
-            {
-                GetShownItems().ForEach(i => i.Active = true);
-            }
-            else
-            {
-                GetShownItems().ForEach(i => i.Active = false);
-            }
+            // 全选时过滤掉被 OnDisabledCallback 禁用的项，保持其原有选中状态
+            var active = state == CheckboxState.Checked;
+            GetShownItems().Where(i => !IsItemDisabled(i)).ToList().ForEach(i => i.Active = active);
 
             if (OnSelectedItemsChanged != null)
             {
@@ -260,4 +258,9 @@ public partial class TransferPanel
     private bool GetDisableState(SelectedItem? item) => OnDisabledCallback != null
         ? OnDisabledCallback(item)
         : IsDisabled;
+
+    /// <summary>
+    /// 判断指定数据项是否被 <see cref="OnDisabledCallback"/> 禁用，全选时禁用项将被过滤
+    /// </summary>
+    private bool IsItemDisabled(SelectedItem item) => OnDisabledCallback?.Invoke(item) == true;
 }

--- a/test/UnitTest/Components/TransferPanelTest.cs
+++ b/test/UnitTest/Components/TransferPanelTest.cs
@@ -115,6 +115,57 @@ public class TransferPanelTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task OnHeaderCheck_FilterDisabledItem_Ok()
+    {
+        List<SelectedItem> items =
+        [
+            new("1", "Test1"),
+            new("2", "Test2")
+        ];
+        var cut = Context.Render<TransferPanel>(pb =>
+        {
+            pb.Add(a => a.Items, items);
+            // 仅禁用 Value 为 "1" 的项，Header(null) 不禁用以便点击全选
+            pb.Add(a => a.OnDisabledCallback, item => item?.Value == "1");
+        });
+
+        // 点击 Header 触发全选
+        var checkbox = cut.FindComponent<Checkbox<SelectedItem>>();
+        await cut.InvokeAsync(() => checkbox.Instance.SetState(CheckboxState.Checked));
+
+        // 全选时禁用项被过滤，保持未选中状态
+        Assert.False(items[0].Active);
+
+        // 未禁用项被选中
+        Assert.True(items[1].Active);
+
+        // 取消全选时禁用项同样被过滤，保持原有状态
+        await cut.InvokeAsync(() => checkbox.Instance.SetState(CheckboxState.UnChecked));
+        Assert.False(items[0].Active);
+        Assert.False(items[1].Active);
+    }
+
+    [Fact]
+    public void HeaderCheckState_FilterDisabledItem_Ok()
+    {
+        // 禁用项 "1" 未选中，未禁用项 "2" 已选中
+        List<SelectedItem> items =
+        [
+            new("1", "Test1") { Active = false },
+            new("2", "Test2") { Active = true }
+        ];
+        var cut = Context.Render<TransferPanel>(pb =>
+        {
+            pb.Add(a => a.Items, items);
+            pb.Add(a => a.OnDisabledCallback, item => item?.Value == "1");
+        });
+
+        // 禁用项不参与全选状态计算，未禁用项全部选中时 Header 为 Checked
+        var checkbox = cut.FindComponent<Checkbox<SelectedItem>>();
+        Assert.Equal(CheckboxState.Checked, checkbox.Instance.State);
+    }
+
+    [Fact]
     public void HeaderTemplate_Ok()
     {
         var cut = Context.Render<TransferPanel>(pb =>

--- a/test/UnitTest/Components/TransferPanelTest.cs
+++ b/test/UnitTest/Components/TransferPanelTest.cs
@@ -81,6 +81,40 @@ public class TransferPanelTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void OnDisabledCallback_Ok()
+    {
+        // 回调根据 item 决定禁用状态：Header(null) 与 Value 为 "1" 的项被禁用
+        var cut = Context.Render<TransferPanel>(pb =>
+        {
+            pb.Add(a => a.Items,
+            [
+                new("1", "Test1"),
+                new("2", "Test2")
+            ]);
+            pb.Add(a => a.OnDisabledCallback, item => item == null || item.Value == "1");
+        });
+
+        // 索引 0 为 Header，回调返回 true 被禁用
+        var checkboxes = cut.FindComponents<Checkbox<SelectedItem>>();
+        Assert.True(checkboxes[0].Instance.IsDisabled);
+
+        // 索引 1 为 Test1，回调返回 true 被禁用
+        Assert.True(checkboxes[1].Instance.IsDisabled);
+
+        // 索引 2 为 Test2，回调返回 false 未禁用
+        Assert.False(checkboxes[2].Instance.IsDisabled);
+
+        // 设置了回调时优先使用回调结果：IsDisabled=true 但回调返回 false 时仍未禁用
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.IsDisabled, true);
+            pb.Add(a => a.OnDisabledCallback, item => false);
+        });
+        checkboxes = cut.FindComponents<Checkbox<SelectedItem>>();
+        Assert.All(checkboxes, c => Assert.False(c.Instance.IsDisabled));
+    }
+
+    [Fact]
     public void HeaderTemplate_Ok()
     {
         var cut = Context.Render<TransferPanel>(pb =>


### PR DESCRIPTION
## Link issues
fixes #8145 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a per-item disabled-state callback to Transfer and TransferPanel and use it to control checkbox disabled states.

New Features:
- Introduce an OnDisabledCallback parameter on Transfer and TransferPanel to determine disabled state per item, including the header.

Enhancements:
- Wire the new OnDisabledCallback through Transfer to TransferPanel and adjust templates to respect callback results over the global IsDisabled flag.

Tests:
- Add unit coverage validating TransferPanel OnDisabledCallback behavior and precedence over the IsDisabled property.