### PR TITLE
feat(Drawer): add IsLazyLoadChildContent parameter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.0</Version>
+    <Version>10.8.1-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Drawer/Drawer.razor
+++ b/src/BootstrapBlazor/Components/Drawer/Drawer.razor
@@ -10,11 +10,14 @@
     }
     <div class="@DrawerClassString" style="@DrawerStyleString" @onclick:stopPropagation>
         <div class="drawer-content">
-            <CascadingValue Name="BodyContext" Value="BodyContext" IsFixed="true">
-                <CascadingValue Value="Close" IsFixed=" true">
-                    @ChildContent
+            @if (!IsLazyLoadChildContent || _firstOpened)
+            {
+                <CascadingValue Name="BodyContext" Value="BodyContext" IsFixed="true">
+                    <CascadingValue Value="Close" IsFixed=" true">
+                        @ChildContent
+                    </CascadingValue>
                 </CascadingValue>
-            </CascadingValue>
+            }
         </div>
         @if (AllowResize)
         {

--- a/src/BootstrapBlazor/Components/Drawer/Drawer.razor.cs
+++ b/src/BootstrapBlazor/Components/Drawer/Drawer.razor.cs
@@ -148,16 +148,41 @@ public partial class Drawer
     [Parameter]
     public bool BodyScroll { get; set; }
 
+    /// <summary>
+    /// <para lang="zh">获得/设置 是否延迟渲染子组件 默认 false 立即渲染 设置为 true 时首次打开抽屉后才渲染子组件 防止子组件脚本在不可见状态下测量尺寸失效 关闭后子组件保持渲染状态不销毁</para>
+    /// <para lang="en">Gets or sets Whether to lazy render child content. Default is false. When true, child content is rendered after the drawer is opened for the first time, preventing child component scripts from measuring size incorrectly while hidden. Content stays rendered after closing</para>
+    /// <para>v<version>10.8.1</version></para>
+    /// </summary>
+    [Parameter]
+    public bool IsLazyLoadChildContent { get; set; }
+
     private string? KeyboardString => IsKeyboard ? "true" : null;
 
     private string? BodyScrollString => BodyScroll ? "true" : null;
 
     private bool _render = true;
 
+    private bool _firstOpened;
+
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
     protected override bool ShouldRender() => _render;
+
+    /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        // 启用延迟渲染时 首次打开后才渲染 ChildContent 防止不可见状态下子组件脚本测量尺寸失效
+        // When lazy load is enabled, render ChildContent after first opened to prevent child component scripts from measuring size incorrectly while hidden
+        if (IsOpen)
+        {
+            _firstOpened = true;
+        }
+    }
 
     /// <summary>
     /// <inheritdoc/>

--- a/test/UnitTest/Components/DrawerTest.cs
+++ b/test/UnitTest/Components/DrawerTest.cs
@@ -103,8 +103,40 @@ public class DrawerTest : BootstrapBlazorTestBase
             });
         });
 
+        // 默认 IsLazyLoadChildContent 为 false 未打开时也渲染 ChildContent
         var button = cut.FindComponent<Button>();
         Assert.NotNull(button);
+    }
+
+    [Fact]
+    public void IsLazyLoadChildContent_Ok()
+    {
+        var cut = Context.Render<Drawer>(builder =>
+        {
+            builder.Add(a => a.IsLazyLoadChildContent, true);
+            builder.Add(a => a.ChildContent, s =>
+            {
+                s.OpenComponent<Button>(0);
+                s.CloseComponent();
+            });
+        });
+
+        // 未打开时不渲染 ChildContent
+        Assert.Empty(cut.FindComponents<Button>());
+
+        // 首次打开后渲染 ChildContent
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.IsOpen, true);
+        });
+        Assert.Single(cut.FindComponents<Button>());
+
+        // 关闭后 ChildContent 保持渲染 内部组件状态不丢失
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.IsOpen, false);
+        });
+        Assert.Single(cut.FindComponents<Button>());
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8205 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add an option for the Drawer component to lazy-render its child content only after first open while preserving child state across subsequent open/close cycles.

New Features:
- Introduce IsLazyLoadChildContent parameter on Drawer to control whether child content is rendered immediately or only after the drawer is first opened.

Tests:
- Add unit coverage for default child-content rendering and the new lazy-loading behavior of Drawer child content.