### PR TITLE
fix(TreeView): keep active item after filter

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.9.0</Version>
+    <Version>10.9.1-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -915,7 +915,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }
 
     /// <summary>
-    /// <para lang="zh">Clear all selected nodes</para>
+    /// <para lang="zh">清除所有选中的节点</para>
     /// <para lang="en">Clear all selected nodes</para>
     /// </summary>
     public void ClearCheckedItems()
@@ -937,7 +937,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }
 
     /// <summary>
-    /// <para lang="zh">获得 all selected node 集合s</para>
+    /// <para lang="zh">获得所有选中的节点集合</para>
     /// <para lang="en">Gets all selected node collections</para>
     /// </summary>
     public IEnumerable<TreeViewItem<TItem>> GetCheckedItems() => Items.Aggregate(new List<TreeViewItem<TItem>>(), (t, item) =>
@@ -948,7 +948,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }).Where(i => i.CheckedState == CheckboxState.Checked);
 
     /// <summary>
-    /// <para lang="zh">Check if the 数据 is the same</para>
+    /// <para lang="zh">检查数据是否相同</para>
     /// <para lang="en">Check if the data is the same</para>
     /// </summary>
     /// <param name="x"></param>

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -799,7 +799,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }
 
     /// <summary>
-    /// <para lang="zh">Set the active node</para>
+    /// <para lang="zh">设置活动节点</para>
     /// <para lang="en">Set the active node</para>
     /// </summary>
     public void SetActiveItem(TItem item)

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -750,6 +750,10 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     {
         _searchText = null;
         _searchItems = null;
+        if (_activeItem != null && Items != null)
+        {
+            _activeItem = _treeNodeStateCache.Find(Items, _activeItem.Value, out _);
+        }
         _rows = null;
         StateHasChanged();
         return Task.CompletedTask;

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -740,9 +740,23 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     {
         if (OnSearchAsync != null)
         {
-            _searchItems = await OnSearchAsync(_searchText);
             _rows = null;
-            StateHasChanged();
+            _searchItems = await OnSearchAsync(_searchText);
+            if (_searchItems == null || _activeItem == null)
+            {
+                StateHasChanged();
+                return;
+            }
+
+            var val = _searchItems.GetAllItems().FirstOrDefault(i => Equals(i.Value, _activeItem.Value));
+            if (val == null)
+            {
+                StateHasChanged();
+                return;
+            }
+
+            _activeItem = val;
+            SetActiveItem(val.Value);
         }
     }
 
@@ -750,12 +764,15 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     {
         _searchText = null;
         _searchItems = null;
+        _rows = null;
         if (_activeItem != null && Items != null)
         {
-            _activeItem = _treeNodeStateCache.Find(Items, _activeItem.Value, out _);
+            SetActiveItem(_activeItem.Value);
         }
-        _rows = null;
-        StateHasChanged();
+        else
+        {
+            StateHasChanged();
+        }
         return Task.CompletedTask;
     }
 
@@ -804,11 +821,8 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     /// </summary>
     public void SetActiveItem(TItem item)
     {
-        if (Items != null)
-        {
-            var val = Items.GetAllItems().FirstOrDefault(i => Equals(i.Value, item));
-            SetActiveItem(val);
-        }
+        var val = Rows.GetAllItems().FirstOrDefault(i => Equals(i.Value, item));
+        SetActiveItem(val);
     }
 
     private static CheckboxState ToggleCheckState(CheckboxState state) => state switch

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -968,7 +968,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
 
     private List<TreeViewItem<TItem>> GetTreeItems() => _searchItems ?? Items;
 
-    private bool GetActive(TreeViewItem<TItem> item) => _activeItem == item;
+    private bool GetActive(TreeViewItem<TItem> item) => _activeItem == null ? false : this.Equals<TItem>(_activeItem.Value, item.Value);
 
     private int GetIndex(TreeViewItem<TItem> item) => Rows.IndexOf(item);
 }

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -760,7 +760,7 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }
 
     /// <summary>
-    /// <para lang="zh">Set the active node</para>
+    /// <para lang="zh">设置活动节点</para>
     /// <para lang="en">Set the active node</para>
     /// </summary>
     public void SetActiveItem(TreeViewItem<TItem>? item)

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -788,8 +788,8 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }
 
     /// <summary>
-    /// <para lang="zh">Set the 数据 source method for <see cref="Items"/></para>
-    /// <para lang="en">Set the data source method for <see cref="Items"/></para>
+    /// <para lang="zh">设置数据集方法</para>
+    /// <para lang="en">Set the data source method</para>
     /// </summary>
     public void SetItems(List<TreeViewItem<TItem>> items)
     {

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -1549,8 +1549,8 @@ public class TreeViewTest : BootstrapBlazorTestBase
         });
 
         var input = cut.FindComponent<BootstrapInput<string?>>();
