### PR TITLE
fix(Table): preserve conditions when resetting SearchForm

### DIFF
--- a/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
@@ -218,8 +218,8 @@ public partial class Table<TItem>
                 {
                     item.Reset();
                 }
+                _searchFilter = _searchItems.ToFilter();
             }
-            _searchItems = null;
         }
         else if (CustomerSearchModel != null)
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
@@ -206,7 +206,11 @@ public partial class Table<TItem>
     protected async Task ResetSearchClick()
     {
         await ToggleLoading(true);
-        if (UseSearchForm)
+        if (OnResetSearchAsync != null)
+        {
+            await OnResetSearchAsync(SearchModel);
+        }
+        else if(UseSearchForm)
         {
             _searchFilter = null;
             _advanceSearchFilter = null;
@@ -224,10 +228,6 @@ public partial class Table<TItem>
         else if (CustomerSearchModel != null)
         {
             CustomerSearchModel.Reset();
-        }
-        else if (OnResetSearchAsync != null)
-        {
-            await OnResetSearchAsync(SearchModel);
         }
         else if (SearchTemplate == null)
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
@@ -219,7 +219,9 @@ public partial class Table<TItem>
                     item.Reset();
                 }
             }
-            _searchItems = null;
+            //_searchItems = null;
+            // 这里不能完全将_searchFilter设为null，以便用户在实现自定义时部分查询条件没有置为null
+            _searchFilter = _searchItems.ToFilter();
         }
         else if (CustomerSearchModel != null)
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
@@ -206,11 +206,7 @@ public partial class Table<TItem>
     protected async Task ResetSearchClick()
     {
         await ToggleLoading(true);
-        if (OnResetSearchAsync != null)
-        {
-            await OnResetSearchAsync(SearchModel);
-        }
-        else if(UseSearchForm)
+        if (UseSearchForm)
         {
             _searchFilter = null;
             _advanceSearchFilter = null;
@@ -228,6 +224,10 @@ public partial class Table<TItem>
         else if (CustomerSearchModel != null)
         {
             CustomerSearchModel.Reset();
+        }
+        else if (OnResetSearchAsync != null)
+        {
+            await OnResetSearchAsync(SearchModel);
         }
         else if (SearchTemplate == null)
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
@@ -219,9 +219,7 @@ public partial class Table<TItem>
                     item.Reset();
                 }
             }
-            //_searchItems = null;
-            // 这里不能完全将_searchFilter设为null，以便用户在实现自定义时部分查询条件没有置为null
-            _searchFilter = _searchItems.ToFilter();
+            _searchItems = null;
         }
         else if (CustomerSearchModel != null)
         {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.Search.cs
@@ -160,8 +160,8 @@ public partial class Table<TItem>
     public Alignment SearchDialogLabelAlign { get; set; }
 
     /// <summary>
-    /// <para lang="zh">重置搜索按钮异步回调方法</para>
-    /// <para lang="en">Reset Search Button Async Callback</para>
+    /// <para lang="zh">重置搜索按钮异步回调方法，仅使用 <see cref="SearchModel" /> 时触发此回调方法</para>
+    /// <para lang="en">Reset Search Button Async Callback, only triggered when using <see cref="SearchModel" /></para>
     /// </summary>
     [Parameter]
     public Func<TItem, Task>? OnResetSearchAsync { get; set; }

--- a/test/UnitTest/Components/TableDialogTest.cs
+++ b/test/UnitTest/Components/TableDialogTest.cs
@@ -358,7 +358,7 @@ public class TableDialogTest : TableDialogTestBase
         // 关闭弹窗
         await cut.InvokeAsync(() => modal.Instance.CloseCallback());
         Assert.NotNull(filter);
-        Assert.Empty(filter.Filters);
+        Assert.Empty(filter.Filters.SelectMany(i => i.Filters).SelectMany(i => i.Filters));
     }
 
     [Fact]


### PR DESCRIPTION
## Link issues
fixes #8368

## Summary By Copilot

修正 `UseSearchForm` 模式下的搜索表单重置逻辑，使自定义重置后保留的查询条件继续生效，并同步更新参数注释及相关单元测试断言。

## 根本原因

`ResetSearchClick` 在调用各搜索项的 `Reset` 方法后直接将 `_searchItems` 置为 `null`，导致自定义重置逻辑保留或恢复的非空查询条件被丢弃。

## 解决方法

- 重置各搜索项后，通过 `_searchItems.ToFilter()` 重新生成 `_searchFilter`，保留重置后的有效查询条件。
- 更新 `OnResetSearchAsync` 注释，明确该回调仅在使用 `SearchModel` 时触发。
- 调整表格弹窗测试对嵌套过滤条件的断言。

## Regression?
- [x] No

## Risk
- [x] Low

变更仅影响 `UseSearchForm` 模式下的重置过滤条件生成逻辑，并有自动化测试覆盖。

## Verification
- [ ] Manual (required)
- [x] Automated

GitHub Actions `run test` 已通过，Codecov project 与 patch 检查均已通过。

## Packaging changes reviewed?
- [x] N/A

## ☑️ Self Check before Merge
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Preserve customized search criteria during search form resets while clarifying reset callback behavior and updating related tests.

Bug Fixes:
- Preserve effective search criteria when resetting a table search form in UseSearchForm mode.

Enhancements:
- Clarify when the asynchronous search reset callback is invoked and update nested filter assertions in table dialog tests.

Tests:
- Update table dialog coverage to validate nested filter results after reset-related changes.