### PR TITLE
fix(Captcha): correct css variable

### DIFF
--- a/src/BootstrapBlazor/Components/Captcha/Captcha.razor.scss
+++ b/src/BootstrapBlazor/Components/Captcha/Captcha.razor.scss
@@ -94,7 +94,7 @@
             width: var(--bb-captcha-footer-height);
             height: var(--bb-captcha-footer-height);
             background: var(--bb-captcha-bar-bg);
-            color: var(---bb-captcha-bar-color);
+            color: var(--bb-captcha-bar-color);
             box-shadow: var(--bb-captcha-bar-shadow);
             cursor: pointer;
             border-radius: var(--bb-captcha-radius);


### PR DESCRIPTION
## Summary

`src/BootstrapBlazor/Components/Captcha/Captcha.razor.scss:97` 中 `var(---bb-captcha-bar-color)` 多了一个连字符，与第 12 行定义的 `--bb-captcha-bar-color` 不匹配，导致 `var()` 解析失败，`.captcha-bar` 的 `color` 声明无效。

本 PR 将其修正为 `var(--bb-captcha-bar-color)`。

Close #8337

## Summary by Sourcery

Bug Fixes:
- Correct the captcha bar color CSS variable name to match the defined --bb-captcha-bar-color token.