### PR TITLE
feat(DrawerOptions): add OnClosingAsync parameter

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Drawers.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Drawers.razor
@@ -72,6 +72,9 @@
 </DemoBlock>
 
 <DemoBlock Title="@Localizer["DrawerServiceTitle"]" Introduction="@Localizer["DrawerServiceIntro"]" Name="DrawerService">
+    <section ignore>
+        <p>@((MarkupString)Localizer["DrawerServiceContent"].Value)</p>
+    </section>
     <Button OnClickWithoutRender="@DrawerServiceShow" Text="@Localizer["Open"]"></Button>
 </DemoBlock>
 

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -2143,6 +2143,7 @@
     "Close": "close the drawer",
     "Content": "The layout, components, etc. in the drawer are fully customizable",
     "Description": "Sometimes, the Dialog component does not meet our needs. For example, your form is very long, or you need to temporarily display some documents. Drawer has almost the same API as Dialog, which brings a different experience to the UI.",
+    "DrawerServiceContent": "When opening a drawer by calling <code>DrawerService.Show</code>, you can intercept closing through the <code>OnClosingAsync</code> callback of <code>DrawerOption</code>. This works in the same way as components such as <code>Dialog</code>. Return <code>false</code> from the callback to cancel closing the drawer.",
     "DrawerServiceIntro": "Open the drawer pop-up window by calling the <code>DrawerService</code> service",
     "DrawerServiceTitle": "Drawer Service",
     "DrawerTips": "Sometimes we want to expand a pop-up window in a certain container. We can do this by embedding a <code>&lt;Drawer/&gt;</code> drawer component in a specific container and then setting the parameter <code>Position=\"absolute\"</code> for relative positioning. Note: The parent container style needs to be set to <code>position: relative;</code>",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -2143,6 +2143,7 @@
     "Close": "关闭抽屉",
     "Content": "抽屉内布局、组件等完全可以自定义",
     "Description": "有些时候, Dialog 组件并不满足我们的需求, 比如你的表单很长, 亦或是你需要临时展示一些文档, Drawer 拥有和 Dialog 几乎相同的 API, 在 UI 上带来不一样的体验",
+    "DrawerServiceContent": "通过调用 <code>DrawerService.Show</code> 方法打开抽屉弹窗时，可以通过 <code>DrawerOption</code> 的 <code>OnClosingAsync</code> 回调方法进行拦截，用法与 <code>Dialog</code> 等组件一致，回调方法返回 <code>false</code> 时中止弹窗关闭",
     "DrawerServiceIntro": "通过调用 <code>DrawerService</code> 服务打开抽屉弹窗",
     "DrawerServiceTitle": "调用服务打开抽屉",
     "DrawerTips": "有时候我们的弹窗希望在某个容器内展开，可通过在特定容器内置 <code>&lt;Drawer/&gt;</code> 抽屉组件，然后设置参数 <code>Position=\"absolute\"</code> 相对定位来实现此需求；注意：父容器样式需要设置 <code>position: relative;</code>",

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.9.2</Version>
+    <Version>10.9.3-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Dialog/DialogOption.cs
+++ b/src/BootstrapBlazor/Components/Dialog/DialogOption.cs
@@ -9,7 +9,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">Dialog 对话框组件</para>
 /// <para lang="en">Dialog component</para>
 /// </summary>
