### PR TITLE
feat(Layout): add IsExpandOnHover parameter

### DIFF
--- a/src/BootstrapBlazor/Components/Layout/Layout.razor
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor
@@ -89,7 +89,7 @@
     </header>;
 
     RenderFragment RenderSide =>
-    @<aside class="@SideClassString" style="@SideStyleString">
+    @<aside class="@SideClassString" style="@SideStyleString" @onclick="OnClickSidebar" @onmouseleave="OnMouseLeaveSidebar">
         @if (Side != null)
         {
             @Side

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -673,6 +673,11 @@ public partial class Layout : ITabHeader
     {
         base.OnParametersSet();
 
+        if (!IsCollapsed || IsExpandOnHover)
+        {
+            _isSidebarExpand = false;
+        }
+
         TooltipText ??= Localizer[nameof(TooltipText)];
         MenuBarIcon ??= IconTheme.GetIconByKey(ComponentIcons.LayoutMenuBarIcon);
     }

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -122,6 +122,13 @@ public partial class Layout : ITabHeader
     public EventCallback<bool> IsCollapsedChanged { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 侧边栏收缩后是否鼠标悬停展开 默认为 true 悬停展开；为 false 时点击侧边栏展开，鼠标移出后自动收起</para>
+    /// <para lang="en">Gets or sets Whether the collapsed sidebar expands on mouse hover. Default true. When false, the sidebar expands on click and collapses when the mouse leaves</para>
+    /// </summary>
+    [Parameter]
+    public bool IsExpandOnHover { get; set; } = true;
+
+    /// <summary>
     /// <para lang="zh">获得/设置 菜单手风琴效果</para>
     /// <para lang="en">Gets or sets Menu Accordion effect</para>
     /// </summary>
@@ -468,6 +475,7 @@ public partial class Layout : ITabHeader
         .AddClass("has-sidebar", Side != null && IsFullSide)
         .AddClass("has-footer", ShowFooter && Footer != null)
         .AddClass("is-collapsed", IsCollapsed)
+        .AddClass("is-click-expand", IsCollapsed && !IsExpandOnHover)
         .AddClass("is-fixed-tab", IsFixedTabHeader && UseTabSet)
         .AddClass("is-page", IsPage)
         .AddClassFromAttributes(AdditionalAttributes)
@@ -502,6 +510,7 @@ public partial class Layout : ITabHeader
     private string? SideClassString => CssBuilder.Default("layout-side")
         .AddClass("is-fixed-header", IsFixedHeader)
         .AddClass("is-fixed-footer", IsFixedFooter)
+        .AddClass("is-expand", _isSidebarExpand)
         .Build();
 
     /// <summary>
@@ -756,8 +765,37 @@ public partial class Layout : ITabHeader
     private async Task ToggleSidebar()
     {
         IsCollapsed = !IsCollapsed;
+        _isSidebarExpand = false;
 
         await TriggerCollapseChanged();
+    }
+
+    private bool _isSidebarExpand;
+
+    /// <summary>
+    /// <para lang="zh">点击侧边栏回调方法 IsExpandOnHover 为 false 时点击展开侧边栏</para>
+    /// <para lang="en">Callback method when clicking the sidebar. Expands the sidebar when IsExpandOnHover is false</para>
+    /// </summary>
+    private void OnClickSidebar()
+    {
+        if (IsCollapsed && !IsExpandOnHover && !_isSidebarExpand)
+        {
+            _isSidebarExpand = true;
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// <para lang="zh">鼠标移出侧边栏回调方法 IsExpandOnHover 为 false 时自动收起侧边栏</para>
+    /// <para lang="en">Callback method when the mouse leaves the sidebar. Collapses the sidebar when IsExpandOnHover is false</para>
+    /// </summary>
+    private void OnMouseLeaveSidebar()
+    {
+        if (_isSidebarExpand)
+        {
+            _isSidebarExpand = false;
+            StateHasChanged();
+        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -474,7 +474,7 @@ public partial class Layout : ITabHeader
     private string? ClassString => CssBuilder.Default("layout")
         .AddClass("has-sidebar", Side != null && IsFullSide)
         .AddClass("has-footer", ShowFooter && Footer != null)
-        .AddClass("is-collapsed", IsCollapsed)
+        .AddClass("is-collapsed", IsCollapsed && IsExpandOnHover)
         .AddClass("is-click-expand", IsCollapsed && !IsExpandOnHover)
         .AddClass("is-fixed-tab", IsFixedTabHeader && UseTabSet)
         .AddClass("is-page", IsPage)

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
@@ -1,4 +1,4 @@
-﻿@use "../../wwwroot/scss/variables" as *;
+@use "../../wwwroot/scss/variables" as *;
 
 [data-bs-theme='dark'] .layout {
     --bb-layout-header-background: #{$bb-layout-header-background-dark};
@@ -340,7 +340,7 @@
             }
         }
 
-        &.is-collapsed {
+        &.is-collapsed:not(.is-click-expand) {
             .layout-side {
                 &:not(:hover) {
                     --bb-layout-sidebar-width: var(--bb-layout-sidebar-collapse-width);
@@ -357,7 +357,28 @@
                     }
                 }
             }
+        }
 
+        &.is-collapsed.is-click-expand {
+            .layout-side {
+                &:not(.is-expand) {
+                    --bb-layout-sidebar-width: var(--bb-layout-sidebar-collapse-width);
+
+                    .menu.is-vertical {
+                        --bb-layout-sidebar-width: var(--bb-layout-sidebar-collapse-width);
+                    }
+                }
+
+                &.is-expand {
+                    .layout-title,
+                    .menu.is-vertical .menu-text {
+                        opacity: 1;
+                    }
+                }
+            }
+        }
+
+        &.is-collapsed {
             .layout-main {
                 display: block;
             }

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.scss
@@ -240,7 +240,8 @@
         --bb-layout-footer-height: 0px;
     }
 
-    &.is-collapsed {
+    &.is-collapsed,
+    &.is-click-expand {
         .fa-bars {
             transform: rotate(90deg);
         }
@@ -303,7 +304,7 @@
 }
 
 @media (max-width: 767.99px) {
-    .layout.is-collapsed .layout-right {
+    .layout:is(.is-collapsed, .is-click-expand) .layout-right {
         overflow: hidden;
         height: var(--bb-layout-height);
     }
@@ -340,7 +341,7 @@
             }
         }
 
-        &.is-collapsed:not(.is-click-expand) {
+        &.is-collapsed {
             .layout-side {
                 &:not(:hover) {
                     --bb-layout-sidebar-width: var(--bb-layout-sidebar-collapse-width);
@@ -359,7 +360,7 @@
             }
         }
 
-        &.is-collapsed.is-click-expand {
+        &.is-click-expand {
             .layout-side {
                 &:not(.is-expand) {
                     --bb-layout-sidebar-width: var(--bb-layout-sidebar-collapse-width);
@@ -378,7 +379,8 @@
             }
         }
 
-        &.is-collapsed {
+        &.is-collapsed,
+        &.is-click-expand {
             .layout-main {
                 display: block;
             }

--- a/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.scss
+++ b/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.scss
@@ -1,4 +1,4 @@
-﻿@use "../../wwwroot/scss/variables" as *;
+@use "../../wwwroot/scss/variables" as *;
 
 .layout-split-bar {
     width: 1px;
@@ -33,7 +33,8 @@
     }
 }
 
-.is-collapsed {
+.is-collapsed,
+.is-click-expand {
     .layout-split-bar-body {
         display: none;
     }

--- a/test/UnitTest/Components/LayoutTest.cs
+++ b/test/UnitTest/Components/LayoutTest.cs
@@ -229,6 +229,32 @@ public class LayoutTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task IsExpandOnHover_OK()
+    {
+        var cut = Context.Render<Layout>(pb =>
+        {
+            pb.Add(a => a.IsCollapsed, true);
+            pb.Add(a => a.Side, CreateSide());
+            pb.Add(a => a.IsExpandOnHover, false);
+        });
+        Assert.Contains("is-click-expand", cut.Markup);
+        Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName);
+
+        // 点击侧边栏展开
+        var side = cut.Find(".layout-side");
+        await cut.InvokeAsync(() => side.Click());
+        cut.WaitForAssertion(() => Assert.Contains("is-expand", cut.Find(".layout-side").ClassName));
+
+        // 鼠标移出侧边栏收起
+        await cut.InvokeAsync(() => side.TriggerEvent("onmouseleave", new MouseEventArgs()));
+        cut.WaitForAssertion(() => Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName));
+
+        // 默认悬停展开 不追加 is-click-expand 样式
+        cut.Render(pb => pb.Add(a => a.IsExpandOnHover, true));
+        cut.WaitForAssertion(() => Assert.DoesNotContain("is-click-expand", cut.Markup));
+    }
+
+    [Fact]
     public async Task ShowCollapseBar_OK()
     {
         var cut = Context.Render<Layout>(pb =>

--- a/test/UnitTest/Components/LayoutTest.cs
+++ b/test/UnitTest/Components/LayoutTest.cs
@@ -238,6 +238,7 @@ public class LayoutTest : BootstrapBlazorTestBase
             pb.Add(a => a.IsExpandOnHover, false);
         });
         Assert.Contains("is-click-expand", cut.Markup);
+        Assert.DoesNotContain("is-collapsed", cut.Markup);
         Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName);
 
         // 点击侧边栏展开
@@ -252,6 +253,7 @@ public class LayoutTest : BootstrapBlazorTestBase
         // 默认悬停展开 不追加 is-click-expand 样式
         cut.Render(pb => pb.Add(a => a.IsExpandOnHover, true));
         cut.WaitForAssertion(() => Assert.DoesNotContain("is-click-expand", cut.Markup));
+        Assert.Contains("is-collapsed", cut.Markup);
     }
 
     [Fact]

--- a/test/UnitTest/Components/LayoutTest.cs
+++ b/test/UnitTest/Components/LayoutTest.cs
@@ -254,6 +254,20 @@ public class LayoutTest : BootstrapBlazorTestBase
         cut.Render(pb => pb.Add(a => a.IsExpandOnHover, true));
         cut.WaitForAssertion(() => Assert.DoesNotContain("is-click-expand", cut.Markup));
         Assert.Contains("is-collapsed", cut.Markup);
+
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.IsExpandOnHover, false);
+        });
+        await cut.InvokeAsync(() => side.Click());
+        cut.WaitForAssertion(() => Assert.Contains("is-expand", cut.Find(".layout-side").ClassName));
+
+        cut.Render(pb =>
+        {
+            pb.Add(a => a.IsCollapsed, false);
+        });
+        await cut.InvokeAsync(() => side.Click());
+        cut.WaitForAssertion(() => Assert.Contains("is-expand", cut.Find(".layout-side").ClassName));
     }
 
     [Fact]

--- a/test/UnitTest/Components/LayoutTest.cs
+++ b/test/UnitTest/Components/LayoutTest.cs
@@ -244,11 +244,11 @@ public class LayoutTest : BootstrapBlazorTestBase
         // 点击侧边栏展开
         var side = cut.Find(".layout-side");
         await cut.InvokeAsync(() => side.Click());
-        cut.WaitForAssertion(() => Assert.Contains("is-expand", cut.Find(".layout-side").ClassName));
+        Assert.Contains("is-expand", cut.Find(".layout-side").ClassName);
 
         // 鼠标移出侧边栏收起
         await cut.InvokeAsync(() => side.TriggerEvent("onmouseleave", new MouseEventArgs()));
-        cut.WaitForAssertion(() => Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName));
+        Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName);
 
         // 默认悬停展开 不追加 is-click-expand 样式
         cut.Render(pb => pb.Add(a => a.IsExpandOnHover, true));
@@ -257,17 +257,19 @@ public class LayoutTest : BootstrapBlazorTestBase
 
         cut.Render(pb =>
         {
-            pb.Add(a => a.IsExpandOnHover, false);
+            pb.Add(a => a.IsCollapsed, true);
+            pb.Add(a => a.IsExpandOnHover, true);
         });
         await cut.InvokeAsync(() => side.Click());
-        cut.WaitForAssertion(() => Assert.Contains("is-expand", cut.Find(".layout-side").ClassName));
+        Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName);
 
         cut.Render(pb =>
         {
             pb.Add(a => a.IsCollapsed, false);
+            pb.Add(a => a.IsExpandOnHover, true);
         });
         await cut.InvokeAsync(() => side.Click());
-        cut.WaitForAssertion(() => Assert.Contains("is-expand", cut.Find(".layout-side").ClassName));
+        Assert.DoesNotContain("is-expand", cut.Find(".layout-side").ClassName);
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8348

## Summary By Copilot

Add a new `IsExpandOnHover` parameter to the `Layout` component (default `true`, preserving existing behavior). When set to `false`, the collapsed sidebar no longer expands on mouse hover; instead it expands on click and collapses again when the mouse leaves the sidebar area.

Changes:
- `Layout.razor.cs`: new `IsExpandOnHover` parameter, `is-click-expand` / `is-expand` class logic, click & mouse-leave handlers
- `Layout.razor`: bind `@onclick` / `@onmouseleave` on the sidebar `aside`
- `Layout.razor.scss`: gate hover-expand rules behind `:not(.is-click-expand)`, add click-expand rules driven by `.is-expand`; bundle css regenerated
- `LayoutTest.cs`: new unit test `IsExpandOnHover_OK`

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

Default value keeps the existing hover behavior; click mode is opt-in only.

## Verification
- [x] Manual (required)
- [x] Automated

`LayoutTest` 31/31 passed (including new `IsExpandOnHover_OK`), `UniTest.Sass` passed.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Allow collapsed Layout sidebars to expand on click instead of hover when configured.

New Features:
- Add an opt-in click-to-expand mode for collapsed Layout sidebars through the new IsExpandOnHover parameter.

Enhancements:
- Preserve hover expansion by default while collapsing click-expanded sidebars when the pointer leaves the sidebar.

Tests:
- Add unit coverage for click expansion, mouse-leave collapse, and default hover behavior.