### PR TITLE
feat(Table): remove bb-table prefix in localstorage

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.1-beta01</Version>
+    <Version>10.8.1-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.js
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.js
@@ -971,21 +971,28 @@ const removeColumnWidthState = tableName => {
 }
 
 export function clearColumnStates(tableName) {
-    const columnStateKey = `bb-table-${tableName}`;
-    localStorage.removeItem(columnStateKey);
+    localStorage.removeItem(tableName);
+    localStorage.removeItem(`bb-table-${tableName}`);
 }
 
 const getColumnStateFromLocalstorage = tableName => {
-    const columnStateKey = `bb-table-${tableName}`;
-    return getLocalStorageValue(columnStateKey);
+    let state = getLocalStorageValue(tableName);
+    if (state === null) {
+        const legacyKey = `bb-table-${tableName}`;
+        state = getLocalStorageValue(legacyKey);
+        if (state !== null) {
+            localStorage.setItem(tableName, JSON.stringify(state));
+            localStorage.removeItem(legacyKey);
+        }
+    }
+    return state;
 }
 
 const saveColumnStateToLocalstorage = (table, state) => {
     const { options: { tableName } } = table;
     if (tableName) {
-        const columnStateKey = `bb-table-${tableName}`;
         const columnState = state ?? getColumnStateObject(table);
-        localStorage.setItem(columnStateKey, JSON.stringify(columnState));
+        localStorage.setItem(tableName, JSON.stringify(columnState));
     }
 }
 


### PR DESCRIPTION
## Link issues
fixes #8210 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Switch table column state persistence to use the raw table name as the localStorage key while migrating existing data from the legacy bb-table-prefixed key.

Enhancements:
- Add backward-compatible migration logic to read existing column state from the legacy bb-table-prefixed key and re-save it under the new key.
- Update column state clearing to remove entries stored under both the new table name key and the legacy bb-table-prefixed key.