### PR TITLE
feat(Extensions): support T/P/E format

### DIFF
--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -163,7 +163,7 @@ public static class ObjectExtensions
     }
 
     /// <summary>
-    /// <para lang="zh">Tries to convert the string representation of a value to a specified 类型</para>
+    /// <para lang="zh">尝试将字符串表示的值转换为指定类型</para>
     /// <para lang="en">Tries to convert the string representation of a value to a specified type</para>
     /// </summary>
     /// <typeparam name="TValue"></typeparam>
@@ -207,7 +207,7 @@ public static class ObjectExtensions
     }
 
     /// <summary>
-    /// <para lang="zh">Formats the file size into a string with appropriate units</para>
+    /// <para lang="zh">将文件大小格式化为带有适当单位的字符串</para>
     /// <para lang="en">Formats the file size into a string with appropriate units</para>
     /// </summary>
     /// <param name="fileSize"></param>

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -211,7 +211,18 @@ public static class ObjectExtensions
     /// <para lang="en">Formats the file size into a string with appropriate units</para>
     /// </summary>
     /// <param name="bytes"></param>
-    public static string ToFileSizeString(this long bytes)
+    public static string ToFileSizeString(this long bytes) => bytes.ToFileSizeString(CultureInfo.CurrentCulture);
+
+    /// <summary>
+    /// <para lang="zh">使用指定文化将文件大小格式化为带有适当单位的字符串</para>
+    /// <para lang="en">Formats the file size into a string with appropriate units using the specified culture</para>
+    /// </summary>
+    /// <param name="bytes"></param>
+    /// <param name="culture">
+    /// <para lang="zh">格式化使用的文化，为 <c>null</c> 时使用 <see cref="CultureInfo.CurrentCulture"/></para>
+    /// <para lang="en">The culture used for formatting; falls back to <see cref="CultureInfo.CurrentCulture"/> when <c>null</c></para>
+    /// </param>
+    public static string ToFileSizeString(this long bytes, CultureInfo culture)
     {
         const double kb = 1024d;
         const double mb = kb * 1024d;
@@ -222,13 +233,13 @@ public static class ObjectExtensions
 
         return bytes switch
         {
-            >= (long)eb => $"{bytes / eb:0.0} EB",
-            >= (long)pb => $"{bytes / pb:0.0} PB",
-            >= (long)tb => $"{bytes / tb:0.0} TB",
-            >= (long)gb => $"{bytes / gb:0.0} GB",
-            >= (long)mb => $"{bytes / mb:0.0} MB",
-            >= (long)kb => $"{bytes / kb:0.0} KB",
-            _ => $"{bytes} B"
+            >= (long)eb => string.Create(culture, $"{bytes / eb:0.0} EB"),
+            >= (long)pb => string.Create(culture, $"{bytes / pb:0.0} PB"),
+            >= (long)tb => string.Create(culture, $"{bytes / tb:0.0} TB"),
+            >= (long)gb => string.Create(culture, $"{bytes / gb:0.0} GB"),
+            >= (long)mb => string.Create(culture, $"{bytes / mb:0.0} MB"),
+            >= (long)kb => string.Create(culture, $"{bytes / kb:0.0} KB"),
+            _ => string.Create(culture, $"{bytes} B")
         };
     }
 

--- a/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ObjectExtensions.cs
@@ -210,14 +210,27 @@ public static class ObjectExtensions
     /// <para lang="zh">将文件大小格式化为带有适当单位的字符串</para>
     /// <para lang="en">Formats the file size into a string with appropriate units</para>
     /// </summary>
