### PR TITLE
feat(Theme): remove switch theme circle animation

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Components/ThemeMode.razor.js
+++ b/src/BootstrapBlazor.Server/Components/Components/ThemeMode.razor.js
@@ -1,4 +1,4 @@
-﻿import { getTheme, switchTheme, calcCenterPosition } from "../../_content/BootstrapBlazor/modules/utility.js"
+import { getTheme, switchTheme } from "../../_content/BootstrapBlazor/modules/utility.js"
 import EventHandler from "../../_content/BootstrapBlazor/modules/event-handler.js"
 
 export function init(id) {
@@ -13,8 +13,9 @@ export function init(id) {
                 theme = 'dark';
             }
 
-            const rect = calcCenterPosition(el);
-            switchTheme(theme, rect.x, rect.y);
+            // const rect = calcCenterPosition(el);
+            // switchTheme(theme, rect.x, rect.y);
+            switchTheme(theme);
         });
     }
 }

--- a/src/BootstrapBlazor/Components/ThemeProvider/ThemeProvider.razor.js
+++ b/src/BootstrapBlazor/Components/ThemeProvider/ThemeProvider.razor.js
@@ -1,4 +1,4 @@
-﻿import { getTheme, setTheme, switchTheme, calcCenterPosition } from "../../modules/utility.js"
+import { getTheme, setTheme, switchTheme } from "../../modules/utility.js"
 import EventHandler from "../../modules/event-handler.js"
 import Data from "../../modules/data.js"
 
@@ -26,8 +26,7 @@ export function init(id, invoke, themeValue, callback) {
         const activeTheme = e.delegateTarget.getAttribute('data-bb-theme-value');
         theme.currentTheme = activeTheme;
 
-        const rect = calcCenterPosition(el);
-        switchTheme(activeTheme, rect.x, rect.y);
+        switchTheme(activeTheme);
         if (callback) {
             invoke.invokeMethodAsync(callback, activeTheme);
         }
@@ -53,6 +52,6 @@ const changeTheme = id => {
     }
 
     if (theme.currentTheme === 'auto') {
-        switchTheme('auto', window.innerWidth, 0);
+        switchTheme('auto');
     }
 }

--- a/src/BootstrapBlazor/wwwroot/modules/utility.js
+++ b/src/BootstrapBlazor/wwwroot/modules/utility.js
@@ -802,16 +802,17 @@ export function setActiveTheme(el, activeItem) {
 }
 
 export function switchTheme(theme, x = 0, y = 0, sync = true) {
-    if (isFunction(document.startViewTransition)) {
-        document.documentElement.style.setProperty('--bb-theme-x', `${x}px`);
-        document.documentElement.style.setProperty('--bb-theme-y', `${y}px`);
-        document.startViewTransition(() => {
-            setTheme(theme, sync);
-        });
-    }
-    else {
-        setTheme(theme, sync);
-    }
+    //if (isFunction(document.startViewTransition)) {
+    //    document.documentElement.style.setProperty('--bb-theme-x', `${x}px`);
+    //    document.documentElement.style.setProperty('--bb-theme-y', `${y}px`);
+    //    document.startViewTransition(() => {
+    //        setTheme(theme, sync);
+    //    });
+    //}
+    //else {
+    //    setTheme(theme, sync);
+    //}
+    setTheme(theme, sync);
 }
 
 const deepMerge = (obj1, obj2, skipNull = true) => {


### PR DESCRIPTION
## Link issues
fixes #8362 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Remove the circular animation from theme changes and apply theme updates directly.

Bug Fixes:
- Remove the circular view-transition animation when switching themes.

Enhancements:
- Simplify theme switching to apply the selected theme directly without transition positioning.