### PR TITLE
feat(Dom2Image): update SnapDOM version to 2.24.0

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.DockView" Version="10.0.23" />
-    <PackageReference Include="BootstrapBlazor.Dom2Image" Version="10.0.1" />
+    <PackageReference Include="BootstrapBlazor.Dom2Image" Version="10.0.2" />
     <PackageReference Include="BootstrapBlazor.DriverJs" Version="10.0.3" />
     <PackageReference Include="BootstrapBlazor.ElementIcon" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.EmbedPDF" Version="10.0.8" />

--- a/src/BootstrapBlazor.Server/Components/Samples/Dom2Images.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dom2Images.razor
@@ -16,6 +16,7 @@
 <DemoBlock Title="@Localizer["Dom2ImageNormalTitle"]" Introduction="@Localizer["Dom2ImageNormalIntro"]" Name="Normal">
     <section ignore>
         <p>@((MarkupString)Localizer["Dom2ImageDesc"].Value)</p>
+        <p>@((MarkupString)Localizer["Dom2ImageExcludeTip"].Value)</p>
         <div>
             <Button OnClick="OnGetUrlAsync" Text="@Localizer["Dom2ImageButtonText"]" Icon="fa-solid fa-image"></Button>
             <Button OnClickWithoutRender="OnDownloadAsync" Text="@Localizer["Dom2ImageDownloadText"]" Icon="fa-solid fa-download"></Button>

--- a/src/BootstrapBlazor.Server/Components/Samples/Dom2Images.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Dom2Images.razor.cs
@@ -39,18 +39,27 @@ public partial class Dom2Images
 
     private async Task OnGetUrlAsync()
     {
-        _imageData = await Dom2ImageService.GetUrlAsync("#table-9527");
+        var options = GetDom2ImageOptions();
+        _imageData = await Dom2ImageService.GetUrlAsync("#table-9527", options);
     }
 
     private async Task OnDownloadAsync()
     {
         var fileName = $"table-9527-{DateTime.Now:HHmmss}";
-        await Dom2ImageService.DownloadAsync("#table-9527", fileName);
+        var options = GetDom2ImageOptions();
+        await Dom2ImageService.DownloadAsync("#table-9527", fileName, options: options);
     }
 
     private async Task OnFullAsync()
     {
         var fileName = $"full-{DateTime.Now:HHmmss}";
-        await Dom2ImageService.DownloadAsync(".tabs-body-content:not(.d-none)", fileName);
+        var options = GetDom2ImageOptions();
+        await Dom2ImageService.DownloadAsync(".tabs-body-content:not(.d-none)", fileName, options: options);
     }
+
+    private static Dom2ImageOptions GetDom2ImageOptions() => new()
+    {
+        // 排除表格 Header 中的筛选和排序图标，避免对齐问题
+        Exclude = new[] { ".filter-icon", ".sort-icon" }
+    };
 }

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2091,6 +2091,7 @@
     "Dom2ImageButtonText": "Convert",
     "Dom2ImageDesc": "Since the underlying framework uses <a href=\"https://github.com/zumerlab/snapdom?wt.mc_id=DT-MVP-5004174\" target=\"_blank\">SnapDOM</a> , if you encounter any problems during actual use, please refer to the project <a href=\"https://github.com/zumerlab/snapdom/issues?wt.mc_id=DT-MVP-5004174\" target=\"_blank\">Issue</a>",
     "Dom2ImageDownloadText": "Download",
+    "Dom2ImageExcludeTip": "In this example, set <code>Exclude</code> to filter out the icons in the table header",
     "Dom2ImageFullText": "Capture",
     "Dom2ImageIntro": "Export HTML snippets as images",
     "Dom2ImageNormalIntro": "Convert the node to an image by specifying a <code>Selector</code>",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2091,6 +2091,7 @@
     "Dom2ImageButtonText": "转换",
     "Dom2ImageDesc": "由于底层使用的是 <a href=\"https://github.com/zumerlab/snapdom?wt.mc_id=DT-MVP-5004174\" target=\"_blank\">SnapDOM</a> 实际使用过程中遇到问题请参考项目 <a href=\"https://github.com/zumerlab/snapdom/issues?wt.mc_id=DT-MVP-5004174\" target=\"_blank\">Issue</a>",
     "Dom2ImageDownloadText": "下载",
+    "Dom2ImageExcludeTip": "本例中，通过设置 <code>Exclude</code> 过滤掉表头上的图标",
     "Dom2ImageFullText": "长截图",
     "Dom2ImageIntro": "将 Html 片段导出为图片",
     "Dom2ImageNormalIntro": "通过指定 <code>Selector</code> 将此节点转成图片",


### PR DESCRIPTION
## Link issues
fixes #8315 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Update Dom2Image sample to use configurable options when generating images, aligned with the upgraded SnapDOM version.

New Features:
- Allow Dom2Image operations in the sample to exclude specific DOM elements (e.g., filter and sort icons) when generating images.

Enhancements:
- Add localized explanatory text to the Dom2Image demo about excluding elements from captured images.
- Update project configuration to reference the newer SnapDOM/Dom2Image-related version and align localization resources with the new options.