### PR TITLE
fix(RouteTableFactory): prevent ambiguous route false positive

### DIFF
--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.10.0</Version>
+    <Version>10.10.1-beta01</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Router/RouteTableFactory.cs
+++ b/src/BootstrapBlazor/Router/RouteTableFactory.cs
@@ -81,7 +81,24 @@ internal static class RouteTableFactory
         }
 
         routes.Sort(CompareRoutes);
+        DetectAmbiguousRoutes(routes);
         return [.. routes];
+    }
+
+    private static void DetectAmbiguousRoutes(List<RouteDefinition> routes)
+    {
+        for (var i = 1; i < routes.Count; i++)
+        {
+            var x = routes[i - 1];
+            var y = routes[i];
+            if (CompareRoutes(x, y) == 0)
+            {
+                throw new InvalidOperationException(
+                    $"The following routes are ambiguous:{Environment.NewLine}" +
+                    $"'{x.Template}' in '{x.Handler.FullName}'{Environment.NewLine}" +
+                    $"'{y.Template}' in '{y.Handler.FullName}'");
+            }
+        }
     }
 
     private static string[] GetSegments(string url)
@@ -252,16 +269,7 @@ internal static class RouteTableFactory
             }
         }
 
-        var lengthResult = x.Segments.Length.CompareTo(y.Segments.Length);
-        if (lengthResult != 0)
-        {
-            return lengthResult;
-        }
-
-        throw new InvalidOperationException(
-            $"The following routes are ambiguous:{Environment.NewLine}" +
-            $"'{x.Template}' in '{x.Handler.FullName}'{Environment.NewLine}" +
-            $"'{y.Template}' in '{y.Handler.FullName}'");
+        return x.Segments.Length.CompareTo(y.Segments.Length);
     }
 
     private static int GetRank(RouteSegment segment) => segment switch

--- a/test/UnitTest/Components/RouteTableFactoryTest.cs
+++ b/test/UnitTest/Components/RouteTableFactoryTest.cs
@@ -1,0 +1,53 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using System.Reflection;
+using System.Collections;
+
+namespace UnitTest.Components;
+
+public class RouteTableFactoryTest
+{
+    [Fact]
+    public void CompareRoutes_ReturnsZeroForSameRoute()
+    {
+        var route = CreateRouteDefinition("/{id}");
+        var method = GetFactoryType().GetMethod("CompareRoutes", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var result = method.Invoke(null, [route, route]);
+
+        Assert.Equal(0, result);
+    }
+
+    [Fact]
+    public void DetectAmbiguousRoutes_ThrowsForDifferentAmbiguousRoutes()
+    {
+        var routeDefinitionType = GetFactoryType().GetNestedType("RouteDefinition", BindingFlags.NonPublic)!;
+        var routes = (IList)Activator.CreateInstance(typeof(List<>).MakeGenericType(routeDefinitionType))!;
+        routes.Add(CreateRouteDefinition("/{id}"));
+        routes.Add(CreateRouteDefinition("/{name}"));
+        var method = GetFactoryType().GetMethod("DetectAmbiguousRoutes", BindingFlags.NonPublic | BindingFlags.Static)!;
+
+        var exception = Assert.Throws<TargetInvocationException>(() => method.Invoke(null, [routes]));
+
+        var innerException = Assert.IsType<InvalidOperationException>(exception.InnerException);
+        Assert.Contains("The following routes are ambiguous", innerException.Message);
+    }
+
+    private static object CreateRouteDefinition(string template)
+    {
+        var factoryType = GetFactoryType();
+        var parsedTemplate = factoryType
+            .GetMethod("ParseTemplate", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, [template])!;
+        var segments = parsedTemplate.GetType().GetProperty("Segments")!.GetValue(parsedTemplate)!;
+        var routeDefinitionType = factoryType.GetNestedType("RouteDefinition", BindingFlags.NonPublic)!;
+        var constructor = routeDefinitionType.GetConstructors().Single();
+        return constructor.Invoke([template, segments, typeof(ComponentBase), Array.Empty<string>()]);
+    }
+
+    private static Type GetFactoryType()
+        => Type.GetType("BootstrapBlazor.Components.RouteTableFactory, BootstrapBlazor")!;
+}


### PR DESCRIPTION
## Link issues
fixes #8392

## Summary By Copilot

- Keep route precedence sorting while making `CompareRoutes` a pure comparer.
- Detect adjacent ambiguous routes in a separate linear pass after sorting.
- Add regression coverage for self-comparison and genuinely ambiguous routes.
- Bump the package version to `10.10.1-beta01`.

## Regression?
- [x] Yes
- [ ] No

Route table creation could incorrectly report a valid route as ambiguous during sorting.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The change is limited to route table construction and preserves the existing precedence and ambiguity rules.

## Verification
- [ ] Manual (required)
- [x] Automated

`dotnet test test\UnitTest\UnitTest.csproj --no-restore --filter FullyQualifiedName~RouteTableFactoryTest --verbosity minimal`

All 2 targeted tests passed.

## Packaging changes reviewed?
- [x] Yes
- [ ] No
- [ ] N/A

The package version is updated from `10.10.0` to `10.10.1-beta01`.

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Fix route table construction so ambiguity errors are raised only for genuinely ambiguous routes.

Bug Fixes:
- Prevent valid routes from being incorrectly reported as ambiguous during route sorting by performing ambiguity detection after sorting.

Enhancements:
- Keep route precedence ordering while making route comparison a pure comparer.

Build:
- Bump the package version to 10.10.1-beta01.

Tests:
- Add regression coverage for route self-comparison and genuinely ambiguous routes.