### PR TITLE
refactor: remove redundant component rendering calls

### DIFF
--- a/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimePicker/DatePickerBody.razor.cs
@@ -796,7 +796,6 @@ public partial class DatePickerBody
     private void OnShowTimePicker()
     {
         _showTimePicker = true;
-        StateHasChanged();
     }
 
     private bool HasSeconds => TimeFormat.Contains('s');

--- a/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
+++ b/src/BootstrapBlazor/Components/DateTimeRange/DateTimeRange.razor.cs
@@ -554,10 +554,6 @@ public partial class DateTimeRange
         {
             await ClickConfirmButton();
         }
-        else
-        {
-            StateHasChanged();
-        }
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/DragDrap/Dropzone.razor.cs
+++ b/src/BootstrapBlazor/Components/DragDrap/Dropzone.razor.cs
@@ -277,7 +277,6 @@ public partial class Dropzone<TItem> : IDisposable
                     //DragDropService.Commit();
                 }
             }
-            StateHasChanged();
         }
         Items.Remove(default!);
     }
@@ -305,14 +304,11 @@ public partial class Dropzone<TItem> : IDisposable
         }
 
         DragDropService.DragTargetItem = item;
-
-        StateHasChanged();
     }
 
     private void OnDragLeave()
     {
         DragDropService.DragTargetItem = default;
-        StateHasChanged();
     }
 
     private void OnDrop()
@@ -357,7 +353,6 @@ public partial class Dropzone<TItem> : IDisposable
             }
         }
 
-        StateHasChanged();
         OnItemDrop.InvokeAsync(activeItem);
     }
 

--- a/src/BootstrapBlazor/Components/Filters/FilterProvider.razor.cs
+++ b/src/BootstrapBlazor/Components/Filters/FilterProvider.razor.cs
@@ -122,7 +122,6 @@ public partial class FilterProvider
         {
             await TableColumnFilter.Reset();
         }
-        StateHasChanged();
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -786,7 +786,6 @@ public partial class Layout : ITabHeader
         if (IsCollapsed && !IsExpandOnHover && !_isSidebarExpand)
         {
             _isSidebarExpand = true;
-            StateHasChanged();
         }
     }
 

--- a/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
+++ b/src/BootstrapBlazor/Components/Layout/Layout.razor.cs
@@ -799,7 +799,6 @@ public partial class Layout : ITabHeader
         if (_isSidebarExpand)
         {
             _isSidebarExpand = false;
-            StateHasChanged();
         }
     }
 

--- a/src/BootstrapBlazor/Components/ValidateForm/BootstrapBlazorDataAnnotationsValidator.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/BootstrapBlazorDataAnnotationsValidator.cs
@@ -9,13 +9,13 @@ namespace BootstrapBlazor.Components;
 
 /// <summary>
 /// <para lang="zh">BootstrapBlazorDataAnnotationsValidator 验证组件</para>
-/// <para lang="en">BootstrapBlazorDataAnnotationsValidator Validation Component</para>
+/// <para lang="en">BootstrapBlazorDataAnnotationsValidator validation component</para>
 /// </summary>
 public class BootstrapBlazorDataAnnotationsValidator : ComponentBase, IDisposable
 {
     /// <summary>
     /// <para lang="zh">获得/设置 当前编辑数据上下文</para>
-    /// <para lang="en">Gets or sets Current Edit Data Context</para>
+    /// <para lang="en">Gets or sets the current edit context</para>
     /// </summary>
     [CascadingParameter]
     [NotNull]
@@ -23,7 +23,7 @@ public class BootstrapBlazorDataAnnotationsValidator : ComponentBase, IDisposabl
 
     /// <summary>
     /// <para lang="zh">获得/设置 当前编辑窗体上下文</para>
-    /// <para lang="en">Gets or sets 当前编辑窗体上下文</para>
+    /// <para lang="en">Gets or sets the current validation form</para>
     /// </summary>
     [CascadingParameter]
     [NotNull]
@@ -38,7 +38,7 @@ public class BootstrapBlazorDataAnnotationsValidator : ComponentBase, IDisposabl
 
     /// <summary>
     /// <para lang="zh">初始化方法</para>
-    /// <para lang="en">初始化方法</para>
+    /// <para lang="en">Initializes the component</para>
     /// </summary>
     protected override void OnInitialized()
     {
@@ -54,7 +54,7 @@ public class BootstrapBlazorDataAnnotationsValidator : ComponentBase, IDisposabl
     private TaskCompletionSource<bool>? _tcs;
     /// <summary>
     /// <para lang="zh">手动验证表单方法</para>
-    /// <para lang="en">手动验证表单方法</para>
+    /// <para lang="en">Validates the form manually</para>
     /// </summary>
     internal async Task<bool> ValidateAsync()
     {
@@ -66,7 +66,7 @@ public class BootstrapBlazorDataAnnotationsValidator : ComponentBase, IDisposabl
 
     /// <summary>
     /// <para lang="zh">手动验证表单方法</para>
-    /// <para lang="en">手动验证表单方法</para>
+    /// <para lang="en">Validates the form manually</para>
     /// </summary>
     [ExcludeFromCodeCoverage]
     internal bool Validate() => CurrentEditContext.Validate();
@@ -145,8 +145,7 @@ public class BootstrapBlazorDataAnnotationsValidator : ComponentBase, IDisposabl
     }
 
     /// <summary>
-    /// <para lang="zh"><inheritdoc/></para>
-    /// <para lang="en"><inheritdoc/></para>
+    /// <inheritdoc/>
     /// </summary>
     public void Dispose()
     {


### PR DESCRIPTION
## Link issues
fixes #8401

## Summary By Copilot

- Remove redundant `StateHasChanged` calls from DatePickerBody, DateTimeRange, Dropzone, FilterProvider, and Layout event handlers.
- Preserve the automatic rendering behavior provided by Blazor event callbacks.
- Normalize the Chinese and English XML comments in `BootstrapBlazorDataAnnotationsValidator`.

## Regression?
- [ ] Yes
- [x] No

The changes remove duplicate render requests without changing component state transitions or public APIs.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The affected methods are Blazor event handlers, which automatically schedule rendering after their callbacks complete.

## Verification
- [ ] Manual (required)
- [x] Automated

`dotnet test test\UnitTest\UnitTest.csproj -f net10.0 --nologo --verbosity quiet`

All 2570 tests passed.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

No package or version files changed.

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [x] Merge the latest code from the main branch

## Summary by Sourcery

Eliminate duplicate component rendering calls and clarify validator documentation.

Enhancements:
- Remove redundant manual render requests from Blazor component event handlers while preserving their existing state updates and automatic rendering behavior.

Documentation:
- Improve and normalize the English XML documentation for the data annotations validator.