### PR TITLE
feat(Tab): add OnActiveTabItemChanged parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
+++ b/src/BootstrapBlazor/Components/Tab/Tab.razor.cs
@@ -19,6 +19,8 @@ public partial class Tab
 {
     private bool FirstRender { get; set; } = true;
 
+    private TabItem? _activeTabItem;
+
     private string? WrapClassString => CssBuilder.Default("tabs-nav-wrap")
         .AddClass("extend", ShouldShowExtendButtons())
         .Build();
@@ -248,6 +250,13 @@ public partial class Tab
     /// </summary>
     [Parameter]
     public Func<TabItem, Task>? OnClickTabItemAsync { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置 当前激活标签变化时的回调方法</para>
+    /// <para lang="en">Gets or sets the callback when the active tab changes</para>
+    /// </summary>
+    [Parameter]
+    public Func<TabItem?, Task>? OnActiveTabItemChanged { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 关闭当前 TabItem 菜单文本</para>
@@ -725,8 +734,7 @@ public partial class Tab
 
         if (!ClickTabToNavigation)
         {
-            TabItems.ForEach(i => i.SetActive(false));
-            item.SetActive(true);
+            ActiveTabItem(item);
             InvokeUpdate = true;
             StateHasChanged();
         }
@@ -744,32 +752,19 @@ public partial class Tab
             var index = TabItems.IndexOf(item);
             if (index > -1)
             {
-                index--;
-                if (index < 0)
+                item = TabItems.Take(index).LastOrDefault(i => !i.IsDisabled)
+                    ?? (IsLoopSwitchTabItem ? TabItems.Skip(index + 1).LastOrDefault(i => !i.IsDisabled) : null);
+                if (item == null)
                 {
-                    if (IsLoopSwitchTabItem)
-                    {
-                        index = TabItems.Count - 1;
-                    }
-                    else
-                    {
-                        return;
-                    }
+                    return;
                 }
-
-                if (!ClickTabToNavigation)
-                {
-                    item.SetActive(false);
-                }
-
-                item = TabItems[index];
                 if (ClickTabToNavigation)
                 {
                     Navigator.NavigateTo(item.Url);
                 }
                 else
                 {
-                    item.SetActive(true);
+                    ActiveTabItem(item);
                     InvokeUpdate = true;
                 }
             }
@@ -786,35 +781,21 @@ public partial class Tab
         if (item != null)
         {
             var index = TabItems.IndexOf(item);
-            if (index < TabItems.Count)
+            if (index > -1)
             {
-                index++;
-                if (index + 1 > TabItems.Count)
+                item = TabItems.Skip(index + 1).FirstOrDefault(i => !i.IsDisabled)
+                    ?? (IsLoopSwitchTabItem ? TabItems.Take(index).FirstOrDefault(i => !i.IsDisabled) : null);
+                if (item == null)
                 {
-                    if (IsLoopSwitchTabItem)
-                    {
-                        index = 0;
-                    }
-                    else
-                    {
-                        return;
-                    }
+                    return;
                 }
-
-                if (!ClickTabToNavigation)
-                {
-                    item.SetActive(false);
-                }
-
-                item = TabItems[index];
-
                 if (ClickTabToNavigation)
                 {
                     Navigator.NavigateTo(item.Url);
                 }
                 else
                 {
-                    item.SetActive(true);
+                    ActiveTabItem(item);
                     InvokeUpdate = true;
                 }
             }
@@ -843,8 +824,12 @@ public partial class Tab
             if (activeItem == null)
             {
                 activeItem = TabItems[0];
-                activeItem.SetActive(true);
+                ActiveTabItem(activeItem);
             }
+        }
+        else
+        {
+            SynchronizeActiveTabItem();
         }
         InvokeUpdate = true;
     }
@@ -880,7 +865,11 @@ public partial class Tab
     /// <para lang="en">Add TabItem method. Called by TabItem</para>
     /// </summary>
     /// <param name="item"><para lang="zh">TabItemBase 实例</para><para lang="en">TabItemBase instance</para></param>
-    internal void AddItem(TabItem item) => TabItems.Add(item);
+    internal void AddItem(TabItem item)
+    {
+        TabItems.Add(item);
+        SynchronizeActiveTabItem();
+    }
 
     /// <summary>
     /// <para lang="zh">通过 Url 添加 TabItem 标签方法</para>
@@ -986,10 +975,6 @@ public partial class Tab
     {
         var item = TabItem.Create(parameters);
         item.TabSet = this;
-        if (item.IsActive)
-        {
-            TabItems.ForEach(i => i.SetActive(false));
-        }
 
         if (index.HasValue)
         {
@@ -998,6 +983,11 @@ public partial class Tab
         else
         {
             TabItems.Add(item);
+        }
+
+        if (item.IsActive)
+        {
+            ActiveTabItem(item);
         }
     }
 
@@ -1022,7 +1012,8 @@ public partial class Tab
         // 删除的 TabItem 是当前 Tab
         // 查找后面的 Tab
         var activeItem = TabItems.Find(i => i.IsActive)
-                         ?? (index < TabItems.Count ? TabItems[index] : TabItems.LastOrDefault());
+                         ?? TabItems.Skip(index).FirstOrDefault(i => !i.IsDisabled)
+                         ?? TabItems.Take(index).LastOrDefault(i => !i.IsDisabled);
         if (activeItem != null)
         {
             if (ClickTabToNavigation)
@@ -1031,13 +1022,14 @@ public partial class Tab
             }
             else
             {
-                activeItem.SetActive(true);
+                ActiveTabItem(activeItem);
                 StateHasChanged();
             }
         }
         else
         {
             // 无标签
+            SynchronizeActiveTabItem();
             StateHasChanged();
         }
     }
@@ -1074,10 +1066,32 @@ public partial class Tab
     /// </summary>
     public TabItem? GetActiveTab() => TabItems.Find(s => s.IsActive);
 
-    private void ActiveTabItem(TabItem item)
+    private void ActiveTabItem(TabItem? item)
     {
+        if (item != null && (item.IsDisabled || !TabItems.Contains(item)))
+        {
+            return;
+        }
+
         TabItems.ForEach(i => i.SetActive(false));
-        item.SetActive(true);
+        item?.SetActive(true);
+        NotifyActiveTabChanged(item);
+    }
+
+    private void SynchronizeActiveTabItem() => NotifyActiveTabChanged(GetActiveTab());
+
+    private void NotifyActiveTabChanged(TabItem? item)
+    {
+        if (ReferenceEquals(item, _activeTabItem))
+        {
+            return;
+        }
+        _activeTabItem = item;
+
+        if (OnActiveTabItemChanged != null)
+        {
+            _ = OnActiveTabItemChanged(item);
+        }
     }
 
     /// <summary>
@@ -1088,6 +1102,12 @@ public partial class Tab
     /// <param name="disabled"></param>
     public void SetDisabledItem(TabItem item, bool disabled)
     {
+        var index = TabItems.IndexOf(item);
+        if (index < 0)
+        {
+            return;
+        }
+
         item.SetDisabledWithoutRender(disabled);
         if (disabled)
         {
@@ -1095,8 +1115,10 @@ public partial class Tab
         }
         if (TabItems.Find(i => i.IsActive) == null)
         {
-            var tabItem = TabItems.Find(i => !i.IsDisabled);
-            tabItem?.SetActive(true);
+            var tabItem = disabled
+                ? TabItems.Skip(index + 1).FirstOrDefault(i => !i.IsDisabled) ?? TabItems.Take(index).LastOrDefault(i => !i.IsDisabled)
+                : item;
+            ActiveTabItem(tabItem);
         }
         StateHasChanged();
     }
@@ -1262,8 +1284,12 @@ public partial class Tab
                 var item = TabItems.Find(i => i.IsDisabled == false);
                 if (item != null)
                 {
-                    item.SetActive(true);
+                    ActiveTabItem(item);
                 }
+            }
+            else
+            {
+                SynchronizeActiveTabItem();
             }
         }
 

