### PR TITLE
fix(Table): dynamically added columns are not visible in the UI

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.1</Version>
+    <Version>10.8.2-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -1463,6 +1463,7 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
             // 未匹配到状态的列按其在 Columns 中的相对位置插入而不是追加到末尾
             // 防止多语言切换等场景列字段名变化导致仅部分列匹配时列顺序错乱
             var insertIndex = 0;
+            var widthChanged = false;
             foreach (var col in Columns)
             {
                 if (col.GetIgnore())
@@ -1474,14 +1475,21 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
                 if (stateMap.TryGetValue(name, out var item))
                 {
                     item.DisplayName = col.GetDisplayName();
+                    widthChanged = NormalizeVisibleColumnWidth(item, col) || widthChanged;
                     insertIndex = _tableColumnStates.IndexOf(item) + 1;
                 }
                 else
                 {
                     item = CreateTableColumnState(col);
+                    widthChanged = NormalizeVisibleColumnWidth(item, col) || widthChanged;
                     _tableColumnStates.Insert(insertIndex, item);
                     insertIndex++;
                 }
+            }
+
+            if (widthChanged)
+            {
+                UpdateTableColumnStateWidth();
             }
 
             // 根据 _tableColumnStates 顺序重建可见列顺序
@@ -1505,6 +1513,45 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         Width = col.Fixed && !col.Width.HasValue ? DefaultFixedColumnWidth : col.Width,
         Visible = col.GetVisible(_screenSize)
     };
+
+    private bool NormalizeVisibleColumnWidth(TableColumnState item, ITableColumn col)
+    {
+        if (!item.Visible || item.Width.HasValue)
+        {
+            return false;
+        }
+
+        item.Width = GetDefaultColumnStateWidth(col);
+        return true;
+    }
+
+    private int GetDefaultColumnStateWidth(ITableColumn col) => col.Width ?? (col.Fixed ? DefaultFixedColumnWidth : ColumnMinWidth ?? Options.CurrentValue.TableSettings.ColumnMinWidth);
+
+    private void UpdateTableColumnStateWidth()
+    {
+        var tableWidth = 0;
+        var useTableWidth = true;
+        foreach (var column in _tableColumnStateCache.Columns)
+        {
+            if (!column.Visible)
+            {
+                continue;
+            }
+
+            if (column.Width.HasValue)
+            {
+                tableWidth += column.Width.Value;
+            }
+            else
+            {
+                useTableWidth = false;
+                break;
+            }
+        }
+
+        _tableColumnStateCache.TableWidth = useTableWidth ? tableWidth : 0;
+        UpdateTableWidth();
+    }
 
     private async Task OnTableRenderAsync(bool firstRender)
     {

--- a/test/UnitTest/Components/TableTest.cs
+++ b/test/UnitTest/Components/TableTest.cs
@@ -999,6 +999,116 @@ public class TableTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void ShowColumnList_NewVisibleColumnUseDefaultWidth_Ok()
+    {
+        var state = new TableColumnClientStatus()
+        {
+            TableWidth = 240,
+            Columns =
+            [
+                new TableColumnState() { Name = nameof(Foo.Name), Visible = true, Width = 120 },
+                new TableColumnState() { Name = nameof(Foo.Address), Visible = true, Width = 120 },
+                new TableColumnState() { Name = nameof(Foo.Count), Visible = true },
+                new TableColumnState() { Name = nameof(Foo.DateTime), Visible = true }
+            ]
+        };
+
+        Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test-new-column").SetResult(state);
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.AllowResizing, true);
+                pb.Add(a => a.ColumnMinWidth, 80);
+                pb.Add(a => a.Items, Foo.GenerateFoo(localizer, 2));
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, string>>(3);
+                    builder.AddAttribute(4, "Field", "Address");
+                    builder.AddAttribute(5, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, int>>(6);
+                    builder.AddAttribute(7, "Field", foo.Count);
+                    builder.AddAttribute(8, "FieldExpression", Utility.GenerateValueExpression(foo, "Count", typeof(int)));
+                    builder.AddAttribute(9, nameof(ITableColumn.Width), 90);
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, bool>>(10);
+                    builder.AddAttribute(11, "Field", foo.Complete);
+                    builder.AddAttribute(12, "FieldExpression", Utility.GenerateValueExpression(foo, "Complete", typeof(bool)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, DateTime?>>(13);
+                    builder.AddAttribute(14, "Field", foo.DateTime);
+                    builder.AddAttribute(15, "FieldExpression", Utility.GenerateValueExpression(foo, "DateTime", typeof(DateTime?)));
+                    builder.AddAttribute(16, nameof(ITableColumn.Fixed), true);
+                    builder.CloseComponent();
+                });
+                pb.Add(a => a.ClientTableName, "test-new-column");
+            });
+        });
+
+        cut.Contains("style=\"width: 90px;\"");
+        cut.Contains("style=\"width: 80px;\"");
+        cut.Contains("style=\"width: 200px;\"");
+    }
+
+    [Fact]
+    public void ShowColumnList_NewVisibleColumnUseOptionDefaultWidth_Ok()
+    {
+        var state = new TableColumnClientStatus()
+        {
+            TableWidth = 240,
+            Columns =
+            [
+                new TableColumnState() { Name = nameof(Foo.Name), Visible = true, Width = 120 },
+                new TableColumnState() { Name = nameof(Foo.Address), Visible = true, Width = 120 }
+            ]
+        };
+
+        Context.JSInterop.Setup<TableColumnClientStatus>("getColumnStates", "test-new-column-option-width").SetResult(state);
+        var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();
+        var cut = Context.Render<BootstrapBlazorRoot>(pb =>
+        {
+            pb.AddChildContent<Table<Foo>>(pb =>
+            {
+                pb.Add(a => a.RenderMode, TableRenderMode.Table);
+                pb.Add(a => a.AllowResizing, true);
+                pb.Add(a => a.Items, Foo.GenerateFoo(localizer, 2));
+                pb.Add(a => a.TableColumns, foo => builder =>
+                {
+                    builder.OpenComponent<TableColumn<Foo, string>>(0);
+                    builder.AddAttribute(1, "Field", "Name");
+                    builder.AddAttribute(2, "FieldExpression", Utility.GenerateValueExpression(foo, "Name", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, string>>(3);
+                    builder.AddAttribute(4, "Field", "Address");
+                    builder.AddAttribute(5, "FieldExpression", Utility.GenerateValueExpression(foo, "Address", typeof(string)));
+                    builder.CloseComponent();
+
+                    builder.OpenComponent<TableColumn<Foo, int>>(6);
+                    builder.AddAttribute(7, "Field", foo.Count);
+                    builder.AddAttribute(8, "FieldExpression", Utility.GenerateValueExpression(foo, "Count", typeof(int)));
+                    builder.CloseComponent();
+                });
+                pb.Add(a => a.ClientTableName, "test-new-column-option-width");
+            });
+        });
+
+        cut.Contains("style=\"width: 64px;\"");
+        cut.Contains("style=\"width: 304px;\"");
+    }
+
+    [Fact]
     public void ShowCardView_Ok()
     {
         var localizer = Context.Services.GetRequiredService<IStringLocalizer<Foo>>();


### PR DESCRIPTION
## Link issues
fixes #8240 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure dynamically added visible table columns receive appropriate default widths and update cached table width accordingly.

Bug Fixes:
- Fix visibility and sizing of newly added table columns by assigning default widths when none are stored and recalculating the table width cache.

Tests:
- Add unit tests verifying default and option-based widths for newly visible table columns and the resulting table width calculation.