### PR TITLE
feat(UploadFile): support custom upload progress

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.9.3-beta01</Version>
+    <Version>10.9.3-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Upload/UploadFile.cs
+++ b/src/BootstrapBlazor/Components/Upload/UploadFile.cs
@@ -68,22 +68,40 @@ public class UploadFile
     internal Action<UploadFile>? UpdateCallback { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 上传进度百分比</para>
-    /// <para lang="en">Gets or sets the upload progress percentage</para>
+    /// <para lang="zh">获得 上传进度百分比</para>
+    /// <para lang="en">Gets the upload progress percentage</para>
     /// </summary>
-    internal int ProgressPercent { get; set; }
+    public int ProgressPercent { get; internal set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 文件是否上传处理完毕</para>
-    /// <para lang="en">Gets or sets whether the file upload has been completed</para>
+    /// <para lang="zh">获得 文件是否上传处理完毕</para>
+    /// <para lang="en">Gets whether the file upload has been completed</para>
     /// </summary>
-    internal bool Uploaded { get; set; } = true;
+    public bool Uploaded { get; internal set; } = true;
 
     /// <summary>
     /// <para lang="zh">获得/设置 用于客户端验证的 ID</para>
     /// <para lang="en">Gets or sets the ID for client-side validation</para>
     /// </summary>
     internal string? ValidateId { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">更新上传进度百分比</para>
+    /// <para lang="en">Updates the upload progress percentage</para>
+    /// </summary>
+    /// <param name="progressPercent">上传进度百分比，取值范围 0 到 100 / Upload progress percentage, ranging from 0 to 100</param>
+    public void UpdateProgress(int progressPercent)
+    {
+        var percent = Math.Clamp(progressPercent, 0, 100);
+        if (percent > ProgressPercent)
+        {
+            ProgressPercent = percent;
+            if (UpdateCallback != null)
+            {
+                UpdateCallback(this);
+            }
+        }
+    }
 
     /// <summary>
     /// <para lang="zh">获得 UploadFile 的文件名</para>

--- a/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/UploadFileExtensions.cs
@@ -105,15 +105,8 @@ public static class UploadFileExtensions
                         totalRead += bytesRead;
                         await uploadFile.WriteAsync(buffer, 0, bytesRead, token);
 
-                        if (upload.UpdateCallback != null)
-                        {
-                            var percent = (int)((totalRead / upload.File.Size) * 100);
-                            if (percent > upload.ProgressPercent)
-                            {
-                                upload.ProgressPercent = percent;
-                                upload.UpdateCallback(upload);
-                            }
-                        }
+                        var percent = (int)((totalRead / upload.File.Size) * 100);
+                        upload.UpdateProgress(percent);
                     }
                     upload.Uploaded = true;
                     ret = true;

--- a/test/UnitTest/Components/UploadAvatarTest.cs
+++ b/test/UnitTest/Components/UploadAvatarTest.cs
@@ -222,6 +222,29 @@ public class UploadAvatarTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void UpdateProgress_Ok()
+    {
+        var updateCount = 0;
+        var file = new UploadFile();
+        SetUpdateCallback(file, _ => updateCount++);
+
+        Assert.True(file.Uploaded);
+        Assert.Equal(0, file.ProgressPercent);
+
+        file.UpdateProgress(50);
+        Assert.Equal(50, file.ProgressPercent);
+        Assert.Equal(1, updateCount);
+
+        file.UpdateProgress(40);
+        Assert.Equal(50, file.ProgressPercent);
+        Assert.Equal(1, updateCount);
+
+        file.UpdateProgress(120);
+        Assert.Equal(100, file.ProgressPercent);
+        Assert.Equal(2, updateCount);
+    }
+
+    [Fact]
     public async Task ValidateForm_ToggleMessage()
     {
         bool? invalid = null;
@@ -331,4 +354,7 @@ public class UploadAvatarTest : BootstrapBlazorTestBase
 
     [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_Uploaded")]
     static extern void SetUploaded(UploadFile @this, bool v);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = "set_UpdateCallback")]
+    static extern void SetUpdateCallback(UploadFile @this, Action<UploadFile>? v);
 }


### PR DESCRIPTION
## Link issues
fixes #8372

## Summary By Copilot

Add controlled custom upload progress support to `UploadFile`:

- expose `ProgressPercent` and `Uploaded` as read-only public state
- add `UpdateProgress(int)` to clamp progress, prevent regressions, and refresh the upload UI
- reuse the new API in `SaveToFileAsync`
- cover progress updates, regression prevention, upper-bound clamping, and callback invocation

## Regression?
- [x] No

## Risk
- [x] Low

The change adds an incremental API while retaining internal ownership of upload completion and rendering callbacks.

## Verification
- [ ] Manual (required)
- [x] Automated

`dotnet test .\test\UnitTest\UnitTest.csproj --no-restore --filter "FullyQualifiedName~UnitTest.Components.UploadAvatarTest|FullyQualifiedName~UnitTest.Components.UploadButtonTest|FullyQualifiedName~UnitTest.Components.UploadCardTest|FullyQualifiedName~UnitTest.Components.UploadDropTest|FullyQualifiedName~UnitTest.Components.UploadInputTest" --verbosity quiet`

49 tests passed.

## Packaging changes reviewed?
- [x] N/A

## ☑️ Self Check before Merge
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Support controlled custom upload progress updates for UploadFile while preserving automatic progress reporting during file saves.

New Features:
- Expose upload progress and completion state as publicly readable properties and provide a controlled API for updating upload progress.

Enhancements:
- Centralize upload progress updates so progress is clamped, cannot regress, and refresh callbacks are invoked only when progress advances.

Tests:
- Add coverage for progress updates, regression prevention, upper-bound clamping, and callback behavior.