### PR TITLE
fix(Drawer): preserve rendered size when resizing

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Drawers.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/Drawers.razor.cs
@@ -67,6 +67,7 @@ public sealed partial class Drawers
         ChildContent = builder => builder.AddContent(0, "Test"),
         ShowBackdrop = true,
         AllowResize = true,
-        IsBackdrop = true
+        IsBackdrop = true,
+        Width = "50%"
     });
 }

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.10.1-beta01</Version>
+    <Version>10.10.1-beta02</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Drawer/Drawer.razor.js
+++ b/src/BootstrapBlazor/Components/Drawer/Drawer.razor.js
@@ -22,11 +22,11 @@ const initDrag = el => {
             isVertical = drawerBody.classList.contains("top") || drawerBody.classList.contains("bottom")
             bar.classList.add('drag')
             if (isVertical) {
-                height = parseInt(getComputedStyle(drawerBody).getPropertyValue('--bb-drawer-height'))
+                height = drawerBody.getBoundingClientRect().height
                 originY = e.clientY || e.touches[0].clientY
             }
             else {
-                width = parseInt(getComputedStyle(drawerBody).getPropertyValue('--bb-drawer-width'))
+                width = drawerBody.getBoundingClientRect().width
                 originX = e.clientX || e.touches[0].clientX
             }
         },


### PR DESCRIPTION
## Link issues
fixes #8394

## Summary By Copilot

- Start Drawer resizing from its rendered pixel dimensions instead of parsing the configured CSS custom property.
- Preserve the current size when percentage or other CSS units are used.
- Demonstrate resizing a Drawer configured with `Width = "50%"`.
- Bump the package version to `10.10.1-beta02`.

## Regression?
- [x] Yes
- [ ] No

Resizable Drawers configured with percentage dimensions could jump to an incorrect size when dragging started.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The change only affects the initial size captured when a Drawer resize gesture starts.

## Verification
- [ ] Manual (required)
- [x] Automated

`node --check src\BootstrapBlazor\Components\Drawer\Drawer.razor.js`

`dotnet test test\UnitTest\UnitTest.csproj --no-restore --filter "FullyQualifiedName~DrawerTest|FullyQualifiedName~DrawerServiceTest" --verbosity minimal`

All 20 targeted tests passed.

## Packaging changes reviewed?
- [x] Yes
- [ ] No
- [ ] N/A

The package version is updated from `10.10.1-beta01` to `10.10.1-beta02`.

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Fix Drawer resizing so gestures begin from the currently rendered size rather than the configured CSS dimension.

Bug Fixes:
- Preserve a Drawer’s current rendered dimensions when resizing, including Drawers configured with percentage-based or other non-pixel sizes.

Build:
- Bump the BootstrapBlazor package version to 10.10.1-beta02.