### PR TITLE
fix(Block): prevent stale IsShow state

### DIFF
--- a/src/BootstrapBlazor/Components/Block/Block.cs
+++ b/src/BootstrapBlazor/Components/Block/Block.cs
@@ -83,6 +83,7 @@ public class Block : BootstrapComponentBase
     {
         await base.OnParametersSetAsync();
 
+        IsShow = false;
         if (Users != null || Roles != null)
         {
             IsShow = await ProcessAuthorizeAsync();

--- a/src/BootstrapBlazor/Components/Block/Block.cs
+++ b/src/BootstrapBlazor/Components/Block/Block.cs
@@ -37,15 +37,15 @@ public class Block : BootstrapComponentBase
     public IEnumerable<string>? Users { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示此 Block 默认显示 返回 true 时显示</para>
-    /// <para lang="en">Gets or sets whether to show this Block. Default is true</para>
+    /// <para lang="zh">获得/设置 是否显示此 Block 设置 true 时显示</para>
+    /// <para lang="en">Gets or sets whether to show this Block. The content is shown when set to true</para>
     /// </summary>
     [Parameter]
     public Func<string?, Task<bool>>? OnQueryCondition { get; set; }
 
     /// <summary>
-    /// <para lang="zh">获得/设置 是否显示此 Block 默认显示 null 未参与判断 设置 true 时显示</para>
-    /// <para lang="en">Gets or sets whether to show this Block. Default is null (not participating in judgment). Show if set to true</para>
+    /// <para lang="zh">获得/设置 是否显示此 Block 默认值为 null（不参与判断），未设置任何判断条件时不显示</para>
+    /// <para lang="en">Gets or sets whether to show this Block. Default is null (not participating in judgment); the content is hidden when no condition is configured</para>
     /// </summary>
     [Parameter]
     public bool? Condition { get; set; }
@@ -100,34 +100,42 @@ public class Block : BootstrapComponentBase
 
     private async Task<bool> ProcessAuthorizeAsync()
     {
-        bool isAuthenticated = false;
-        AuthenticationState? state = null;
+        var ret = false;
+
         var provider = ServiceProvider.GetService<AuthenticationStateProvider>();
         if (provider != null)
         {
-            state = await provider.GetAuthenticationStateAsync();
+            var state = await provider.GetAuthenticationStateAsync();
+            var user = state.User;
+            if (user.Identity is { IsAuthenticated: true })
+            {
+                ret = IsAllowed(Users, i => i.Equals(user.Identity.Name, StringComparison.OrdinalIgnoreCase)) && IsAllowed(Roles, user.IsInRole);
+            }
         }
-        if (state != null)
+
+        return ret;
+    }
+
+    private static bool IsAllowed(IEnumerable<string>? values, Func<string, bool> predicate)
+    {
+        // 为空是直接返回 true 允许
+        if (values == null)
         {
-            var identity = state.User.Identity;
-            if (identity != null)
-            {
-                isAuthenticated = identity.IsAuthenticated;
-            }
+            return true;
         }
-        if (isAuthenticated)
+
+        var hasValue = false;
+        foreach (var value in values)
         {
-            if (Users?.Any() ?? false)
+            hasValue = true;
+            if (predicate(value))
             {
-                var userName = state!.User.Identity!.Name;
-                isAuthenticated = Users.Any(i => i.Equals(userName, StringComparison.OrdinalIgnoreCase));
-            }
-            if (Roles?.Any() ?? false)
-            {
-                isAuthenticated = Roles.Any(i => state!.User.IsInRole(i));
+                return true;
             }
         }
-        return isAuthenticated;
+
+        // values 集合为空时返回 true 允许
+        return !hasValue;
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Block/Block.cs
+++ b/src/BootstrapBlazor/Components/Block/Block.cs
@@ -77,8 +77,7 @@ public class Block : BootstrapComponentBase
     private bool IsShow { get; set; }
 
     /// <summary>
-    /// <para lang="zh">OnParametersSetAsync 方法</para>
-    /// <para lang="en">OnParametersSetAsync method</para>
+    /// <inheritdoc/>
     /// </summary>
     protected override async Task OnParametersSetAsync()
     {

--- a/test/UnitTest/Components/BlockTest.cs
+++ b/test/UnitTest/Components/BlockTest.cs
@@ -3,6 +3,9 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Microsoft.AspNetCore.Components.Authorization;
+using System.Security.Claims;
+
 namespace UnitTest.Components;
 
 public class BlockTest : TestBase
@@ -52,12 +55,47 @@ public class BlockTest : TestBase
         Assert.Equal("", cut.Markup);
     }
 
+    [Fact]
+    public void ResetCondition_Ok()
+    {
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Condition, true);
+            builder.Add(a => a.ChildContent, BuildComponent());
+        });
+
+        cut.Render(parameters => parameters
+            .Add(a => a.Condition, null)
+            .Add(a => a.ChildContent, BuildComponent()));
+
+        Assert.Equal("", cut.Markup);
+    }
+
+    [Fact]
+    public void NullIdentity_HidesContent_Ok()
+    {
+        Context.Services.AddSingleton<AuthenticationStateProvider, NullIdentityAuthenticationStateProvider>();
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, ["Admin"]);
+            builder.Add(a => a.ChildContent, BuildComponent());
+        });
+
+        Assert.Equal("", cut.Markup);
+    }
+
     internal static RenderFragment BuildComponent() => builder =>
     {
         builder.OpenElement(0, "div");
         builder.AddContent(1, "test");
         builder.CloseElement();
     };