-    /// <param name="fileSize"></param>
-    public static string ToFileSizeString(this long fileSize) => fileSize switch
+    /// <param name="bytes"></param>
+    public static string ToFileSizeString(this long bytes)
     {
-        >= 1024 and < 1024 * 1024 => $"{Math.Round(fileSize / 1024D, 0, MidpointRounding.AwayFromZero)} KB",
-        >= 1024 * 1024 and < 1024 * 1024 * 1024 => $"{Math.Round(fileSize / 1024 / 1024D, 0, MidpointRounding.AwayFromZero)} MB",
-        >= 1024 * 1024 * 1024 => $"{Math.Round(fileSize / 1024 / 1024 / 1024D, 0, MidpointRounding.AwayFromZero)} GB",
-        _ => $"{fileSize} B"
-    };
+        const double kb = 1024d;
+        const double mb = kb * 1024d;
+        const double gb = mb * 1024d;
+        const double tb = gb * 1024d;
+        const double pb = tb * 1024d;
+        const double eb = pb * 1024d;
+
+        return bytes switch
+        {
+            >= (long)eb => $"{bytes / eb:0.0} EB",
+            >= (long)pb => $"{bytes / pb:0.0} PB",
+            >= (long)tb => $"{bytes / tb:0.0} TB",
+            >= (long)gb => $"{bytes / gb:0.0} GB",
+            >= (long)mb => $"{bytes / mb:0.0} MB",
+            >= (long)kb => $"{bytes / kb:0.0} KB",
+            _ => $"{bytes} B"
+        };
+    }
 
     internal static void Clone<TModel>(this TModel source, TModel item)
     {

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -169,6 +169,9 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
     [InlineData(1024f, "1 KB")]
     [InlineData(1024 * 1024f, "1 MB")]
     [InlineData(1024 * 1024 * 1024f, "1 GB")]
+    [InlineData(1024L * 1024 * 1024 * 1024, "1 TB")]
+    [InlineData(1024L * 1024 * 1024 * 1024 * 1024, "1 PB")]
+    [InlineData(1024L * 1024 * 1024 * 1024 * 1024 * 1024, "1 EB")]
     public void ToFileSizeString_Ok(long source, string expect)
     {
         var actual = source.ToFileSizeString();

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -179,6 +179,18 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
     }
 
     [Theory]
+    [InlineData("de-DE", "1,5 GB")]
+    [InlineData("en-US", "1.5 GB")]
+    [InlineData("zh-CN", "1.5 GB")]
+    public void ToFileSizeString_WithCulture(string cultureName, string expect)
+    {
+        // 显式传入文化，输出随之本地化
+        var bytes = (long)(1024L * 1024 * 1024 * 1.5);
+        var actual = bytes.ToFileSizeString(new CultureInfo(cultureName));
+        Assert.Equal(expect, actual);
+    }
+
+    [Theory]
     [InlineData(ItemChangedType.Add, true, false)]
     [InlineData(ItemChangedType.Update, true, false)]
     [InlineData(ItemChangedType.Add, false, true)]

--- a/test/UnitTest/Extensions/ObjectExtensionsTest.cs
+++ b/test/UnitTest/Extensions/ObjectExtensionsTest.cs
@@ -166,12 +166,12 @@ public class ObjectExtensionsTest : BootstrapBlazorTestBase
 
     [Theory]
     [InlineData(100f, "100 B")]
-    [InlineData(1024f, "1 KB")]
-    [InlineData(1024 * 1024f, "1 MB")]
-    [InlineData(1024 * 1024 * 1024f, "1 GB")]
-    [InlineData(1024L * 1024 * 1024 * 1024, "1 TB")]
-    [InlineData(1024L * 1024 * 1024 * 1024 * 1024, "1 PB")]
-    [InlineData(1024L * 1024 * 1024 * 1024 * 1024 * 1024, "1 EB")]
+    [InlineData(1024f, "1.0 KB")]
+    [InlineData(1024 * 1024f, "1.0 MB")]
+    [InlineData(1024 * 1024 * 1024f, "1.0 GB")]
+    [InlineData(1024L * 1024 * 1024 * 1024, "1.0 TB")]
+    [InlineData(1024L * 1024 * 1024 * 1024 * 1024, "1.0 PB")]
+    [InlineData(1024L * 1024 * 1024 * 1024 * 1024 * 1024, "1.0 EB")]
     public void ToFileSizeString_Ok(long source, string expect)
     {
         var actual = source.ToFileSizeString();


### PR DESCRIPTION
## Link issues
fixes #8236 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Extend file size formatting utilities to support larger units (TB/PB/EB) with consistent decimal output and update related documentation and tests.

New Features:
- Support formatting file sizes using TB, PB, and EB units in ObjectExtensions.ToFileSizeString.

Enhancements:
- Adjust file size formatting to use decimal representation (e.g., 1.0 KB/MB/GB) for consistency across units.
- Improve XML documentation comments for object conversion and file size formatting helpers.

Tests:
- Extend ObjectExtensions file size formatting tests to cover KB/MB/GB with decimal output and new TB/PB/EB units.