### PR TITLE
doc(PopConfirmButton): add IsKeepOpenOnOutsideClick documentation

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/PopoverConfirms.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/PopoverConfirms.razor
@@ -7,6 +7,11 @@
 <DemoBlock Title="@Localizer["PopoverConfirmsNormalTitle"]"
            Introduction="@Localizer["PopoverConfirmsNormalIntro"]"
            Name="Normal">
+    <section ignore>
+        <Tips>
+            <div><code>10.9.3</code> 版本前点击按钮弹窗后点击文档其他地方弹窗是保持打开状态的，<code>10.9.3</code> 增加了参数 <code>IsKeepOpenOnOutsideClick</code> 默认值为 <code>false</code> 点击文档其他地方时弹窗会关闭，设置其值为 <code>true</code> 可保持弹窗打开状态</div>
+        </Tips>
+    </section>
     <div class="d-flex justify-content-center border p-3 rounded">
         <div class="d-flex flex-column w-100" style="height: 240px;">
             <div class="d-flex justify-content-center">

--- a/src/BootstrapBlazor.Server/Components/Samples/PopoverConfirms.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/PopoverConfirms.razor
@@ -9,7 +9,7 @@
            Name="Normal">
     <section ignore>
         <Tips>
-            <div><code>10.9.3</code> 版本前点击按钮弹窗后点击文档其他地方弹窗是保持打开状态的，<code>10.9.3</code> 增加了参数 <code>IsKeepOpenOnOutsideClick</code> 默认值为 <code>false</code> 点击文档其他地方时弹窗会关闭，设置其值为 <code>true</code> 可保持弹窗打开状态</div>
+            <div>@((MarkupString)Localizer["PopoverConfirmsNormalTips"].Value)</div>
         </Tips>
     </section>
     <div class="d-flex justify-content-center border p-3 rounded">

--- a/src/BootstrapBlazor.Server/Locales/en-US.json
+++ b/src/BootstrapBlazor.Server/Locales/en-US.json
@@ -3765,6 +3765,7 @@
     "PopoverConfirmsNormalPopupBoxText": "pop-up box below",
     "PopoverConfirmsNormalRightPopup": "right popup",
     "PopoverConfirmsNormalRightPopupContent": "Is this a piece of content sure to delete?",
+    "PopoverConfirmsNormalTips": "Before version <code>10.9.3</code>, the popover remained open when clicking elsewhere in the document. Version <code>10.9.3</code> added the <code>IsKeepOpenOnOutsideClick</code> parameter. Its default value is <code>false</code>, which closes the popover when clicking elsewhere. Set it to <code>true</code> to keep the popover open.",
     "PopoverConfirmsNormalTitle": "Basic usage",
     "PopoverConfirmsShowButtonsButtonText": "Custom Component",
     "PopoverConfirmsShowButtonsDesc": "In a custom component, you can call the <code>Close</code> or <code>Confirm</code> method inside the component through cascading parameters",

--- a/src/BootstrapBlazor.Server/Locales/zh-CN.json
+++ b/src/BootstrapBlazor.Server/Locales/zh-CN.json
@@ -3765,6 +3765,7 @@
     "PopoverConfirmsNormalPopupBoxText": "下面弹框",
     "PopoverConfirmsNormalRightPopup": "右侧弹窗",
     "PopoverConfirmsNormalRightPopupContent": "这是一段内容确定删除吗？",
+    "PopoverConfirmsNormalTips": "<code>10.9.3</code> 版本前点击按钮弹窗后点击文档其他地方弹窗是保持打开状态的，<code>10.9.3</code> 增加了参数 <code>IsKeepOpenOnOutsideClick</code> 默认值为 <code>false</code> 点击文档其他地方时弹窗会关闭，设置其值为 <code>true</code> 可保持弹窗打开状态",
     "PopoverConfirmsNormalTitle": "基础用法",
     "PopoverConfirmsShowButtonsButtonText": "自定义组件",
     "PopoverConfirmsShowButtonsDesc": "自定义组件内可通过级联参数调用组件内部的 <code>Close</code> 或者 <code>Confirm</code> 方法",

--- a/src/BootstrapBlazor/Components/Button/PopConfirmButtonBase.cs
+++ b/src/BootstrapBlazor/Components/Button/PopConfirmButtonBase.cs
@@ -34,6 +34,7 @@ public abstract class PopConfirmButtonBase : ButtonBase
     /// <summary>
     /// <para lang="zh">获得/设置 点击弹窗外部时是否保持弹窗打开 默认 false</para>
     /// <para lang="en">Gets or sets whether to keep the popup open when clicking outside it. Default is false</para>
+    /// <para>v<version>10.9.3</version></para>
     /// </summary>
     [Parameter]
     public bool IsKeepOpenOnOutsideClick { get; set; }


### PR DESCRIPTION
## Link issues
fixes #8370

## Summary By Copilot

Add version metadata and localized usage tips for the `PopConfirmButton.IsKeepOpenOnOutsideClick` parameter.

## Regression?
- [x] No

## Risk
- [x] Low

Documentation and localization changes only.

## Verification
- [x] Automated

- `dotnet build src\BootstrapBlazor\BootstrapBlazor.csproj --no-restore --nologo -c Release`
- Parsed `zh-CN.json` and `en-US.json` with `ConvertFrom-Json`

The Server project build was also attempted. Its default output is locked by the running `BootstrapBlazor.Server` process; an isolated-output build reaches unrelated pre-existing duplicate member errors in `JitViewers.razor.cs`.

## Packaging changes reviewed?
- [x] N/A

## ☑️ Self Check before Merge
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Document the PopConfirmButton option for keeping its confirmation popup open after outside clicks.

Enhancements:
- Document the PopConfirmButton outside-click behavior parameter with its version metadata.

Documentation:
- Add localized usage guidance for keeping popovers open when clicking outside them.