+
+    private sealed class NullIdentityAuthenticationStateProvider : AuthenticationStateProvider
+    {
+        public override Task<AuthenticationState> GetAuthenticationStateAsync() => Task.FromResult(new AuthenticationState(new ClaimsPrincipal()));
+    }
 }
 
 public class BlockAuthorizationTest : AuthorizationViewTestBase
@@ -69,7 +107,7 @@ public class BlockAuthorizationTest : AuthorizationViewTestBase
 
         var cut = Context.Render<Block>(builder =>
         {
-            builder.Add(a => a.Users, new List<string>() { "Admin" });
+            builder.Add(a => a.Users, ["Admin"]);
             builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
         });
         Assert.Equal("<div>test</div>", cut.Markup);
@@ -82,9 +120,146 @@ public class BlockAuthorizationTest : AuthorizationViewTestBase
 
         var cut = Context.Render<Block>(builder =>
         {
-            builder.Add(a => a.Roles, new List<string>() { "Administrators" });
+            builder.Add(a => a.Roles, ["Administrators"]);
             builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
         });
         Assert.Equal("<div>test</div>", cut.Markup);
+    }
+
+    [Fact]
+    public void Users_NotEmpty_Ok()
+    {
+        AuthorizationContext.SetAuthorized("Admin");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, ["User", "Admin"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("<div>test</div>", cut.Markup);
+    }
+
+    [Fact]
+    public void Roles_NotEmpty_Ok()
+    {
+        AuthorizationContext.SetRoles("Administrators");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Roles, ["Users", "Administrators"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("<div>test</div>", cut.Markup);
+    }
+
+    [Fact]
+    public void UsersAndRoles_Match_Ok()
+    {
+        AuthorizationContext.SetAuthorized("Admin");
+        AuthorizationContext.SetRoles("Administrators");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, ["Admin"]);
+            builder.Add(a => a.Roles, ["Administrators"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("<div>test</div>", cut.Markup);
+    }
+
+    [Fact]
+    public void UsersAndRoles_RequireBoth_Ok()
+    {
+        AuthorizationContext.SetAuthorized("Admin");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, ["Admin"]);
+            builder.Add(a => a.Roles, ["Administrators"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("", cut.Markup);
+    }
+
+    [Fact]
+    public void UserMismatch_HidesContent_Ok()
+    {
+        AuthorizationContext.SetAuthorized("Admin");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, ["User"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("", cut.Markup);
+    }
+
+    [Fact]
+    public void RoleMismatch_HidesContent_Ok()
+    {
+        AuthorizationContext.SetRoles("Users");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Roles, ["Administrators"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("", cut.Markup);
+    }
+
+    [Fact]
+    public void UnauthorizedUser_HidesContent_Ok()
+    {
+        AuthorizationContext.SetNotAuthorized();
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, ["Admin"]);
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("", cut.Markup);
+    }
+
+    [Fact]
+    public void EmptyUsers_DoesNotRestrict_Ok()
+    {
+        AuthorizationContext.SetAuthorized("Admin");
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, Array.Empty<string>());
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("<div>test</div>", cut.Markup);
+    }
+
+    [Fact]
+    public void Users_EnumeratedOnce_Ok()
+    {
+        AuthorizationContext.SetAuthorized("Admin");
+        var enumerationCount = 0;
+
+        IEnumerable<string> Users()
+        {
+            enumerationCount++;
+            yield return "Admin";
+        }
+
+        var cut = Context.Render<Block>(builder =>
+        {
+            builder.Add(a => a.Users, Users());
+            builder.Add(a => a.ChildContent, BlockTest.BuildComponent());
+        });
+
+        Assert.Equal("<div>test</div>", cut.Markup);
+        Assert.Equal(1, enumerationCount);
     }
 }


### PR DESCRIPTION
## Link issues
fixes #8416

## Summary By Copilot

- Reset Block display state before each parameter evaluation to prevent stale IsShow values.
- Refactor Block authorization checks to avoid repeated enumeration while preserving configured Users and Roles restrictions.
- Add Block unit tests for condition reset, authorization match and mismatch, unauthenticated users, null identities, empty collections, and deferred enumeration coverage.

## Regression?
- [ ] Yes
- [x] No

## Risk
- [ ] High
- [ ] Medium
- [x] Low

The change is limited to Block visibility and authorization evaluation, with targeted unit test coverage for the affected behavior.

## Verification
- [ ] Manual (required)
- [x] Automated

`dotnet test test\UnitTest\UnitTest.csproj --filter FullyQualifiedName~Block --no-restore --nologo -v minimal`

Result: Failed: 0, Passed: 2585, Skipped: 0, Total: 2585.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch
