### PR TITLE
feat(TreeView): redesign reset search logic

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/TreeViews.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/TreeViews.razor.cs
@@ -61,11 +61,11 @@ public sealed partial class TreeViews
 
     private List<TreeViewItem<TreeFoo>>? AsyncItems { get; set; }
 
-    private List<TreeViewItem<TreeFoo>>? MaxItems { get; set; } = TreeFoo.GetTreeItems();
+    private List<TreeViewItem<TreeFoo>> MaxItems { get; set; } = TreeFoo.GetTreeItems();
 
-    private List<TreeViewItem<TreeFoo>>? SearchItems1 { get; set; } = TreeFoo.GetTreeItems();
+    private List<TreeViewItem<TreeFoo>> SearchItems1 { get; set; } = TreeFoo.GetTreeItems();
 
-    private List<TreeViewItem<TreeFoo>>? SearchItems2 { get; set; } = TreeFoo.GetTreeItems();
+    private List<TreeViewItem<TreeFoo>> SearchItems2 { get; set; } = TreeFoo.GetTreeItems();
 
     private List<TreeViewItem<TreeFoo>> VirtualizeItems { get; } = TreeFoo.GetVirtualizeTreeItems();
 
@@ -269,20 +269,56 @@ public sealed partial class TreeViews
         return ret;
     }
 
-    private static async Task<List<TreeViewItem<TreeFoo>>?> OnSearchAsync(string searchText)
+    private async Task<List<TreeViewItem<TreeFoo>>?> OnSearchAsync(string? searchText)
     {
         await Task.Delay(20);
 
         List<TreeViewItem<TreeFoo>>? items = null;
         if (!string.IsNullOrEmpty(searchText))
         {
-            items =
-            [
-                new TreeViewItem<TreeFoo>(new TreeFoo() { Text = searchText }) { Text = searchText },
-            ];
+            items = GetSearchItems(searchText, SearchItems1);
         }
         return items;
     }
+
+    private static List<TreeViewItem<TreeFoo>> GetSearchItems(string searchText, IEnumerable<TreeViewItem<TreeFoo>> source)
+    {
+        var items = new List<TreeViewItem<TreeFoo>>();
+        foreach (var item in source)
+        {
+            // 递归过滤子节点，保留层次结构
+            var children = GetSearchItems(searchText, item.Items);
+
+            // 节点自身匹配或其后代存在匹配时保留该节点
+            var isMatch = !string.IsNullOrEmpty(item.Text) && item.Text.Contains(searchText, StringComparison.OrdinalIgnoreCase);
+            if (isMatch || children.Count > 0)
+            {
+                // 克隆节点，避免污染原始数据源
+                var node = CloneItem(item);
+                node.Items = children;
+                foreach (var child in children)
+                {
+                    child.Parent = node;
+                }
+                items.Add(node);
+            }
+        }
+        return items;
+    }
+
+    private static TreeViewItem<TreeFoo> CloneItem(TreeViewItem<TreeFoo> item) => new(item.Value)
+    {
+        Text = item.Text,
+        Icon = item.Icon,
+        ExpandIcon = item.ExpandIcon,
+        CssClass = item.CssClass,
+        IsActive = item.IsActive,
+        IsDisabled = item.IsDisabled,
+        IsExpand = true,
+        HasChildren = item.HasChildren,
+        CheckedState = item.CheckedState,
+        Template = item.Template
+    };
 
     private static async Task<IEnumerable<TreeViewItem<TreeFoo>>> OnExpandVirtualNodeAsync(TreeViewItem<TreeFoo> node)
     {

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -124,8 +124,8 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     public string? ClearSearchIcon { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 搜索回调方法，默认为 null</para>
-    /// <para lang="en">Gets or sets the search callback method. Default is null</para>
+    /// <para lang="zh">获得/设置 搜索回调方法，默认为 null。重置搜索时以 null 作为搜索条件再次调用</para>
+    /// <para lang="en">Gets or sets the search callback method. Default is null. It is invoked again with a null search term when the search is reset</para>
     /// </summary>
     /// <remarks>Enabled by setting <see cref="ShowSearch"/> to true.</remarks>
     [Parameter]
@@ -738,42 +738,25 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
 
     private async Task OnClickSearch()
     {
-        if (OnSearchAsync != null)
+        _searchItems = OnSearchAsync == null ? null : await OnSearchAsync(_searchText);
+        _rows = null;
+        if (_activeItem != null)
         {
-            _rows = null;
-            _searchItems = await OnSearchAsync(_searchText);
-            if (_searchItems == null || _activeItem == null)
+            var item = Rows.FirstOrDefault(i => Equals(i.Value, _activeItem.Value));
+            if (item != null)
             {
-                StateHasChanged();
+                SetActiveItem(item);
                 return;
             }
-
-            var val = _searchItems.GetAllItems().FirstOrDefault(i => Equals(i.Value, _activeItem.Value));
-            if (val == null)
-            {
-                StateHasChanged();
-                return;
-            }
-
-            _activeItem = val;
-            SetActiveItem(val.Value);
         }
+
+        StateHasChanged();
     }
 
-    private Task OnClickResetSearch()
+    private async Task OnClickResetSearch()
     {
         _searchText = null;
-        _searchItems = null;
-        _rows = null;
-        if (_activeItem != null && Items != null)
-        {
-            SetActiveItem(_activeItem.Value);
-        }
-        else
-        {
-            StateHasChanged();
-        }
-        return Task.CompletedTask;
+        await OnClickSearch();
     }
 
     /// <summary>

--- a/test/UnitTest/Components/SelectTreeTest.cs
+++ b/test/UnitTest/Components/SelectTreeTest.cs
@@ -235,7 +235,9 @@ public class SelectTreeTest : BootstrapBlazorTestBase
             builder.Add(a => a.OnSearchAsync, new Func<string?, Task<List<TreeViewItem<TreeFoo>>?>>(v =>
             {
                 key = v;
-                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>([new TreeViewItem<TreeFoo>(new TreeFoo()) { Text = v }]);
+                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>(string.IsNullOrEmpty(v)
+                    ? null
+                    : [new TreeViewItem<TreeFoo>(new TreeFoo()) { Text = v }]);
             }));
             builder.Add(a => a.Items, items);
         });

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -1513,7 +1513,9 @@ public class TreeViewTest : BootstrapBlazorTestBase
             pb.Add(a => a.OnSearchAsync, new Func<string?, Task<List<TreeViewItem<TreeFoo>>?>>(v =>
             {
                 key = v;
-                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>([new TreeViewItem<TreeFoo>(new TreeFoo()) { Text = v }]);
+                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>(string.IsNullOrEmpty(v)
+                    ? null
+                    : [new TreeViewItem<TreeFoo>(new TreeFoo()) { Text = v }]);
             }));
             pb.Add(a => a.Items, items);
         });
@@ -1651,11 +1653,18 @@ public class TreeViewTest : BootstrapBlazorTestBase
     {
         var items = TreeFoo.GetTreeItems();
         List<TreeViewItem<TreeFoo>>? searchResult = [items[0]];
+        var searchCount = 0;
+        string? searchText = string.Empty;
         var cut = Context.Render<TreeView<TreeFoo>>(pb =>
         {
             pb.Add(a => a.ShowSearch, true);
             pb.Add(a => a.Items, items);
-            pb.Add(a => a.OnSearchAsync, _ => Task.FromResult(searchResult));
+            pb.Add(a => a.OnSearchAsync, text =>
+            {
+                searchCount++;
+                searchText = text;
+                return Task.FromResult<List<TreeViewItem<TreeFoo>>?>(searchResult);
+            });
         });
         var input = cut.FindComponent<BootstrapInput<string?>>();
 
@@ -1669,6 +1678,8 @@ public class TreeViewTest : BootstrapBlazorTestBase
 
         await cut.InvokeAsync(() => input.Instance.OnEscAsync!(string.Empty));
         Assert.Equal(9, cut.FindAll(".tree-content").Count);
+        Assert.Equal(3, searchCount);
+        Assert.Null(searchText);
 
         cut.Render(pb =>
         {

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -1586,25 +1586,26 @@ public class TreeViewTest : BootstrapBlazorTestBase
 
         var checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
         await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
-        Assert.Single(checkedItems!);
+        Assert.NotNull(checkedItems);
+        Assert.Single(checkedItems);
         Assert.Equal(items[0].Value.Id, checkedItems[0].Value.Id);
         Assert.Equal(CheckboxState.Checked, items[0].CheckedState);
 
         await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
-        Assert.Empty(checkedItems!);
+        Assert.Empty(checkedItems);
         Assert.Equal(CheckboxState.UnChecked, items[0].CheckedState);
 
         searchItems = [new(new TreeFoo { Id = "NotFound", Text = "NotFound" }) { Text = "NotFound" }];
         await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
         checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
         await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
-        Assert.Empty(checkedItems!);
+        Assert.Empty(checkedItems);
 
         searchItems = [items[0]];
         await cut.InvokeAsync(() => input.Instance.OnEnterAsync!(string.Empty));
         checkbox = cut.FindComponent<Checkbox<TreeViewItem<TreeFoo>>>();
         await cut.InvokeAsync(checkbox.Instance.OnToggleClick);
-        Assert.Single(checkedItems!);
+        Assert.Single(checkedItems);
         Assert.Same(items[0], checkedItems[0]);
     }
 


### PR DESCRIPTION
## Link issues
fixes #8297 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Refine TreeView search and reset behavior to support null search terms and maintain active item selection after searches are cleared.

New Features:
- Add hierarchical search helper for TreeView samples that filters and clones tree nodes while preserving parent-child structure.

Bug Fixes:
- Ensure TreeView reset search action re-invokes the search callback with a null term to clear results consistently.
- Prevent search callbacks from returning non-null results on empty search terms in TreeView and SelectTree tests.

Enhancements:
- Make sample TreeView search item collections non-nullable and improve active item restoration logic when applying search results.
- Adjust TreeView search callback documentation to describe behavior on search reset.

Tests:
- Update TreeView and SelectTree unit tests to validate search callbacks are invoked with null on reset and that search counts and results are correct.