### PR TITLE
feat(Hub): use pagehide event instead of unload

### DIFF
--- a/src/BootstrapBlazor/wwwroot/modules/hub.js
+++ b/src/BootstrapBlazor/wwwroot/modules/hub.js
@@ -1,4 +1,4 @@
-﻿import { getClientInfo } from "./client.js"
+import { getClientInfo } from "./client.js"
 import Data from "./data.js"
 import EventHandler from "./event-handler.js";
 
@@ -55,7 +55,7 @@ export async function init(id, options) {
         await callback();
     }, interval);
 
-    window.addEventListener('unload', () => {
+    EventHandler.on(window, 'pagehide', () => {
         dispose(id);
     });
 
@@ -67,6 +67,7 @@ export async function dispose(id) {
     const hub = Data.get(id);
 
     if (hub) {
+        EventHandler.off(window, 'pagehide');
         clearInterval(hub.handler);
         hub.chanel.postMessage({ id, type: 'dispose' });
         hub.chanel.close();


### PR DESCRIPTION
## Link issues
fixes #8317 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Use the pagehide event via the shared EventHandler utility to dispose hub instances when the page is hidden, and ensure the handler is removed during hub disposal.

Bug Fixes:
- Prevent potential issues with relying on the unload event by switching hub cleanup to the more reliable pagehide event and unregistering the handler on dispose.

Enhancements:
- Align hub lifecycle handling with the centralized EventHandler system instead of directly attaching unload listeners to window.