--- a/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
+++ b/src/BootstrapBlazor/Components/Tab/TabItemContent.cs
@@ -7,7 +7,7 @@ using Microsoft.AspNetCore.Components.Rendering;
 
 namespace BootstrapBlazor.Components;
 
-class TabItemContent : IComponent
+internal class TabItemContent : IComponent
 {
     /// <summary>
     /// <para lang="zh">获得/设置 标签项，默认为 null</para>

--- a/src/BootstrapBlazor/Extensions/TabItemExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/TabItemExtensions.cs
@@ -8,28 +8,31 @@ using System.Collections.Concurrent;
 namespace BootstrapBlazor.Components;
 
 /// <summary>
-/// <para lang="zh">TabItem Extension</para>
+/// <para lang="zh">TabItem 扩展方法</para>
 /// <para lang="en">TabItem Extension</para>
 /// </summary>
 internal static class TabItemExtensions
 {
-    public static RenderFragment RenderContent(this TabItem item, ConcurrentDictionary<TabItem, TabItemContent> cache) => builder =>
+    extension(TabItem item)
     {
-        builder.OpenComponent<TabItemContent>(0);
-        builder.AddAttribute(10, nameof(TabItemContent.Item), item);
-        builder.AddComponentReferenceCapture(20, content =>
+        public RenderFragment RenderContent(ConcurrentDictionary<TabItem, TabItemContent> cache) => builder =>
         {
-            var tabItemContent = (TabItemContent)content;
-            cache.AddOrUpdate(item, tabItemContent, (_, _) => tabItemContent);
-        });
-        builder.CloseComponent();
-    };
+            builder.OpenComponent<TabItemContent>(0);
+            builder.AddAttribute(10, nameof(TabItemContent.Item), item);
+            builder.AddComponentReferenceCapture(20, content =>
+            {
+                var tabItemContent = (TabItemContent)content;
+                cache.AddOrUpdate(item, tabItemContent, (_, _) => tabItemContent);
+            });
+            builder.CloseComponent();
+        };
 
-    public static void Refresh(this TabItem item, ConcurrentDictionary<TabItem, TabItemContent> cache)
-    {
-        if (cache.TryGetValue(item, out var content))
+        public void Refresh(ConcurrentDictionary<TabItem, TabItemContent> cache)
         {
-            content.Render();
+            if (cache.TryGetValue(item, out var content))
+            {
+                content.Render();
+            }
         }
     }
 }

