### PR TITLE
fix(ImagePreviewer): improve the initial value null check

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.2-beta04</Version>
+    <Version>10.8.2-beta05</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor.cs
+++ b/src/BootstrapBlazor/Components/ImagePreviewer/ImagePreviewer.razor.cs
@@ -98,7 +98,7 @@ public partial class ImagePreviewer
     [NotNull]
     private IIconTheme? IconTheme { get; set; }
 
-    private string? GetFirstImageUrl() => PreviewList.First();
+    private string? GetFirstImageUrl() => PreviewList.FirstOrDefault();
 
     private bool ShowButtons => PreviewList.Count > 1;
 


### PR DESCRIPTION
## Link issues
fixes #8271

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [x] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [x] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [x] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Prevent ImagePreviewer from throwing when the preview list is empty by returning a nullable first image URL.