-public class DialogOption : ICloseable
+public class DialogOption : IClosable
 {
     /// <summary>
     /// <para lang="zh">获得/设置 关联的 Modal 实例</para>
@@ -192,12 +192,12 @@ public class DialogOption : ICloseable
     public string? CloseButtonText { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ICloseable.OnCloseAsync"/>
+    /// <inheritdoc cref="IClosable.OnCloseAsync"/>
     /// </summary>
     public Func<Task>? OnCloseAsync { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ICloseable.OnClosingAsync"/>
+    /// <inheritdoc cref="IClosable.OnClosingAsync"/>
     /// </summary>
     public Func<Task<bool>>? OnClosingAsync { get; set; }
 

--- a/src/BootstrapBlazor/Components/Drawer/Drawer.razor.cs
+++ b/src/BootstrapBlazor/Components/Drawer/Drawer.razor.cs
@@ -9,7 +9,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">Drawer 抽屉组件</para>
 /// <para lang="en">Drawer component</para>
 /// </summary>
-public partial class Drawer
+public partial class Drawer : IClosable
 {
     private string? ClassString => CssBuilder.Default("drawer collapse")
         .AddClass("no-bd", !ShowBackdrop)
@@ -121,11 +121,16 @@ public partial class Drawer
     public int? ZIndex { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 关闭抽屉回调委托 默认 null</para>
-    /// <para lang="en">Gets or sets Close Drawer Callback Delegate. Default is null</para>
+    /// <inheritdoc cref="IClosable.OnCloseAsync"/>
     /// </summary>
     [Parameter]
     public Func<Task>? OnCloseAsync { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="IClosable.OnClosingAsync"/>
+    /// </summary>
+    [Parameter]
+    public Func<Task<bool>>? OnClosingAsync { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 抽屉内容相关数据 多用于传值</para>
@@ -227,6 +232,11 @@ public partial class Drawer
     [JSInvokable]
     public async Task Close()
     {
+        if (OnClosingAsync != null && !await OnClosingAsync())
+        {
+            return;
+        }
+
         IsOpen = false;
         var animation = await InvokeAsync<bool>("execute", Id, false);
         if (animation)

--- a/src/BootstrapBlazor/Components/Drawer/DrawerContainer.cs
+++ b/src/BootstrapBlazor/Components/Drawer/DrawerContainer.cs
@@ -98,6 +98,10 @@ public class DrawerContainer : ComponentBase, IDisposable
         {
             parameters.Add(nameof(Drawer.OnClickBackdrop), option.OnClickBackdrop);
         }
+        if (option.OnClosingAsync != null)
+        {
+            parameters.Add(nameof(Drawer.OnClosingAsync), option.OnClosingAsync);
+        }
         if (option.BodyContext != null)
         {
             parameters.Add(nameof(Drawer.BodyContext), option.BodyContext);

--- a/src/BootstrapBlazor/Components/Drawer/DrawerOption.cs
+++ b/src/BootstrapBlazor/Components/Drawer/DrawerOption.cs
@@ -9,7 +9,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">Drawer 弹出窗参数配置类</para>
 /// <para lang="en">Drawer Option Class</para>
 /// </summary>
-public class DrawerOption
+public class DrawerOption : IClosable
 {
     /// <summary>
     /// <para lang="zh">获得/设置 Drawer 组件样式</para>
@@ -84,10 +84,14 @@ public class DrawerOption
     public Func<Task>? OnClickBackdrop { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 关闭当前 Drawer 回调委托 默认 null</para>
-    /// <para lang="en">Gets or sets Close Drawer Callback Delegate. Default is null</para>
+    /// <inheritdoc cref="IClosable.OnCloseAsync"/>
     /// </summary>
     public Func<Task>? OnCloseAsync { get; set; }
+
+    /// <summary>
+    /// <inheritdoc cref="IClosable.OnClosingAsync"/>
+    /// </summary>
+    public Func<Task<bool>>? OnClosingAsync { get; set; }
 
     /// <summary>
     /// <para lang="zh">获得/设置 相关连数据，多用于传值使用</para>

--- a/src/BootstrapBlazor/Components/Modal/IClosable.cs
+++ b/src/BootstrapBlazor/Components/Modal/IClosable.cs
@@ -9,7 +9,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">可关闭接口</para>
 /// <para lang="en">the closable interface</para>
 /// </summary>
-public interface ICloseable
+public interface IClosable
 {
     /// <summary>
     /// <para lang="zh">获得/设置 弹出窗口关闭时的回调委托</para>

--- a/src/BootstrapBlazor/Components/Modal/Modal.razor.cs
+++ b/src/BootstrapBlazor/Components/Modal/Modal.razor.cs
@@ -11,7 +11,7 @@ namespace BootstrapBlazor.Components;
 /// <para lang="zh">Modal 组件</para>
 /// <para lang="en">Modal component</para>
 /// </summary>
-public partial class Modal : ICloseable
+public partial class Modal : IClosable
 {
     [Inject]
     [NotNull]
@@ -77,13 +77,13 @@ public partial class Modal : ICloseable
     public Func<Task>? OnShownAsync { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ICloseable.OnCloseAsync"/>
+    /// <inheritdoc cref="IClosable.OnCloseAsync"/>
     /// </summary>
     [Parameter]
     public Func<Task>? OnCloseAsync { get; set; }
 
     /// <summary>
-    /// <inheritdoc cref="ICloseable.OnClosingAsync"/>
+    /// <inheritdoc cref="IClosable.OnClosingAsync"/>
     /// </summary>
     [Parameter]
     public Func<Task<bool>>? OnClosingAsync { get; set; }

--- a/test/UnitTest/Components/DrawerTest.cs
+++ b/test/UnitTest/Components/DrawerTest.cs
@@ -240,6 +240,57 @@ public class DrawerTest : BootstrapBlazorTestBase
         cut.Contains("data-bb-scroll=\"true\"");
     }
 
+    [Fact]
+    public async Task OnClosingAsync_ReturnFalse()
+    {
+        var onCloseCalled = false;
+        var isOpenChangedCalled = false;
+        var cut = Context.Render<Drawer>(builder =>
+        {
+            builder.Add(a => a.IsOpen, true);
+            builder.Add(a => a.OnClosingAsync, () => Task.FromResult(false));
+            builder.Add(a => a.OnCloseAsync, () =>
+            {
+                onCloseCalled = true;
+                return Task.CompletedTask;
+            });
+            builder.Add(a => a.IsOpenChanged, EventCallback.Factory.Create<bool>(this, _ => isOpenChangedCalled = true));
+        });
+
+        Assert.IsType<IClosable>(cut.Instance, exactMatch: false);
+        await cut.InvokeAsync(cut.Instance.Close);
+
+        Assert.True(cut.Instance.IsOpen);
+        Assert.False(onCloseCalled);
+        Assert.False(isOpenChangedCalled);
+    }
+
+    [Fact]
+    public async Task OnClosingAsync_ReturnTrue()
+    {
+        var callbacks = new List<string>();
+        var cut = Context.Render<Drawer>(builder =>
+        {
+            builder.Add(a => a.IsOpen, true);
+            builder.Add(a => a.OnClosingAsync, () =>
+            {
+                callbacks.Add("closing");
+                return Task.FromResult(true);
+            });
+            builder.Add(a => a.OnCloseAsync, () =>
+            {
+                callbacks.Add("close");
+                return Task.CompletedTask;
+            });
+            builder.Add(a => a.IsOpenChanged, EventCallback.Factory.Create<bool>(this, _ => callbacks.Add("changed")));
+        });
+
+        await cut.InvokeAsync(cut.Instance.Close);
+
+        Assert.False(cut.Instance.IsOpen);
+        Assert.Equal(["closing", "close", "changed"], callbacks);
+    }
+
     class MockContent : ComponentBase
     {
         [CascadingParameter(Name = "BodyContext")]

--- a/test/UnitTest/Services/DrawerServiceTest.cs
+++ b/test/UnitTest/Services/DrawerServiceTest.cs
@@ -67,6 +67,36 @@ public class DrawerServiceTest : BootstrapBlazorTestBase
         Assert.True(closed);
     }
 
+    [Fact]
+    public async Task OnClosingAsync_Ok()
+    {
+        var closing = false;
+        var closed = false;
+        var option = new DrawerOption
+        {
+            OnClosingAsync = () =>
+            {
+                closing = true;
+                return Task.FromResult(false);
+            },
+            OnCloseAsync = () =>
+            {
+                closed = true;
+                return Task.CompletedTask;
+            }
+        };
+        var service = Context.Services.GetRequiredService<DrawerService>();
+        var cut = Context.Render<BootstrapBlazorRoot>();
+
+        Assert.IsType<IClosable>(option, exactMatch: false);
+        await service.Show(option);
+        await cut.InvokeAsync(option.CloseAsync);
+
+        Assert.True(closing);
+        Assert.False(closed);
+        Assert.Single(cut.FindComponents<Drawer>());
+    }
+
     private static RenderFragment RenderContent() => builder =>
     {
         builder.AddContent(0, "drawer-content");


### PR DESCRIPTION
## Link issues
fixes #8351 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Add cancellable asynchronous closing support to drawer components and drawer service options.

New Features:
- Add asynchronous pre-close callbacks to drawers, allowing closure to be conditionally cancelled for both component and service-based usage.

Enhancements:
- Align modal, dialog, drawer, and option types under the shared IClosable contract.

Tests:
- Add coverage for allowing and preventing drawer closure through OnClosingAsync callbacks, including callback ordering and drawer service behavior.