### PR TITLE
fix(TreeView): CheckboxItems support filter function

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.9.1-beta01</Version>
+    <Version>10.9.1-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -908,9 +908,36 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
             _ = InvokeVoidAsync("setParentState", Id, Interop, nameof(GetParentsState), Rows.IndexOf(item));
         }
 
+        SyncSearchItemCheckedState(item);
+
         if (OnTreeItemChecked != null)
         {
             await OnTreeItemChecked([.. GetCheckedItems()]);
+        }
+    }
+
+    private void SyncSearchItemCheckedState(TreeViewItem<TItem> item)
+    {
+        if (_searchItems == null)
+        {
+            return;
+        }
+
+        var sourceItem = _treeNodeStateCache.Find(Items, item.Value, out _);
+        if (sourceItem == null || ReferenceEquals(sourceItem, item))
+        {
+            return;
+        }
+
+        sourceItem.CheckedState = item.CheckedState;
+        _treeNodeStateCache.ToggleCheck(sourceItem);
+        if (AutoCheckChildren && sourceItem.CheckedState != CheckboxState.Indeterminate)
+        {
+            sourceItem.SetChildrenCheck(_treeNodeStateCache);
+        }
+        if (AutoCheckParent)
+        {
+            sourceItem.SetParentCheck(_treeNodeStateCache);
         }
     }
 

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -1558,6 +1558,95 @@ public class TreeViewTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task Search_CheckedItem_Ok()
+    {
+        var items = TreeFoo.GetTreeItems();
+        List<TreeViewItem<TreeFoo>>? checkedItems = null;
+        List<TreeViewItem<TreeFoo>> searchItems =
+        [
+            new(new TreeFoo { Id = items[0].Value.Id, Text = items[0].Value.Text }) { Text = items[0].Text }
+        ];
+        var cut = Context.Render<TreeView<TreeFoo>>(pb =>
+        {
+            pb.Add(a => a.ShowSearch, true);
+            pb.Add(a => a.ShowCheckbox, true);
+            pb.Add(a => a.Items, items);
+            pb.Add(a => a.OnSearchAsync, _ => Task.FromResult<List<TreeViewItem<TreeFoo>>?>(searchItems));
+            pb.Add(a => a.OnTreeItemChecked, result =>
+            {
+                checkedItems = result;
+                return Task.CompletedTask;
+            });
+        });
+
+        var input = cut.FindComponent<BootstrapInput<string?>>();
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(items[0].Text));
+
+        var checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
+        await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
+        Assert.Single(checkedItems!);
+        Assert.Equal(items[0].Value.Id, checkedItems[0].Value.Id);
+        Assert.Equal(CheckboxState.Checked, items[0].CheckedState);
+
+        await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
+        Assert.Empty(checkedItems!);
+        Assert.Equal(CheckboxState.UnChecked, items[0].CheckedState);
+
+        searchItems = [new(new TreeFoo { Id = "NotFound", Text = "NotFound" }) { Text = "NotFound" }];
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
+        checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
+        await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
+        Assert.Empty(checkedItems!);
+
+        searchItems = [items[0]];
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
+        checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
+        await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
+        Assert.Single(checkedItems!);
+        Assert.Same(items[0], checkedItems[0]);
+    }
+
+    [Fact]
+    public async Task Search_CheckedItem_Cascade_Ok()
+    {
+        var root = new TreeViewItem<TreeFoo>(new TreeFoo { Id = "Root", Text = "Root" }) { Text = "Root" };
+        var child = new TreeViewItem<TreeFoo>(new TreeFoo { Id = "Child", Text = "Child" }) { Text = "Child", Parent = root };
+        root.Items.Add(child);
+        List<TreeViewItem<TreeFoo>>? checkedItems = null;
+        var cut = Context.Render<TreeView<TreeFoo>>(pb =>
+        {
+            pb.Add(a => a.ShowSearch, true);
+            pb.Add(a => a.ShowCheckbox, true);
+            pb.Add(a => a.AutoCheckChildren, true);
+            pb.Add(a => a.AutoCheckParent, true);
+            pb.Add(a => a.Items, new List<TreeViewItem<TreeFoo>> { root });
+            pb.Add(a => a.OnSearchAsync, _ => Task.FromResult<List<TreeViewItem<TreeFoo>>?>(
+            [
+                new(new TreeFoo { Id = root.Value.Id, Text = root.Value.Text }) { Text = root.Text }
+            ]));
+            pb.Add(a => a.OnTreeItemChecked, result =>
+            {
+                checkedItems = result;
+                return Task.CompletedTask;
+            });
+        });
+
+        var input = cut.FindComponent<BootstrapInput<string?>>();
+        await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(root.Text));
+        var checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
+
+        await cut.InvokeAsync(() => checkbox.Instance.SetState(CheckboxState.Indeterminate));
+        Assert.Empty(checkedItems!);
+        Assert.Equal(CheckboxState.Indeterminate, root.CheckedState);
+        Assert.Equal(CheckboxState.UnChecked, child.CheckedState);
+
+        await cut.InvokeAsync(() => checkbox.Instance.SetState(CheckboxState.Checked));
+        Assert.Equal(2, checkedItems!.Count);
+        Assert.Equal(CheckboxState.Checked, root.CheckedState);
+        Assert.Equal(CheckboxState.Checked, child.CheckedState);
+    }
+
+    [Fact]
     public async Task Search_NullBranches_Ok()
     {
         var items = TreeFoo.GetTreeItems();


### PR DESCRIPTION
## Link issues
fixes #8289 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Ensure TreeView checkbox state changes remain consistent when using search results, including cascaded parent/child checking.

Bug Fixes:
- Fix desynchronization between checked states of TreeView items and their corresponding search result items when toggling checkboxes.
- Ensure cascaded parent/child checkbox behavior works correctly when interacting via search-filtered TreeView items.

Tests:
- Add unit tests covering checkbox interactions on search-filtered TreeView items, including cascade scenarios with parent and child nodes.