### PR TITLE
fixed(MultiSelect)清理分组状态下Divider重叠

### DIFF
--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TValue
 @inherits SimpleSelectBase<TValue>
@@ -113,18 +113,6 @@
                     @foreach (var item in itemGroup)
                     {
                         @RenderRow(item)
-                    }
-
-                    if (!string.IsNullOrEmpty(itemGroup.Key))
-                    {
-                        if (GroupItemTemplate != null)
-                        {
-                            @GroupItemTemplate(itemGroup.Key)
-                        }
-                        else
-                        {
-                            <Divider Text="@itemGroup.Key" />
-                        }
                     }
                 }
             </div>


### PR DESCRIPTION
refactor:清理分组状态下生成多余的Divider组件信息

## Link issues
fixes #8167

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Resolve overlapping dividers in MultiSelect when using grouped options by removing redundant group divider rendering.

Bug Fixes:
- Prevent duplicate dividers from being rendered under grouped MultiSelect items, eliminating visual overlap.

Enhancements:
- Simplify MultiSelect grouped rendering logic by removing unnecessary group footer divider output.