### PR TITLE
test(ContxtMenu): prevent failed unit test

### DIFF
--- a/test/UnitTest/Components/ContextMenuTest.cs
+++ b/test/UnitTest/Components/ContextMenuTest.cs
@@ -7,7 +7,6 @@ using AngleSharp.Dom;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.Localization;
 using Microsoft.Extensions.Options;
-using System.Diagnostics;
 
 namespace UnitTest.Components;
 
@@ -175,8 +174,7 @@ public class ContextMenuTest : BootstrapBlazorTestBase
         });
 
         var element = cut.Find(".context-trigger");
-        var sw = Stopwatch.StartNew();
-        await element.TouchStartAsync(new TouchEventArgs
+        var touchStartTask = element.TouchStartAsync(new TouchEventArgs
         {
             Detail = 0,
             Touches = [new TouchPoint { ClientX = 10, ClientY = 10, ScreenX = 10, ScreenY = 10 }]
@@ -184,12 +182,13 @@ public class ContextMenuTest : BootstrapBlazorTestBase
 
         var trigger = cut.FindComponent<ContextMenuTrigger>().Instance;
         Assert.NotNull(trigger);
+        Assert.True(trigger.IsTouchStarted);
+        Assert.False(touchStartTask.IsCompleted);
 
+        await touchStartTask;
         Assert.True(trigger.IsTouchStarted);
         await cut.InvokeAsync(() => element.TouchEndAsync());
-        sw.Stop();
 
-        Assert.True(sw.ElapsedMilliseconds >= Delay * 2);
         Assert.False(trigger.IsTouchStarted);
     }
 


### PR DESCRIPTION
## Link issues
fixes #8324 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Tests:
- Update ContextMenu_TouchWithTimeout_Ok unit test to assert trigger state and async touch start completion instead of relying on Stopwatch timing.