### PR TITLE
fix(CheckboxList): use items as data source

### DIFF
--- a/src/BootstrapBlazor.Server/docs.json
+++ b/src/BootstrapBlazor.Server/docs.json
@@ -330,7 +330,7 @@
     "hosting": "BV1BD4y1Y7fg"
   },
   "link": {
-    "AntDesign": "https://www.antblazor.com/?from=blazor.zone",
+    "AntDesign": "http://www.antblazor.com/?from=blazor.zone",
     "AtomUI": "https://qinware.com/?from=blazor.zone",
     "SAPHP": "https://www.swiftadmin.net/?from=blazor.zone",
     "Veterinary Hospital": "http://animal.jucun.zone/?from=blazor.zone"

--- a/src/BootstrapBlazor.Server/docs.json
+++ b/src/BootstrapBlazor.Server/docs.json
@@ -330,7 +330,7 @@
     "hosting": "BV1BD4y1Y7fg"
   },
   "link": {
-    "AntDesign": "http://www.antblazor.com/?from=blazor.zone",
+    "AntDesign": "https://www.antblazor.com/?from=blazor.zone",
     "AtomUI": "https://qinware.com/?from=blazor.zone",
     "SAPHP": "https://www.swiftadmin.net/?from=blazor.zone",
     "Veterinary Hospital": "http://animal.jucun.zone/?from=blazor.zone"

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -777,7 +777,8 @@ public static class Utility
 
         if (IsCheckboxList(fieldType, componentType) && item.Items != null)
         {
-            builder.AddAttribute(90, nameof(CheckboxList<>.Items), item.Items.Clone());
+            // 这里不能用Clone方法，因为克隆后会导致CheckboxList组件 Items 每次都是新的实例
+            builder.AddAttribute(90, nameof(CheckboxList<>.Items), item.Items);
         }
 
         // Nullable<bool?>

--- a/src/BootstrapBlazor/Utils/Utility.cs
+++ b/src/BootstrapBlazor/Utils/Utility.cs
@@ -777,7 +777,6 @@ public static class Utility
 
         if (IsCheckboxList(fieldType, componentType) && item.Items != null)
         {
-            // 这里不能用Clone方法，因为克隆后会导致CheckboxList组件 Items 每次都是新的实例
             builder.AddAttribute(90, nameof(CheckboxList<>.Items), item.Items);
         }
 


### PR DESCRIPTION
fix:修复自动生成列为CheckBoxList组件时，数据绑定的Bug，导致每次只能单选的问题

## Link issues
fixes #8265

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## 问题描述 / Problem Description
当Table组件中绑定的数据采用自动生成列时，有字段属性对应生成为`CheckBoxList`组件时，会出现每次只能选中一个，关掉编辑弹窗后，才能再次 `选中/取消` 另一个

## 根本原因 / Root Cause
在`EditorForm`组件中自动生成编辑窗体的数据模板时，对`CheckBoxList`组件的`Items`赋值时采用了克隆，因此导致每次会创建新的实例

## 解决方案 / Solution
修改`Utility.cs`中自动生成编辑弹窗中组件的方法，代码如下所示：
```C#
public static void CreateComponentByFieldType(this RenderTreeBuilder builder, ComponentBase component, IEditorItem item, object model, ItemChangedType changedType = ItemChangedType.Update, bool isSearch = false, ILookupService? lookupService = null, bool? skipValidate = null)
{
    // ....省略以上代码.....
   if (IsCheckboxList(fieldType, componentType) && item.Items != null)
   {
       builder.AddAttribute(90, nameof(CheckboxList<>.Items), item.Items);
   }
   // ....省略以下代码.....
}
```

## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Resolve CheckboxList in auto-generated columns always creating new item instances, which restricted selection to a single item.