### PR TITLE
fix(ValidateForm): DisableAutoSubmitFormByEnter not work in Modal

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.8.2-beta05</Version>
+    <Version>10.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -170,6 +170,19 @@ public partial class ValidateForm
     }
 
     /// <summary>
+    /// <inheritdoc/>
+    /// </summary>
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender);
+
+        if (!firstRender)
+        {
+            await InvokeVoidAsync("update", Id);
+        }
+    }
+
+    /// <summary>
     /// <para lang="zh">添加数据验证组件到 EditForm 中</para>
     /// <para lang="en">Adds a data validation component to the EditForm</para>
     /// </summary>

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -128,7 +128,9 @@ public partial class ValidateForm
 
     private readonly ConcurrentDictionary<IValidateComponent, List<ValidationResult>> _validateResults = new();
 
-    private string? DisableAutoSubmitString => (DisableAutoSubmitFormByEnter.HasValue && DisableAutoSubmitFormByEnter.Value) ? "true" : null;
+    private string? DisableAutoSubmitString => IsFormless
+        ? null
+        : DisableAutoSubmitFormByEnter is true ? "true" : null;
 
     /// <summary>
     /// <para lang="zh">获得验证合法成员集合</para>

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.js
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.js
@@ -14,11 +14,13 @@ export function init(id) {
 }
 
 export function update(id) {
-    const el = document.getElementById(id);
     const form = Data.get(id);
+    if (form) {
+        const el = document.getElementById(id);
 
-    if (el === form.el) {
-        return;
+        if (el === form.el) {
+            return;
+        }
     }
 
     dispose(id);

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.js
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.js
@@ -1,20 +1,48 @@
-﻿import EventHandler from "../../modules/event-handler.js"
+import EventHandler from "../../modules/event-handler.js"
+import Data from "../../modules/data.js"
 
 export function init(id) {
     const el = document.getElementById(id)
+    Data.set(id, {
+        el
+    });
 
-    EventHandler.on(el, 'keydown', e => {
-        if (e.target.nodeName !== 'TEXTAREA') {
-            const dissubmit = el.getAttribute('data-bb-dissubmit') === 'true'
-            if (e.keyCode === 13 && dissubmit) {
-                e.preventDefault()
-                e.stopPropagation()
-            }
-        }
-    })
+    const dissubmit = el.getAttribute('data-bb-dissubmit') === 'true';
+    if (dissubmit) {
+        bind(el);
+    }
+}
+
+export function update(id) {
+    const el = document.getElementById(id);
+    const form = Data.get(id);
+
+    if (el === form.el) {
+        return;
+    }
+
+    dispose(id);
+    init(id);
 }
 
 export function dispose(id) {
-    const el = document.getElementById(id)
-    EventHandler.off(el, 'keydown')
+    const form = Data.get(id);
+    Data.remove(id);
+
+    if (form) {
+        unbind(form.el);
+    }
+}
+
+const unbind = el => {
+    EventHandler.off(el, 'keydown');
+}
+
+const bind = el => {
+    EventHandler.on(el, 'keydown', e => {
+        if (e.key === 'Enter' && e.target.nodeName !== 'TEXTAREA') {
+            e.preventDefault()
+            e.stopPropagation()
+        }
+    });
 }

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -613,6 +613,8 @@ public class ValidateFormTest : BootstrapBlazorTestBase
     {
         var options = Context.Services.GetRequiredService<IOptionsMonitor<BootstrapBlazorOptions>>();
         options.CurrentValue.DisableAutoSubmitFormByEnter = true;
+        var property = typeof(ValidateForm).GetProperty("DisableAutoSubmitString", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        Assert.NotNull(property);
 
         var foo = new Foo() { Name = "Test" };
         var cut = Context.Render<ValidateForm>(pb =>
@@ -631,12 +633,27 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         });
 
         Assert.True(cut.Instance.DisableAutoSubmitFormByEnter);
+        Assert.Equal("true", property.GetValue(cut.Instance));
+        Assert.Equal("true", cut.Find("form").GetAttribute("data-bb-dissubmit"));
 
         cut.Render(pb =>
         {
             pb.Add(a => a.DisableAutoSubmitFormByEnter, false);
         });
         Assert.False(cut.Instance.DisableAutoSubmitFormByEnter);
+        Assert.Null(property.GetValue(cut.Instance));
+        Assert.Null(cut.Find("form").GetAttribute("data-bb-dissubmit"));
+
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.DisableAutoSubmitFormByEnter, true);
+            pb.Add(a => a.IsFormless, true);
+        });
+
+        Assert.True(cut.Instance.DisableAutoSubmitFormByEnter);
+        Assert.True(cut.Instance.IsFormless);
+        Assert.Null(property.GetValue(cut.Instance));
+        Assert.Empty(cut.FindAll("form"));
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8281 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure ValidateForm correctly disables Enter key auto-submit, including when used in modal or dynamically re-rendered forms.

Bug Fixes:
- Fix DisableAutoSubmitFormByEnter so the Enter key no longer submits the form when validation is hosted in a modal or other non-standard form layouts.

Enhancements:
- Track ValidateForm DOM elements and rebind keydown handlers on re-render to keep client-side behavior in sync with the component lifecycle.