### PR TITLE
Add support for ShowDropdownListOnFocus when IsPopover is true

### DIFF
--- a/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
+++ b/src/BootstrapBlazor/Components/AutoComplete/AutoComplete.razor.js
@@ -55,12 +55,19 @@ export function init(id, invoke, value, changedEventCallback) {
         ac.close();
     });
 
+    let isPointerFocus = false;
+    EventHandler.on(input, 'pointerdown', e => {
+        isPointerFocus = true;
+        const handler = setTimeout(() => {
+            clearTimeout(handler);
+            isPointerFocus = false;
+        }, 0);
+    });
+
     EventHandler.on(input, 'focus', e => {
         const showDropdownOnFocus = input.getAttribute('data-bb-auto-dropdown-focus') === 'true';
-        if (showDropdownOnFocus) {
-            if (isPopover === false) {
-                ac.show();
-            }
+        if (showDropdownOnFocus && !(isPopover && isPointerFocus)) {
+            ac.show();
         }
     });
 
@@ -80,9 +87,7 @@ export function init(id, invoke, value, changedEventCallback) {
     }, filterDuration);
 
     Input.composition(input, v => {
-        if (isPopover === false) {
-            ac.show();
-        }
+        ac.show();
 
         const skipMatch = input.getAttribute('data-bb-skip-match') === 'true';
         if (skipMatch) {
@@ -94,11 +99,21 @@ export function init(id, invoke, value, changedEventCallback) {
     });
 
     ac.show = () => {
-        ac.el.classList.add('show');
+        if (ac.popover) {
+            ac.popover.show();
+        }
+        else {
+            ac.el.classList.add('show');
+        }
     }
 
     ac.close = () => {
-        ac.el.classList.remove('show');
+        if (ac.popover) {
+            ac.popover.hide();
+        }
+        else {
+            ac.el.classList.remove('show');
+        }
     }
 
     ac.closePopover = e => {
@@ -224,6 +239,7 @@ export function dispose(id) {
             }
         }
         EventHandler.off(menu, 'click');
+        EventHandler.off(input, 'pointerdown');
         EventHandler.off(input, 'keydown');
         Input.dispose(input);
 


### PR DESCRIPTION
## Link issues
fixes #8277 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Unify AutoComplete dropdown behavior for popover and non-popover modes and refine focus handling to support showing the dropdown on focus when popovers are enabled.

Enhancements:
- Support showing the AutoComplete dropdown on focus when popover mode is enabled, excluding pointer-induced focus to avoid unintended popover behavior.
- Route AutoComplete show/close operations through the popover API when a popover is present, keeping existing class-based behavior for non-popover usage.
- Adjust composition input handling to consistently trigger dropdown display regardless of popover configuration.
- Ensure pointerdown event handlers on the AutoComplete input are properly registered and disposed to prevent leaks.