### PR TITLE
fix(CardUpload): ensure validation tooltips are properly disposed

### DIFF
--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
@@ -51,7 +51,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString">
+    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString" hidden="@(!ShowAddButton())">
         <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
@@ -8,7 +8,7 @@
 }
 <div @attributes="@AdditionalAttributes" class="@ClassString" id="@Id" data-bb-previewer-id="@PreviewerId">
     <div class="upload-body is-avatar">
-        @if (IsUploadButtonAtFirst)
+        @if (IsUploadButtonAtFirst && ShowAddButton())
         {
             @RenderAdd
         }
@@ -37,7 +37,7 @@
                 }
             </div>
         }
-        @if (!IsUploadButtonAtFirst)
+        @if (!IsUploadButtonAtFirst && ShowAddButton())
         {
             @RenderAdd
         }
@@ -51,7 +51,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString" hidden="@(!ShowAddButton())">
+    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString">
         <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
@@ -51,7 +51,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString" hidden="@(!ShowAddButton())">
+    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString">
         <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor
@@ -8,7 +8,7 @@
 }
 <div @attributes="@AdditionalAttributes" class="@ClassString" id="@Id" data-bb-previewer-id="@PreviewerId">
     <div class="upload-body is-avatar">
-        @if (IsUploadButtonAtFirst && ShowAddButton())
+        @if (IsUploadButtonAtFirst)
         {
             @RenderAdd
         }
@@ -37,7 +37,7 @@
                 }
             </div>
         }
-        @if (!IsUploadButtonAtFirst && ShowAddButton())
+        @if (!IsUploadButtonAtFirst)
         {
             @RenderAdd
         }
@@ -51,7 +51,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString">
+    @<div id="@AddId" class="@GetItemClassString("upload-item-plus upload-drop-body btn-browser")" style="@ItemStyleString" hidden="@(!ShowAddButton())">
         <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
@@ -199,8 +199,7 @@ public partial class AvatarUpload<TValue>
             ? [AddId]
             : Files.Select(i => i.ValidateId).ToList();
         var invalidItems = _results.GetInvalidItems(IsInValidOnAddItem, AddId);
-        var addId = IsInValidOnAddItem ? null : AddId;
-        await ValidateModule.InvokeVoidAsync("executeUpload", items, invalidItems, addId);
+        await ValidateModule.InvokeVoidAsync("executeUpload", items, invalidItems, AddId);
     }
 
     private bool IsInValidOnAddItem => Files.Count == 0 && _results.Count > 0;

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
@@ -107,6 +107,7 @@ public partial class AvatarUpload<TValue>
         .AddClass(classString)
         .AddClass("is-circle", IsCircle)
         .AddClass("disabled", IsDisabled)
+        .AddClass("d-none", classString == null && !ShowAddButton())
         .Build();
 
     private string? ItemStyleString => CssBuilder.Default()

--- a/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/AvatarUpload.razor.cs
@@ -107,7 +107,6 @@ public partial class AvatarUpload<TValue>
         .AddClass(classString)
         .AddClass("is-circle", IsCircle)
         .AddClass("disabled", IsDisabled)
-        .AddClass("d-none", classString == null && !ShowAddButton())
         .Build();
 
     private string? ItemStyleString => CssBuilder.Default()

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor
@@ -116,6 +116,6 @@
 @code {
     RenderFragment RenderAdd =>
     @<div id="@AddId" class="@CardItemClass">
-            <i class="@AddIcon"></i>
+        <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor
@@ -8,7 +8,7 @@
 }
 <div @attributes="@AdditionalAttributes" class="@ClassString" id="@Id" data-bb-previewer-id="@PreviewerId">
     <div class="@BodyClassString">
-        @if (IsUploadButtonAtFirst)
+        @if (IsUploadButtonAtFirst && ShowAddButton())
         {
             @RenderAdd
         }
@@ -101,7 +101,7 @@
                 </span>
             </div>
         }
-        @if (!IsUploadButtonAtFirst)
+        @if (!IsUploadButtonAtFirst && ShowAddButton())
         {
             @RenderAdd
         }