--- a/test/UnitTest/Components/TabTest.cs
+++ b/test/UnitTest/Components/TabTest.cs
@@ -323,6 +323,32 @@ public class TabTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task CloseAllTabs_Ok()
+    {
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.ShowExtendButtons, true);
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab1");
+                pb.Add(a => a.Url, "/Index");
+                pb.Add(a => a.ChildContent, "Tab1-Content");
+                pb.Add(a => a.Closable, true);
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.Url, "/");
+                pb.Add(a => a.ChildContent, "Tab2-Content");
+                pb.Add(a => a.Closable, true);
+            });
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.CloseAllTabs());
+        Assert.Empty(cut.Instance.Items);
+    }
+
+    [Fact]
     public void AddTab_Ok()
     {
         var cut = Context.Render<Tab>(pb =>
@@ -534,6 +560,53 @@ public class TabTest : BootstrapBlazorTestBase
     {
         var cut = Context.Render<TabItem>();
         cut.Instance.SetDisabled(true);
+    }
+
+    [Fact]
+    public async Task SetDisabledItem_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+        var items = cut.Instance.Items.ToList();
+
+        await cut.InvokeAsync(() => cut.Instance.SetDisabledItem(new TabItem(), false));
+        await cut.InvokeAsync(() => items[1].SetDisabled(true));
+        await cut.InvokeAsync(cut.Instance.ClickNextTab);
+        Assert.Same(items[2], cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(cut.Instance.ClickPrevTab);
+        Assert.Same(items[0], cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(items[1]));
+        Assert.Same(items[0], cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(() => items[1].SetDisabled(false));
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(items[1]));
+        await cut.InvokeAsync(() => items[1].SetDisabled(true));
+        Assert.Same(items[2], cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(() => items[2].SetDisabled(true));
+        Assert.Same(items[0], cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(() => items[0].SetDisabled(true));
+        Assert.Null(cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(() => items[1].SetDisabled(false));
+        Assert.Same(items[1], cut.Instance.GetActiveTab());
+
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(new TabItem()));
+        Assert.Same(items[1], cut.Instance.GetActiveTab());
+        Assert.Equal(["Tab1", "Tab3", "Tab1", "Tab2", "Tab3", "Tab1", null, "Tab2"], changedItems.Select(i => i?.Text));
     }
 
     [Fact]
@@ -750,6 +823,109 @@ public class TabTest : BootstrapBlazorTestBase
         });
         cut.Contains("Tab1-Content");
         cut.Contains("Tab2-Content");
+    }
+
+    [Fact]
+    public async Task ActiveTabItemChanged_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab1");
+                pb.Add(a => a.ChildContent, "Tab1-Content");
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.ChildContent, "Tab2-Content");
+            });
+        });
+
+        Assert.Equal(["Tab1"], changedItems.Select(i => i?.Text));
+
+        var items = cut.FindAll(".tabs-item");
+        await cut.InvokeAsync(() => items[1].Click());
+        Assert.Equal("Tab2", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab1", "Tab2"], changedItems.Select(i => i?.Text));
+
+        await cut.InvokeAsync(() => cut.FindAll(".tabs-item")[1].Click());
+        Assert.Equal(["Tab1", "Tab2"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task ActiveTabItemChanged_EmptyAndDisabled()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab1");
+                pb.Add(a => a.ChildContent, "Tab1-Content");
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.ChildContent, "Tab2-Content");
+            });
+        });
+
+        Assert.Equal(["Tab1"], changedItems.Select(i => i?.Text));
+
+        var firstItem = cut.Instance.Items.First();
+        await cut.InvokeAsync(() => firstItem.SetDisabled(true));
+        Assert.Equal(["Tab1", "Tab2"], changedItems.Select(i => i?.Text));
+
+        var activeItem = cut.Instance.GetActiveTab();
+        Assert.NotNull(activeItem);
+        await cut.InvokeAsync(() => cut.Instance.RemoveTab(activeItem));
+        Assert.Null(cut.Instance.GetActiveTab());
+        Assert.Equal(new string?[] { "Tab1", "Tab2", null }, changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task ActiveTabItemChanged_CollectionOrderChanged()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab1");
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+        });
+        var activeItem = cut.Instance.GetActiveTab();
+        changedItems.Clear();
+
+        await cut.InvokeAsync(() => cut.Instance.AddTab(new Dictionary<string, object?>
+        {
+            [nameof(TabItem.Text)] = "Inserted",
+            [nameof(TabItem.Url)] = "Inserted"
+        }, 0));
+        Assert.Same(activeItem, cut.Instance.GetActiveTab());
+        Assert.Empty(changedItems);
+
+        await cut.InvokeAsync(() => cut.Instance.DragItemCallback(1, 2));
+        Assert.Same(activeItem, cut.Instance.GetActiveTab());
+        Assert.Empty(changedItems);
     }
 
     [Fact]
