### PR TITLE
feat(Modbus): bump version 10.0.3

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -86,7 +86,7 @@
     <PackageReference Include="BootstrapBlazor.VideoPlayer" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.WinBox" Version="10.0.0" />
     <PackageReference Include="Longbow.Logging" Version="10.0.1" />
-    <PackageReference Include="Longbow.Modbus" Version="10.0.1" />
+    <PackageReference Include="Longbow.Modbus" Version="10.0.3" />
     <PackageReference Include="Longbow.Sockets" Version="10.0.0" />
     <PackageReference Include="Longbow.Tasks" Version="10.0.0" />
     <PackageReference Include="Longbow.TcpSocket" Version="10.0.0" />


### PR DESCRIPTION
## Link issues
fixes #8275 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update the BootstrapBlazor.Server project to use Modbus version 10.0.3.

Bug Fixes:
- Update Modbus dependency to version 10.0.3 to incorporate upstream fixes and improvements.

Build:
- Bump BootstrapBlazor.Server project Modbus package reference to version 10.0.3.