### PR TITLE
fix(Camera): add last device id support switch device

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.2-beta03</Version>
+    <Version>10.8.2-beta04</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Camera/Camera.razor.js
+++ b/src/BootstrapBlazor/Components/Camera/Camera.razor.js
@@ -1,4 +1,4 @@
-﻿import Data from "../../modules/data.js"
+import Data from "../../modules/data.js"
 
 const openDevice = camera => {
     if (camera.video) {

--- a/src/BootstrapBlazor/Components/Camera/Camera.razor.js
+++ b/src/BootstrapBlazor/Components/Camera/Camera.razor.js
@@ -45,6 +45,7 @@ const play = (camera, option = {}) => {
         camera.video.element.srcObject = stream
         camera.video.element.play()
         camera.video.track = stream.getVideoTracks()[0]
+        camera.lastUsedDeviceId = option.video.deviceId.exact ?? option.video.deviceId;
         camera.invoke.invokeMethodAsync("TriggerOpen")
     }).catch(err => {
         delete camera.video
@@ -57,7 +58,7 @@ export function init(id, invoke) {
     if (el === null) {
         return
     }
-    const camera = { el, invoke }
+    const camera = { el, invoke, lastUsedDeviceId: null }
     Data.set(id, camera)
 
     navigator.mediaDevices.getUserMedia({ video: true, audio: false }).then(s => {
@@ -81,6 +82,7 @@ export function update(id) {
     // handler switch device
     if (camera.video) {
         const deviceId = camera.el.getAttribute("data-device-id")
+        if (camera.lastUsedDeviceId === deviceId) return;
         if (camera.video.deviceId !== deviceId) {
             stopDevice(camera)
             openDevice(camera)


### PR DESCRIPTION
## Link issues
fixes #8263 
fixes #8264

Is there an existing issue for this?

I have searched the existing issues
Describe the bug
Camera Devices Added lastUsedDeviceId property to camera object for tracking the last used video device.
Camera组件添加最终使用的设备ID属性，解决因UI刷新导致的视频流画面闪烁问题。

Expected Behavior
Camera Devices Added lastUsedDeviceId property to camera object for tracking the last used video device.
Camera组件添加最终使用的设备ID属性，解决因UI刷新导致的视频流画面闪烁问题。

Interactive render mode
Interactive Server (Interactive server-side rendering (interactive SSR) using Blazor Server)

Steps To Reproduce
none

Exceptions (if any)
No response

.NET Version
NET10.0

Anything else?
No response