@@ -1182,6 +1358,381 @@ public class TabTest : BootstrapBlazorTestBase
         cut.Contains("Localized-Cat");
     }
 
+    [Fact]
+    public async Task ClickPrevTab_WithDisabledTabs_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.IsDisabled, true);
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 激活 Tab3
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(items[2]));
+        Assert.Equal("Tab3", cut.Instance.GetActiveTab()?.Text);
+
+        // ClickPrev 应该跳过禁用的 Tab2，激活 Tab1
+        await cut.InvokeAsync(() => cut.Instance.ClickPrevTab());
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab3", "Tab1"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task ClickNextTab_WithDisabledTabs_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.IsDisabled, true);
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+
+        changedItems.Clear();
+
+        // 当前是 Tab1，ClickNext 应该跳过禁用的 Tab2，激活 Tab3
+        await cut.InvokeAsync(() => cut.Instance.ClickNextTab());
+        Assert.Equal("Tab3", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab3"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task ClickPrevTab_AllDisabled_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 禁用除当前激活外的所有 Tab
+        await cut.InvokeAsync(() => items[1].SetDisabled(true));
+
+        // ClickPrev 应该无效（无可用 Tab）
+        await cut.InvokeAsync(() => cut.Instance.ClickPrevTab());
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Empty(changedItems);
+    }
+
+    [Fact]
+    public async Task ClickNextTab_AllDisabled_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 禁用除当前激活外的所有 Tab
+        await cut.InvokeAsync(() => items[1].SetDisabled(true));
+
+        // ClickNext 应该无效（无可用 Tab）
+        await cut.InvokeAsync(() => cut.Instance.ClickNextTab());
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Empty(changedItems);
+    }
+
+    [Fact]
+    public async Task ClickPrevTab_LoopMode_WithDisabled_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.IsLoopSwitchTabItem, true);
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab1");
+                pb.Add(a => a.IsDisabled, true);
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+
+        changedItems.Clear();
+
+        // 当前是 Tab2，ClickPrev 应该跳过禁用的 Tab1，循环到 Tab3
+        await cut.InvokeAsync(() => cut.Instance.ClickPrevTab());
+        Assert.Equal("Tab3", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab3"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task ClickNextTab_LoopMode_WithDisabled_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.IsLoopSwitchTabItem, true);
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab3");
+                pb.Add(a => a.IsDisabled, true);
+            });
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 激活 Tab2
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(items[1]));
+        changedItems.Clear();
+
+        // ClickNext 应该跳过禁用的 Tab3，循环到 Tab1
+        await cut.InvokeAsync(() => cut.Instance.ClickNextTab());
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab1"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task AddTabItem_WithIsActiveTrue_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+        });
+
+        changedItems.Clear();
+
+        // 添加一个 IsActive=true 的新 Tab
+        await cut.InvokeAsync(() => cut.Instance.AddTab(new Dictionary<string, object?>
+        {
+            [nameof(TabItem.Text)] = "Tab2",
+            [nameof(TabItem.Url)] = "Tab2",
+            [nameof(TabItem.IsActive)] = true
+        }));
+
+        Assert.Equal("Tab2", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab2"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task ActiveTabItem_WithDisabledItem_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.IsDisabled, true);
+            });
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 尝试激活被禁用的 Tab，应该失败
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(items[1]));
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Empty(changedItems);
+    }
+
+    [Fact]
+    public async Task ActiveTabItem_WithNonExistentItem_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+        });
+
+        changedItems.Clear();
+
+        // 尝试激活不在集合中的 Tab，应该失败
+        var externalTab = new TabItem { Text = "External" };
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(externalTab));
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Empty(changedItems);
+    }
+
+    [Fact]
+    public async Task RemoveTab_ActivatesNextNonDisabled_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.IsDisabled, true);
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+
+        changedItems.Clear();
+
+        // 删除 Tab1（当前激活），应该跳过禁用的 Tab2，激活 Tab3
+        var activeItem = cut.Instance.GetActiveTab();
+        Assert.NotNull(activeItem);
+        await cut.InvokeAsync(() => cut.Instance.RemoveTab(activeItem));
+        Assert.Equal("Tab3", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab3"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task RemoveTab_ActivatesPreviousNonDisabled_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb =>
+            {
+                pb.Add(a => a.Text, "Tab2");
+                pb.Add(a => a.IsDisabled, true);
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 激活 Tab3
+        await cut.InvokeAsync(() => cut.Instance.ActiveTab(items[2]));
+        changedItems.Clear();
+
+        // 删除 Tab3，应该跳过禁用的 Tab2，激活 Tab1
+        await cut.InvokeAsync(() => cut.Instance.RemoveTab(items[2]));
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab1"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task SetDisabledItem_ReEnableWithNoActiveTab_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+        });
+
+        var items = cut.Instance.Items.ToList();
+        changedItems.Clear();
+
+        // 禁用所有 Tab
+        await cut.InvokeAsync(() => items[0].SetDisabled(true));
+        await cut.InvokeAsync(() => items[1].SetDisabled(true));
+        Assert.Null(cut.Instance.GetActiveTab());
+
+        // 重新启用 Tab1，应该自动激活它
+        await cut.InvokeAsync(() => items[0].SetDisabled(false));
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Equal(["Tab2", null, "Tab1"], changedItems.Select(i => i?.Text));
+    }
+
+    [Fact]
+    public async Task CloseOtherTabs_TriggersSync_Ok()
+    {
+        var changedItems = new List<TabItem?>();
+        var cut = Context.Render<Tab>(pb =>
+        {
+            pb.Add(a => a.OnActiveTabItemChanged, item =>
+            {
+                changedItems.Add(item);
+                return Task.CompletedTask;
+            });
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab1"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab2"));
+            pb.AddChildContent<TabItem>(pb => pb.Add(a => a.Text, "Tab3"));
+        });
+
+        changedItems.Clear();
+
+        // 关闭其他标签（保留当前激活的 Tab1）
+        await cut.InvokeAsync(() => cut.Instance.CloseOtherTabs());
+        Assert.Equal("Tab1", cut.Instance.GetActiveTab()?.Text);
+        Assert.Single(cut.Instance.Items);
+        // 由于激活 Tab 未变化（仍是 Tab1），不应触发回调
+        Assert.Empty(changedItems);
+    }
+
     class DisableTabItemButton : ComponentBase
     {
         [CascadingParameter, NotNull]
@@ -1211,4 +1762,5 @@ public class TabTest : BootstrapBlazorTestBase
 
         protected override void BuildRenderTree(RenderTreeBuilder builder) => builder.AddContent(0, _renderFragment);
     }
