### PR TITLE
fix(Table): incorrect column order when switching to multiple languages

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.1-beta02</Version>
+    <Version>10.8.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1460,6 +1460,9 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 }
             }
 
+            // 未匹配到状态的列按其在 Columns 中的相对位置插入而不是追加到末尾
+            // 防止多语言切换等场景列字段名变化导致仅部分列匹配时列顺序错乱
+            var insertIndex = 0;
             foreach (var col in Columns)
             {
                 if (col.GetIgnore())
@@ -1471,11 +1474,13 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 if (stateMap.TryGetValue(name, out var item))
                 {
                     item.DisplayName = col.GetDisplayName();
+                    insertIndex = _tableColumnStates.IndexOf(item) + 1;
                 }
                 else
                 {
                     item = CreateTableColumnState(col);
-                    _tableColumnStates.Add(item);
+                    _tableColumnStates.Insert(insertIndex, item);
+                    insertIndex++;
                 }
             }
 

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -9071,6 +9071,131 @@ public class TableTest : BootstrapBlazorTestBase
         Assert.Contains("style=\"width: 80px;\"", colGroup.ToMarkup());
     }
 
+    [Fact]
+    public void ColumnStates_PartialMatch_KeepColumnOrder_Ok()
+    {
+        // 持久化状态中前两列字段名与当前列不匹配 仅 Count 列匹配
+        // 模拟多语言切换后列字段名变化场景
+        var state = new TableColumnClientStatus();
+        state.Columns.Add(new TableColumnState() { Name = "OldName1", Visible = true });
+        state.Columns.Add(new TableColumnState() { Name = "OldName2", Visible = true });
+        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Count), Visible = true });
+
+        Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test_partial_match").SetResult(state);
+
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.ClientTableName, "test_partial_match");
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.Items, Foo.GenerateFoo(localizer, 2));
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", foo.Name);
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, string>>(3);
+                    builder.AddAttribute(4, "Field", foo.Address);
+                    builder.AddAttribute(5, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, int>>(6);
+                    builder.AddAttribute(7, "Field", foo.Count);
+                    builder.AddAttribute(8, "FieldExpression", Utility.GenerateValueExpression(foo, "Count", typeof(int)));
+                    builder.CloseComponent();
+                });
+            });
+        });
+
+        // 未匹配的列应按声明相对位置插入 Count 列不应跳到最前
+        var table = cut.FindComponent<Table<Foo>>();
+        var order = string.Join(",", table.Instance.GetVisibleColumns().Select(i => i.GetFieldName()));
+        Assert.Equal("Name,Address,Count", order);
+    }
+
+    [Fact]
+    public void ColumnStates_DataTableLocalizedColumnName_Ok()
+    {
+        // 模拟英文会话保存的持久化列状态
+        var state = new TableColumnClientStatus();
+        state.Columns.Add(new TableColumnState() { Name = "Name", Visible = true });
+        state.Columns.Add(new TableColumnState() { Name = "Address", Visible = true });
+        state.Columns.Add(new TableColumnState() { Name = "Id", Visible = true });
+
+        Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test_localized_datatable").SetResult(state);
+
+        // 切换中文后 DataTable 列名变化 仅 Id 列与持久化状态匹配
+        var data = new DataTable();
+        data.Columns.Add("姓名", typeof(string));
+        data.Columns.Add("地址", typeof(string));
+        data.Columns.Add("Id", typeof(int));
+        data.Rows.Add("张三", "某地", 1);
+        data.AcceptChanges();
+
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<DynamicObject>>(pb =>
+            {
+                pb.Add(a => a.ClientTableName, "test_localized_datatable");
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.DynamicContext, new DataTableDynamicContext(data));
+            });
+        });
+
+        // 列顺序应保持 DataTable 列声明顺序 Id 列不应跳到最前
+        var table = cut.FindComponent<Table<DynamicObject>>();
+        var order = string.Join(",", table.Instance.GetVisibleColumns().Select(i => i.GetFieldName()));
+        Assert.Equal("姓名,地址,Id", order);
+    }
+
+    [Fact]
+    public void ColumnStates_FullMatch_KeepPersistedOrder_Ok()
+    {
+        // 持久化状态全部匹配时保持持久化顺序 模拟用户拖拽列后的自定义顺序
+        var state = new TableColumnClientStatus();
+        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Count), Visible = true });
+        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Name), Visible = true });
+        state.Columns.Add(new TableColumnState() { Name = nameof(Foo.Address), Visible = true });
+
+        Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test_full_match").SetResult(state);
+
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.ClientTableName, "test_full_match");
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.Items, Foo.GenerateFoo(localizer, 2));
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", foo.Name);
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, string>>(3);
+                    builder.AddAttribute(4, "Field", foo.Address);
+                    builder.AddAttribute(5, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, int>>(6);
+                    builder.AddAttribute(7, "Field", foo.Count);
+                    builder.AddAttribute(8, "FieldExpression", Utility.GenerateValueExpression(foo, "Count", typeof(int)));
+                    builder.CloseComponent();
+                });
+            });
+        });
+
+        var table = cut.FindComponent<Table<Foo>>();
+        var order = string.Join(",", table.Instance.GetVisibleColumns().Select(i => i.GetFieldName()));
+        Assert.Equal("Count,Name,Address", order);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
## Link issues
fixes #8222 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure table column order remains consistent when restoring persisted column states, especially when column names change across languages.

Bug Fixes:
- Prevent table columns from jumping to the front or becoming misordered when only some persisted column names match the current columns, such as after a language switch.

Enhancements:
- Adjust column state restoration to insert unmatched columns according to their declared order instead of appending them, preserving a stable column sequence.

Tests:
- Add unit tests covering partial matches, localized DataTable column names, and full matches to verify correct column ordering with persisted column states.