### PR TITLE
fix(Layout): preserve rendered sidebar width when resizing

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Layouts.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Layouts.razor
@@ -100,7 +100,7 @@
            Introduction="@Localizer["LayoutsCustomPercentIntro"]"
            Name="CustomPercent">
     <div class="layout-demo">
-        <Layout ShowFooter="true" SideWidth="200" AdditionalAssemblies="[typeof(MainLayout).Assembly]">
+        <Layout ShowFooter="true" ShowSplitBar="true" SideWidth="30%" AdditionalAssemblies="[typeof(MainLayout).Assembly]">
             <Header>
                 <div>Header</div>
             </Header>

--- a/src/BootstrapBlazor.Server/Components/Samples/Layouts.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Layouts.razor
@@ -100,7 +100,7 @@
            Introduction="@Localizer["LayoutsCustomPercentIntro"]"
            Name="CustomPercent">
     <div class="layout-demo">
-        <Layout ShowFooter="true" ShowSplitBar="true" SideWidth="30%" AdditionalAssemblies="[typeof(MainLayout).Assembly]">
+        <Layout ShowFooter="true" SideWidth="200" AdditionalAssemblies="[typeof(MainLayout).Assembly]">
             <Header>
                 <div>Header</div>
             </Header>

--- a/src/BootstrapBlazor/BootstrapBlazor.csproj
+++ b/src/BootstrapBlazor/BootstrapBlazor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
-    <Version>10.10.1-beta02</Version>
+    <Version>10.10.1-beta03</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.js
+++ b/src/BootstrapBlazor/Components/Layout/LayoutSplitBar.razor.js
@@ -21,12 +21,7 @@ export function init(id) {
     Drag.drag(bar,
         e => {
             section.classList.add('drag');
-            const widthString = getComputedStyle(section).getPropertyValue('--bb-layout-sidebar-width');
-            if (widthString === '') {
-                section.style.setProperty('--bb-layout-sidebar-width', '0');
-                widthString = '0';
-            }
-            width = parseInt(widthString);
+            width = el.parentElement.getBoundingClientRect().width;
             originX = e.clientX || e.touches[0].clientX;
         },
         e => {


### PR DESCRIPTION
## Link issues
fixes #8396

## Summary By Copilot

- Start Layout sidebar resizing from its rendered pixel width instead of parsing the configured CSS custom property.
- Preserve the current sidebar size when `SideWidth` uses percentages or other CSS units.
- Demonstrate a resizable Layout configured with `SideWidth="30%"`.
- Bump the package version to `10.10.1-beta03`.

## Regression?
- [x] Yes
- [ ] No

Resizable Layout sidebars configured with percentage widths could jump to an incorrect size when dragging started.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The change only affects the initial sidebar width captured when a Layout split-bar resize gesture starts.

## Verification
- [ ] Manual (required)
- [x] Automated

`node --check src\BootstrapBlazor\Components\Layout\LayoutSplitBar.razor.js`

`dotnet test test\UnitTest\UnitTest.csproj --no-restore --filter "FullyQualifiedName~LayoutTest|FullyQualifiedName~LayoutSplitBarTest" --verbosity minimal`

All 32 targeted tests passed.

## Packaging changes reviewed?
- [x] Yes
- [ ] No
- [ ] N/A

The package version is updated from `10.10.1-beta02` to `10.10.1-beta03`.

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Preserve the current rendered sidebar size when resizing Layout sidebars.

Bug Fixes:
- Preserve the rendered sidebar width when starting Layout resize gestures, preventing percentage-based and other CSS-unit widths from jumping to an incorrect size.

Build:
- Bump the BootstrapBlazor package version to 10.10.1-beta03.

Tests:
- Add or update Layout resize coverage and demonstrate resizing with a percentage-based sidebar width.