### PR TITLE
fix(Camera): use exact set device id

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.2-beta02</Version>
+    <Version>10.8.2-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Camera/Camera.razor.js
+++ b/src/BootstrapBlazor/Components/Camera/Camera.razor.js
@@ -11,7 +11,7 @@ const openDevice = camera => {
         const videoHeight = parseInt(camera.el.getAttribute("data-video-height"))
         play(camera, {
             video: {
-                deviceId,
+                deviceId: { exact: deviceId },
                 width: { ideal: videoWidth },
                 height: { ideal: videoHeight }
             }


### PR DESCRIPTION
## Issues
fixed #8255

修改了Camera组件在Edge浏览器不能切换多个摄像头画面的问题deviceId: { exact: deviceId }，严格匹配模式

## Summary by Sourcery

Bug Fixes:
- Fix camera switching in Edge browser by using exact deviceId constraints when opening a video stream.