### PR TITLE
fix(BarChart): stacked bar chart's ShowDataLabel has overlapping text

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="BootstrapBlazor.BarCode" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.BarcodeGenerator" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.BootstrapIcon" Version="10.0.0" />
-    <PackageReference Include="BootstrapBlazor.Chart" Version="10.0.3" />
+    <PackageReference Include="BootstrapBlazor.Chart" Version="10.0.4" />
     <PackageReference Include="BootstrapBlazor.ChatBot" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.CherryMarkdown" Version="10.0.1" />
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="10.0.0" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Charts/Bar.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Charts/Bar.razor
@@ -57,6 +57,12 @@
     <Chart ChartType="ChartType.Bar" OnInitAsync="() => OnInitShowDataLabel(true)" Title="ShowDataLabel Demo" Height="500px" Width="500px" />
 </DemoBlock>
 
+<DemoBlock Title="@Localizer["BarStackedShowDataLabelTitle"]"
+           Introduction="@Localizer["BarStackedShowDataLabelIntro"]"
+           Name="BarStackedShowDataLabel">
+    <Chart ChartType="ChartType.Bar" OnInitAsync="OnInitStackedShowDataLabel" Height="500px" Width="500px" />
+</DemoBlock>
+
 <DemoBlock Title="@Localizer["BarColorSeparatelyTitle"]"
            Introduction="@Localizer["BarColorSeparatelyIntro"]"
            Name="BarColorSeparately">

--- a/src/BootstrapBlazor.Server/Components/Samples/Charts/Bar.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Charts/Bar.razor.cs
@@ -229,6 +229,29 @@ public partial class Bar
         return Task.FromResult(ds);
     }
 
+    private Task<ChartDataSource> OnInitStackedShowDataLabel()
+    {
+        var ds = new ChartDataSource();
+        ds.Options.Title = "Stacked with zero value segment";
+        ds.Options.ShowDataLabel = true;
+        ds.Options.X.Title = "name";
+        ds.Options.Y.Title = "Numerical value";
+        ds.Options.X.Stacked = true;
+        ds.Options.Y.Stacked = true;
+        ds.Labels = ["Alice", "Bob", "Carol"];
+        ds.Data.Add(new ChartDataset()
+        {
+            Label = "Set 0",
+            Data = new object[] { 3, 5, 2 }
+        });
+        ds.Data.Add(new ChartDataset()
+        {
+            Label = "Set 1",
+            Data = new object[] { 2, 0, 4 }
+        });
+        return Task.FromResult(ds);
+    }
+
     private Task<ChartDataSource> OnInitBarColorSeparately(bool barColorSeparately)
     {
         var ds = new ChartDataSource();

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -1260,6 +1260,8 @@
     "BarShowDataLabelIntro": "By setting <code>ShowDataLabel</code> property，control whether to display chart data values",
     "BarShowDataLabelTitle": "Display chart data values",
     "BarStackedIntro": "By setting the X/Y axis <code>Stacked</code> property, control whether to stack the arrangement",
+    "BarStackedShowDataLabelIntro": "When <code>ShowDataLabel</code> is enabled in stacked mode, segments with a value of <code>0</code> do not draw data labels to avoid overlapping with adjacent segment labels. In this example, the top segment of <b>Bob</b> has a value of <code>0</code>, so only the lower segment's data label is displayed",
+    "BarStackedShowDataLabelTitle": "Stacked Data Label",
     "BarStackedTitle": "Stacked",
     "BarTwoYAxesIntro": "Show secondary Y axis: alignment, title and data group",
     "BarTwoYAxesTitle": "Double Y axis",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -1260,6 +1260,8 @@
     "BarShowDataLabelIntro": "通过设置<code>ShowDataLabel</code> 属性，控制是否显示数据值",
     "BarShowDataLabelTitle": "显示图表数据值",
     "BarStackedIntro": "通过设置 X/Y 轴 <code>Stacked</code> 属性，控制是否堆砌排列",
+    "BarStackedShowDataLabelIntro": "堆叠模式开启 <code>ShowDataLabel</code> 时，值为 <code>0</code> 的分段不绘制数据标签，避免与相邻分段标签重叠。本例中 <b>Bob</b> 顶部分段值为 <code>0</code>，仅显示下方分段的数据标签",
+    "BarStackedShowDataLabelTitle": "堆叠图数据标签",
     "BarStackedTitle": "堆砌排列",
     "BarTwoYAxesIntro": "显示第二Y轴:对齐方式,标题和对应数据组",
     "BarTwoYAxesTitle": "双Y轴",


### PR DESCRIPTION
## Link issues
fixes #8196 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add a stacked bar chart demo showcasing data labels to validate and demonstrate the fix for overlapping text in stacked bar charts.

New Features:
- Introduce a stacked bar chart sample with data labels enabled to cover zero-value segments.

Documentation:
- Update localized demo titles and introductions for the new stacked bar chart with data labels example.