### PR TITLE
fix(Table): correct css variable value typo blod -> bold

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.scss
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.scss
@@ -12,7 +12,7 @@
     --bb-table-header-icon-hover-bg: #ddd;
     --bb-table-header-icon-hover-color: #606266;
     --bb-table-header-min-height: 37px;
-    --bb-table-footer-font-weight: blod;
+    --bb-table-footer-font-weight: bold;
     --bb-table-card-row-padding: .75rem .5rem;
     --bb-table-columnlist-max-height: var(--bb-dropdown-max-height);
     --bs-table-striped-bg: rgba(0, 0, 0, .05);


### PR DESCRIPTION
## Summary

`src/BootstrapBlazor/Components/Table/Table.razor.scss:15` 中 `--bb-table-footer-font-weight: blod` 拼写错误（应为 `bold`）。该变量在第 229 行用于 footer 的 `font-weight`，`blod` 不是合法值导致声明无效，Table 合计行无法加粗。

本 PR 将其修正为 `bold`。

Close #8339

## Summary by Sourcery

Bug Fixes:
- Fix invalid table footer font-weight CSS variable value that prevented the footer (summary) row from rendering in bold.