+
 }

--- a/test/UnitTest/Components/TimerTest.cs
+++ b/test/UnitTest/Components/TimerTest.cs
@@ -113,7 +113,13 @@ public class TimerTest : BootstrapBlazorTestBase
         var confirm = cut.Find(".time-panel-btn.confirm");
         await cut.InvokeAsync(() => confirm.Click());
 
-        await Task.Delay(2000, CancellationToken.None);
+        // 使用轮询等待，避免在并发测试时因固定等待时间不足而失败
+        var maxWaitTime = TimeSpan.FromSeconds(5);
+        var startTime = DateTime.Now;
+        while (!timeout && DateTime.Now - startTime < maxWaitTime)
+        {
+            await Task.Delay(100, CancellationToken.None);
+        }
         Assert.True(timeout);
     }
 


### PR DESCRIPTION
## Link issues
fixes #8331 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add an active-tab change callback to the Tab component and adjust tab activation/disabled-handling logic to keep the active tab state synchronized with this callback in all navigation and lifecycle operations.

New Features:
- Introduce an OnActiveTabItemChanged parameter on Tab to notify consumers whenever the active tab item changes.

Bug Fixes:
- Ensure previous/next tab navigation skips disabled tabs and respects loop-switch behavior, avoiding activation of disabled or non-existent tab items.
- Make tab removal and disabling logic consistently select the next available non-disabled tab or clear the active tab when none remain.

Enhancements:
- Centralize active-tab management in Tab via a tracked active TabItem and helper methods, simplifying activation and synchronization logic across the component.
- Refine TabItem extensions into an instance-style helper and mark TabItemContent as internal to better encapsulate tab content management.

Tests:
- Add comprehensive unit tests covering active-tab change notifications, navigation with disabled and looped tabs, tab add/remove behavior, close-all/close-other flows, and disabled re-enable scenarios.