@@ -115,7 +115,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@CardItemClass" hidden="@(!ShowAddButton())">
-        <i class="@AddIcon"></i>
+    @<div id="@AddId" class="@CardItemClass">
+            <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor
@@ -115,7 +115,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@CardItemClass">
+    @<div id="@AddId" class="@CardItemClass" hidden="@(!ShowAddButton())">
         <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor
@@ -115,7 +115,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@CardItemClass" hidden="@(!ShowAddButton())">
+    @<div id="@AddId" class="@CardItemClass">
         <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor
@@ -8,7 +8,7 @@
 }
 <div @attributes="@AdditionalAttributes" class="@ClassString" id="@Id" data-bb-previewer-id="@PreviewerId">
     <div class="@BodyClassString">
-        @if (IsUploadButtonAtFirst && ShowAddButton())
+        @if (IsUploadButtonAtFirst)
         {
             @RenderAdd
         }
@@ -101,7 +101,7 @@
                 </span>
             </div>
         }
-        @if (!IsUploadButtonAtFirst && ShowAddButton())
+        @if (!IsUploadButtonAtFirst)
         {
             @RenderAdd
         }
@@ -115,7 +115,7 @@
 
 @code {
     RenderFragment RenderAdd =>
-    @<div id="@AddId" class="@CardItemClass">
-            <i class="@AddIcon"></i>
+    @<div id="@AddId" class="@CardItemClass" hidden="@(!ShowAddButton())">
+        <i class="@AddIcon"></i>
     </div>;
 }

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
@@ -260,8 +260,7 @@ public partial class CardUpload<TValue>
             ? [AddId]
             : Files.Select(i => i.ValidateId).ToList();
         var invalidItems = _results.GetInvalidItems(IsInValidOnAddItem, AddId);
-        var addId = IsInValidOnAddItem ? null : AddId;
-        await ValidateModule.InvokeVoidAsync("executeUpload", items, invalidItems, addId);
+        await ValidateModule.InvokeVoidAsync("executeUpload", items, invalidItems, AddId);
     }
 
     private bool IsInValidOnAddItem => Files.Count == 0 && _results.Count > 0;

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
@@ -41,6 +41,7 @@ public partial class CardUpload<TValue>
 
     private string? CardItemClass => CssBuilder.Default("upload-item upload-item-plus btn-browser upload-drop-body")
         .AddClass("disabled", IsDisabled)
+        .AddClass("d-none", !ShowAddButton())
         .Build();
 
     private string? StatusIconString => CssBuilder.Default("valid-icon valid")

--- a/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
+++ b/src/BootstrapBlazor/Components/Upload/CardUpload.razor.cs
@@ -41,7 +41,6 @@ public partial class CardUpload<TValue>
 
     private string? CardItemClass => CssBuilder.Default("upload-item upload-item-plus btn-browser upload-drop-body")
         .AddClass("disabled", IsDisabled)
-        .AddClass("d-none", !ShowAddButton())
         .Build();
 
     private string? StatusIconString => CssBuilder.Default("valid-icon valid")

--- a/src/BootstrapBlazor/wwwroot/modules/validate.js
+++ b/src/BootstrapBlazor/wwwroot/modules/validate.js
@@ -28,8 +28,11 @@ const showResult = el => {
 }
 
 export function dispose(id) {
-    const el = document.getElementById(id)
+    const el = document.getElementById(id);
+    disposeTip(el);
+}
 
