### PR TITLE
feat(Dom2Image): bump version 10.0.4

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.DockView" Version="10.0.23" />
-    <PackageReference Include="BootstrapBlazor.Dom2Image" Version="10.0.3" />
+    <PackageReference Include="BootstrapBlazor.Dom2Image" Version="10.0.4" />
     <PackageReference Include="BootstrapBlazor.DriverJs" Version="10.0.3" />
     <PackageReference Include="BootstrapBlazor.ElementIcon" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.EmbedPDF" Version="10.0.8" />


### PR DESCRIPTION
## Link issues
fixes #8373

## Summary By Copilot

Upgrade `BootstrapBlazor.Dom2Image` from `10.0.3` to `10.0.4` in the BootstrapBlazor.Server project.

## Regression?
- [x] No

## Risk
- [x] Low

The change only updates the Dom2Image extension package patch version.

## Verification
- [x] Automated

`dotnet restore .\src\BootstrapBlazor.Server\BootstrapBlazor.Server.csproj --locked-mode`

## Packaging changes reviewed?
- [x] Yes

## ☑️ Self Check before Merge
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Build:
- Update the BootstrapBlazor.Server project to use BootstrapBlazor.Dom2Image version 10.0.4.