+        await cut.InvokeAsync(() => cut.Instance.SetActiveItem(items[1]));
         await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(items[1].Text));
-        await cut.InvokeAsync(() => cut.Find(".tree-node").Click());
         Assert.Equal(items[1].Text, cut.Find(".active .tree-node-text").TextContent);
 
         await cut.InvokeAsync(() => input.Instance.OnEscAsync!(string.Empty));

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -1517,6 +1517,32 @@ public class TreeViewTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task Search_SelectedItem_Ok()
+    {
+        var items = TreeFoo.GetTreeItems();
+        var cut = Context.Render<TreeView<TreeFoo>>(pb =>
+        {
+            pb.Add(a => a.ShowSearch, true);
+            pb.Add(a => a.OnSearchAsync, new Func<string?, Task<List<TreeViewItem<TreeFoo>>?>>(_ =>
+            {
+                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>(
+                [
+                    new TreeViewItem<TreeFoo>(items[1].Value) { Text = items[1].Text }
+                ]);
+            }));
+            pb.Add(a => a.Items, items);
+        });
+
+        var input = cut.FindComponent<BootstrapInput<string?>>();
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(items[1].Text));
+        await cut.InvokeAsync(() => cut.Find(".tree-node").Click());
+        Assert.Equal(items[1].Text, cut.Find(".active .tree-node-text").TextContent);
+
+        await cut.InvokeAsync(() => input.Instance.OnEscAsync!(string.Empty));
+        Assert.Equal(items[1].Text, cut.Find(".active .tree-node-text").TextContent);
+    }
+
+    [Fact]
     public async Task KeyBoard_Ok()
     {
         List<TreeFoo> data =

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -151,6 +151,21 @@ public class TreeViewTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task Items_KeepActiveItem()
+    {
+        var items = TreeFoo.GetTreeItems();
+        var cut = Context.Render<TreeView<TreeFoo>>(pb => pb.Add(a => a.Items, items));
+
+        await cut.InvokeAsync(() => cut.Instance.SetActiveItem(items[0]));
+        Assert.Equal("Navigation one", cut.Find(".active .tree-node-text").TextContent);
+
+        var newItems = TreeFoo.GetTreeItems();
+        cut.Render(pb => pb.Add(a => a.Items, newItems));
+
+        Assert.Equal("Navigation one", cut.Find(".active .tree-node-text").TextContent);
+    }
+
+    [Fact]
     public async Task SetActiveItem_ExpandCollapsedParent()
     {
         // https://github.com/dotnetcore/BootstrapBlazor/issues/8185
@@ -1540,6 +1555,40 @@ public class TreeViewTest : BootstrapBlazorTestBase
 
         await cut.InvokeAsync(() => input.Instance.OnEscAsync!(string.Empty));
         Assert.Equal(items[1].Text, cut.Find(".active .tree-node-text").TextContent);
+    }
+
+    [Fact]
+    public async Task Search_NullBranches_Ok()
+    {
+        var items = TreeFoo.GetTreeItems();
+        List<TreeViewItem<TreeFoo>>? searchResult = [items[0]];
+        var cut = Context.Render<TreeView<TreeFoo>>(pb =>
+        {
+            pb.Add(a => a.ShowSearch, true);
+            pb.Add(a => a.Items, items);
+            pb.Add(a => a.OnSearchAsync, _ => Task.FromResult(searchResult));
+        });
+        var input = cut.FindComponent<BootstrapInput<string?>>();
+
+        await cut.InvokeAsync(() => cut.Instance.SetActiveItem((TreeViewItem<TreeFoo>?)null));
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
+        Assert.Empty(cut.FindAll(".tree-content.active"));
+
+        searchResult = null;
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
+        Assert.Equal(9, cut.FindAll(".tree-content").Count);
+
+        await cut.InvokeAsync(() => input.Instance.OnEscAsync!(string.Empty));
+        Assert.Equal(9, cut.FindAll(".tree-content").Count);
+
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.Items, items);
+            pb.Add(a => a.OnSearchAsync, null);
+        });
+        input = cut.FindComponent<BootstrapInput<string?>>();
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
+        Assert.Equal(9, cut.FindAll(".tree-content").Count);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8285 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Preserve the active TreeView item when filtering or resetting search, and ensure active state is computed by item value rather than reference.

Bug Fixes:
- Keep the previously active TreeView item after applying search filters and when clearing search results.
- Ensure SetActiveItem(TItem) resolves the active node against the currently displayed rows so selection remains consistent under search.
- Fix active-node detection to compare item values instead of object reference, preventing loss of active state when the item list is recreated.

Enhancements:
- Update TreeView public API XML summaries for clearer Chinese and English descriptions of selection and data-related methods.

Tests:
- Add unit tests verifying that the active TreeView item is retained when the item list is refreshed.
- Add unit tests covering search behavior, including maintaining selection through search enter/escape actions and handling null or empty search results.