+const disposeTip = el => {
     if (el) {
         const tip = bootstrap.Tooltip.getInstance(el)
         if (tip) {

--- a/src/BootstrapBlazor/wwwroot/modules/validate.js
+++ b/src/BootstrapBlazor/wwwroot/modules/validate.js
@@ -1,8 +1,9 @@
-﻿export function execute(id, title) {
+export function execute(id, title) {
     const el = document.getElementById(id);
 
     if (el) {
         const tip = bootstrap.Tooltip.getOrCreateInstance(el, { customClass: 'is-invalid', title })
+        tooltipCache.set(id, tip); // 缓存实例
         if (!tip._isShown()) {
             if (title !== tip._config.title) {
                 tip._config.title = title;
@@ -27,6 +28,8 @@ const showResult = el => {
     return ret;
 }
 
+const tooltipCache = new Map(); // 全局缓存池，用来处理上传时增加按钮未渲染，导致提示不能正确删除
+
 export function dispose(id) {
     const el = document.getElementById(id)
 
@@ -34,6 +37,14 @@ export function dispose(id) {
         const tip = bootstrap.Tooltip.getInstance(el)
         if (tip) {
             tip.dispose()
+            tooltipCache.delete(id); // 清理缓存
+        }
+    }
+    else {
+        const cachedTip = tooltipCache.get(id);
+        if (cachedTip) {
+            cachedTip.dispose();
+            tooltipCache.delete(id);
         }
     }
 }

--- a/src/BootstrapBlazor/wwwroot/modules/validate.js
+++ b/src/BootstrapBlazor/wwwroot/modules/validate.js
@@ -1,3 +1,5 @@
+import Data from "./data.js"
+
 export function execute(id, title) {
     const el = document.getElementById(id);
 
@@ -29,10 +31,6 @@ const showResult = el => {
 
 export function dispose(id) {
     const el = document.getElementById(id);
-    disposeTip(el);
-}
-
-const disposeTip = el => {
     if (el) {
         const tip = bootstrap.Tooltip.getInstance(el)
         if (tip) {
@@ -51,20 +49,41 @@ export function executeUpload(items, invalidItems, addId) {
                 execute(id, errorMessage);
                 el.classList.remove('is-valid');
                 el.classList.add('is-invalid');
+
+                if (id === addId) {
+                    const tip = bootstrap.Tooltip.getInstance(el);
+                    if (tip) {
+                        Data.set(addId, tip);
+                        addId = null;
+                    }
+                }
             }
             else {
                 dispose(id);
                 el.classList.remove('is-invalid');
                 el.classList.add('is-valid');
+
+                disposeTip(addId);
+                addId = null;
             }
         }
     });
 
     if (addId) {
-        const el = document.getElementById(addId);
+        disposeTip(addId);
+    }
+}
+
+const disposeTip = id => {
+    const tip = Data.get(id);
+    Data.remove(id);
+
+    if (tip) {
+        tip.dispose();
+
+        const el = document.getElementById(id);
         if (el) {
-            el.classList.remove('is-valid', 'is-invalid');
-            dispose(addId);
+            el.classList.remove('is-invalid');
         }
     }
 }

--- a/src/BootstrapBlazor/wwwroot/modules/validate.js
+++ b/src/BootstrapBlazor/wwwroot/modules/validate.js
@@ -2,8 +2,7 @@ export function execute(id, title) {
     const el = document.getElementById(id);
 
     if (el) {
-        const tip = bootstrap.Tooltip.getOrCreateInstance(el, { customClass: 'is-invalid', title })
-        tooltipCache.set(id, tip); // 缓存实例
+        const tip = bootstrap.Tooltip.getOrCreateInstance(el, { customClass: 'is-invalid', title });
         if (!tip._isShown()) {
             if (title !== tip._config.title) {
                 tip._config.title = title;
@@ -28,8 +27,6 @@ const showResult = el => {
     return ret;
 }
 
-const tooltipCache = new Map(); // 全局缓存池，用来处理上传时增加按钮未渲染，导致提示不能正确删除
-
 export function dispose(id) {
     const el = document.getElementById(id)
 
@@ -37,14 +34,6 @@ export function dispose(id) {
         const tip = bootstrap.Tooltip.getInstance(el)
         if (tip) {
             tip.dispose()
-            tooltipCache.delete(id); // 清理缓存
-        }
-    }
-    else {
-        const cachedTip = tooltipCache.get(id);
-        if (cachedTip) {
-            cachedTip.dispose();
-            tooltipCache.delete(id);
         }
     }
 }


### PR DESCRIPTION
fix：修正CardUpload、AvatarUpload这两个组件表单验证时，这两个组件上已正确上传文件，提示信息不能正确移除的Bug

## Link issues
fixes #8329

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Bug Fixes:
- Ensure validation tooltips are properly disposed when uploaded files make CardUpload and AvatarUpload validation errors obsolete.