### PR TITLE
feat(SelectTable): support keyboard key up/down event

### DIFF
--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor.js
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor.js
@@ -81,8 +81,12 @@ export function init(id, invoke) {
 }
 
 const handlerKeydown = (table, e) => {
-    const key = e.key;
     const { el, invoke, popover: { popover: { tip } } } = table;
+    if (tip === null) {
+        return;
+    }
+
+    const key = e.key;
     if (key === 'Enter') {
         const activeItem = tip.querySelector('.table-fixed-body > table > tbody > tr.active');
         if (activeItem !== null) {

--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor.js
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor.js
@@ -47,9 +47,10 @@ export function init(id, invoke) {
     const observer = new ResizeObserver(setWidth);
     observer.observe(el)
 
+    const input = el.querySelector(".form-select");
     const selectTable = {
         el,
-        input: el.querySelector(".form-select"),
+        input,
         popover,
         observer
     }
@@ -73,6 +74,51 @@ export function init(id, invoke) {
             }
         }
     });
+
+    EventHandler.on(input, 'keydown', e => {
+        handlerKeydown(selectTable, e);
+    });
+}
+
+const handlerKeydown = (table, e) => {
+    const key = e.key;
+    const { el, invoke, popover: { popover: { tip } } } = table;
+    if (key === 'Enter') {
+        const activeItem = tip.querySelector('.table-fixed-body > table > tbody > tr.active');
+        if (activeItem !== null) {
+            setTimeout(() => activeItem.click(), 0);
+        }
+    }
+    else if (key === 'ArrowUp' || key === 'ArrowDown') {
+        e.preventDefault();
+        e.stopPropagation();
+
+        const items = [...tip.querySelectorAll('.table-fixed-body > table > tbody > tr')];
+        if (items.length === 0) {
+            return;
+        }
+
+        let current = tip.querySelector('.active');
+        if (current !== null) {
+            current.classList.remove('active');
+        }
+        let index = current === null ? -1 : items.indexOf(current);
+        index = key === 'ArrowUp' ? index - 1 : index + 1;
+        if (index < 0) {
+            index = items.length - 1;
+        }
+        else if (index > items.length - 1) {
+            index = 0;
+        }
+        current = items[index];
+        current.classList.add('active');
+        scrollIntoView(el, current);
+    }
+}
+
+const scrollIntoView = (el, item) => {
+    const behavior = el.getAttribute('data-bb-scroll-behavior') ?? 'smooth';
+    item.scrollIntoView({ behavior: behavior, block: "nearest", inline: "start" });
 }
 
 export function close(id) {
@@ -86,8 +132,10 @@ export function dispose(id) {
     Data.remove(id)
 
     if (data) {
-        data.observer.disconnect();
-        Popover.dispose(data.popover)
-        EventHandler.off(data.el, 'click');
+        const { el, popover, input, observer } = data;
+        observer.disconnect();
+        Popover.dispose(popover)
+        EventHandler.off(el, 'click');
+        EventHandler.off(input, 'keydown');
     }
 }

--- a/src/BootstrapBlazor/Components/Select/SelectTable.razor.js
+++ b/src/BootstrapBlazor/Components/Select/SelectTable.razor.js
@@ -39,6 +39,14 @@ export function init(id, invoke) {
                 dropdown.style.removeProperty('position');
             }
         },
+        shownCallback: () => {
+            const handler = setTimeout(() => {
+                const activeItem = popover.popover.tip.querySelector('.table-fixed-body > table > tbody > tr.active');
+                if (activeItem !== null) {
+                    scrollIntoView(el, activeItem);
+                }
+            }, 0);
+        },
         hideCallback: async () => {
             await invoke.invokeMethodAsync("TriggerUpdateSelectedItems");
         }


### PR DESCRIPTION
## Link issues
fixes #8279 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add keyboard navigation and selection support to SelectTable popover and ensure proper cleanup of related event handlers on disposal.

New Features:
- Support Enter key to activate the currently highlighted row in the SelectTable popover.
- Support ArrowUp and ArrowDown keys to move the active row within the SelectTable dropdown table.
- Automatically scroll the active table row into view when the SelectTable popover is shown or when keyboard navigation changes the active row.

Enhancements:
- Refine SelectTable disposal logic to disconnect observers and remove click and keydown handlers associated with the component.