### PR TITLE
test(ValidateForm): update async validation coverage

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/ValidateForms.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/ValidateForms.razor
@@ -49,38 +49,36 @@
     <ConsoleLogger @ref="Logger1" />
 </DemoBlock>
 
-<Block Condition="IsAsyncValidationSupported">
-    <DemoBlock Title="@Localizer["ValidateFormAsyncValidationTitle"]" Introduction="@Localizer["ValidateFormAsyncValidationIntro"]" Name="AsyncValidation">
-        <section ignore>
-            <p>@((MarkupString)Localizer["ValidateFormAsyncValidationDescription"].Value)</p>
-            <Pre class="mb-3">public sealed class UniqueUserNameAttribute : AsyncValidationAttribute
+<DemoBlock Title="@Localizer["ValidateFormAsyncValidationTitle"]" Introduction="@Localizer["ValidateFormAsyncValidationIntro"]" Name="AsyncValidation">
+    <section ignore>
+        <p>@((MarkupString)Localizer["ValidateFormAsyncValidationDescription"].Value)</p>
+        <Pre class="mb-3">public sealed class UniqueUserNameAttribute : AsyncValidationAttribute
 {
-    protected override ValidationResult? IsValid(object? value, ValidationContext context)
-        =&gt; throw new InvalidOperationException("Synchronous validation is not supported.");
+protected override ValidationResult? IsValid(object? value, ValidationContext context)
+    =&gt; throw new InvalidOperationException("Synchronous validation is not supported.");
 
-    protected override async Task&lt;ValidationResult?&gt; IsValidAsync(
-        object? value, ValidationContext context, CancellationToken cancellationToken)
-    {
-        await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
-        return string.Equals(value as string, "Blazor", StringComparison.OrdinalIgnoreCase)
-            ? new ValidationResult("The user name already exists.")
-            : ValidationResult.Success;
-    }
+protected override async Task&lt;ValidationResult?&gt; IsValidAsync(
+    object? value, ValidationContext context, CancellationToken cancellationToken)
+{
+    await Task.Delay(TimeSpan.FromSeconds(1), cancellationToken);
+    return string.Equals(value as string, "Blazor", StringComparison.OrdinalIgnoreCase)
+        ? new ValidationResult("The user name already exists.")
+        : ValidationResult.Success;
+}
 }</Pre>
-        </section>
+    </section>
 
-        <ValidateForm Model="@AsyncModel">
-            <div class="row g-3">
-                <div class="col-12 col-sm-6">
-                    <BootstrapInput @bind-Value="@AsyncModel.UserName" DisplayText="@Localizer["AsyncValidationUserName"]" />
-                </div>
-                <div class="col-12">
-                    <Button ButtonType="@ButtonType.Submit" IsAsync="true" Text="@Localizer["ValidateFormsSubmitButtonText"]" />
-                </div>
+    <ValidateForm Model="@AsyncModel">
+        <div class="row g-3">
+            <div class="col-12 col-sm-6">
+                <BootstrapInput @bind-Value="@AsyncModel.UserName" DisplayText="@Localizer["AsyncValidationUserName"]" />
             </div>
-        </ValidateForm>
-    </DemoBlock>
-</Block>
+            <div class="col-12">
+                <Button ButtonType="@ButtonType.Submit" IsAsync="true" Text="@Localizer["ValidateFormsSubmitButtonText"]" />
+            </div>
+        </div>
+    </ValidateForm>
+</DemoBlock>
 
 <DemoBlock Title="@Localizer["ValidateFormInnerComponentTitle"]" Introduction="@Localizer["ValidateFormInnerComponentIntro"]" Name="InnerComponent">
     <section ignore>

--- a/src/BootstrapBlazor.Server/Components/Samples/ValidateForms.razor.cs
+++ b/src/BootstrapBlazor.Server/Components/Samples/ValidateForms.razor.cs
@@ -13,12 +13,6 @@ namespace BootstrapBlazor.Server.Components.Samples;
 /// </summary>
 public partial class ValidateForms
 {
-#if NET11_0_OR_GREATER
-    private const bool IsAsyncValidationSupported = true;
-#else
-    private const bool IsAsyncValidationSupported = false;
-#endif
-
     [NotNull]
     private Foo? Model1 { get; set; }
 
@@ -47,13 +41,10 @@ public partial class ValidateForms
     private sealed class AsyncValidationModel
     {
         [Required]
-#if NET11_0_OR_GREATER
         [UniqueUserName]
-#endif
         public string? UserName { get; set; }
     }
 
-#if NET11_0_OR_GREATER
     private sealed class UniqueUserNameAttribute : AsyncValidationAttribute
     {
         protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
@@ -70,7 +61,6 @@ public partial class ValidateForms
                 : ValidationResult.Success;
         }
     }
-#endif
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -483,6 +483,7 @@ public partial class ValidateForm
         var validationRules = rules.ToList();
         memberName ??= propertyInfo.Name;
 
+        // 验证 RequiredAttribute 规则，确保必填项验证优先执行
         foreach (var rule in validationRules.Where(static rule => rule is RequiredAttribute))
         {
             var result = rule.GetValidationResult(value, context);
@@ -491,6 +492,7 @@ public partial class ValidateForm
 
         if (results.Count == 0)
         {
+            // 验证非 RequiredAttribute 和非 AsyncValidationAttribute 规则
             foreach (var rule in validationRules.Where(static rule => rule is not RequiredAttribute and not AsyncValidationAttribute))
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -501,6 +503,7 @@ public partial class ValidateForm
 
         if (results.Count == 0)
         {
+            // 验证 AsyncValidationAttribute 规则
             foreach (var rule in validationRules.OfType<AsyncValidationAttribute>())
             {
                 cancellationToken.ThrowIfCancellationRequested();

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -861,6 +861,26 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         Assert.False(model.SyncValidated);
         Assert.Equal("Async validation failed", cut.FindComponent<MockInput<string>>().Instance.GetErrorMessage());
     }
+    
+    [Fact]
+    public async Task IAsyncValidatableObject_ModelError()
+    {
+        var model = new MockAsyncModelError();
+        var cut = Context.Render<ValidateForm>(pb =>
+        {
+            pb.Add(a => a.Model, model);
+            pb.AddChildContent<MockInput<string>>(pb =>
+            {
+                pb.Add(a => a.Value, model.Name);
+                pb.Add(a => a.ValueExpression, Utility.GenerateValueExpression(model, nameof(model.Name), typeof(string)));
+            });
+        });
+
+        var valid = await cut.InvokeAsync(() => cut.Instance.ValidateAsync(CancellationToken.None));
+
+        Assert.False(valid);
+    }
+#endif
 
     [Fact]
     public async Task AsyncValidationAttribute_Ok()
@@ -912,26 +932,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             Assert.Contains("is-invalid", input.ClassList);
         }, TimeSpan.FromSeconds(1));
     }
-
-    [Fact]
-    public async Task IAsyncValidatableObject_ModelError()
-    {
-        var model = new MockAsyncModelError();
-        var cut = Context.Render<ValidateForm>(pb =>
-        {
-            pb.Add(a => a.Model, model);
-            pb.AddChildContent<MockInput<string>>(pb =>
-            {
-                pb.Add(a => a.Value, model.Name);
-                pb.Add(a => a.ValueExpression, Utility.GenerateValueExpression(model, nameof(model.Name), typeof(string)));
-            });
-        });
-
-        var valid = await cut.InvokeAsync(() => cut.Instance.ValidateAsync(CancellationToken.None));
-
-        Assert.False(valid);
-    }
-#endif
 
     [Fact]
     public async Task IValidateCollection_Ok()
@@ -1254,6 +1254,23 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         }
     }
 
+    private sealed class MockAsyncModelError : IAsyncValidatableObject
+    {
+        public string? Name { get; set; }
+
+        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) => [];
+
+        public async IAsyncEnumerable<ValidationResult> ValidateAsync(
+            ValidationContext validationContext,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.Yield();
+            cancellationToken.ThrowIfCancellationRequested();
+            yield return new ValidationResult("Model validation failed");
+        }
+    }
+#endif
+
     private sealed class MockAsyncValidationAttributeModel
     {
         [MockAsyncValidation]
@@ -1302,23 +1319,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             return new ValidationResult("Async attribute validation failed");
         }
     }
-
-    private sealed class MockAsyncModelError : IAsyncValidatableObject
-    {
-        public string? Name { get; set; }
-
-        public IEnumerable<ValidationResult> Validate(ValidationContext validationContext) => [];
-
-        public async IAsyncEnumerable<ValidationResult> ValidateAsync(
-            ValidationContext validationContext,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
-        {
-            await Task.Yield();
-            cancellationToken.ThrowIfCancellationRequested();
-            yield return new ValidationResult("Model validation failed");
-        }
-    }
-#endif
 
     private class MockValidateCollectionModel : IValidateCollection
     {

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -934,6 +934,56 @@ public class ValidateFormTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public async Task AsyncValidationAttribute_CancelBeforeValidation()
+    {
+        var model = new MockCancelBeforeAsyncValidationAttributeModel();
+        MockCancelableAsyncValidationAttribute.Reset();
+        var cut = Context.Render<ValidateForm>(pb =>
+        {
+            pb.Add(a => a.Model, model);
+            pb.AddChildContent<MockInput<string>>(pb =>
+            {
+                pb.Add(a => a.Value, model.Name);
+                pb.Add(a => a.ValueExpression, Utility.GenerateValueExpression(model, nameof(model.Name), typeof(string)));
+            });
+        });
+
+        try
+        {
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await cut.InvokeAsync(() => cut.Instance.ValidateAsync(model.TokenSource.Token)));
+            Assert.Equal(0, MockCancelableAsyncValidationAttribute.ValidateCount);
+        }
+        finally
+        {
+            model.TokenSource.Dispose();
+        }
+    }
+
+    [Fact]
+    public async Task AsyncValidationAttribute_AllPassed()
+    {
+        var model = new MockSuccessAsyncValidationAttributeModel();
+        MockFirstSuccessAsyncValidationAttribute.Reset();
+        MockSecondSuccessAsyncValidationAttribute.Reset();
+        var cut = Context.Render<ValidateForm>(pb =>
+        {
+            pb.Add(a => a.Model, model);
+            pb.AddChildContent<MockInput<string>>(pb =>
+            {
+                pb.Add(a => a.Value, model.Name);
+                pb.Add(a => a.ValueExpression, Utility.GenerateValueExpression(model, nameof(model.Name), typeof(string)));
+            });
+        });
+
+        var valid = await cut.InvokeAsync(() => cut.Instance.ValidateAsync(CancellationToken.None));
+
+        Assert.True(valid);
+        Assert.Equal(1, MockFirstSuccessAsyncValidationAttribute.ValidateCount);
+        Assert.Equal(1, MockSecondSuccessAsyncValidationAttribute.ValidateCount);
+        Assert.Null(cut.FindComponent<MockInput<string>>().Instance.GetErrorMessage());
+    }
+
+    [Fact]
     public async Task IValidateCollection_Ok()
     {
         var model = new MockValidateCollectionModel() { Telephone1 = "123", Telephone2 = "123" };
@@ -1303,6 +1353,22 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         public TaskCompletionSource ContinueValidation { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     }
 
+    private sealed class MockCancelBeforeAsyncValidationAttributeModel
+    {
+        [MockCancelBeforeAsyncValidation]
+        [MockCancelableAsyncValidation]
+        public string? Name { get; set; }
+
+        public CancellationTokenSource TokenSource { get; } = new();
+    }
+
+    private sealed class MockSuccessAsyncValidationAttributeModel
+    {
+        [MockFirstSuccessAsyncValidation]
+        [MockSecondSuccessAsyncValidation]
+        public string? Name { get; set; } = "Test";
+    }
+
     private sealed class MockPendingAsyncValidationAttribute : AsyncValidationAttribute
     {
         protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
@@ -1317,6 +1383,73 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             model.ValidationStarted.TrySetResult();
             await model.ContinueValidation.Task.WaitAsync(cancellationToken);
             return new ValidationResult("Async attribute validation failed");
+        }
+    }
+
+    private sealed class MockCancelBeforeAsyncValidationAttribute : ValidationAttribute
+    {
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+        {
+            var model = (MockCancelBeforeAsyncValidationAttributeModel)validationContext.ObjectInstance;
+            model.TokenSource.Cancel();
+            return ValidationResult.Success;
+        }
+    }
+
+    private sealed class MockCancelableAsyncValidationAttribute : AsyncValidationAttribute
+    {
+        public static int ValidateCount { get; private set; }
+
+        public static void Reset() => ValidateCount = 0;
+
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+            => throw new InvalidOperationException("The synchronous validation path should not be used.");
+
+        protected override Task<ValidationResult?> IsValidAsync(
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken)
+        {
+            ValidateCount++;
+            return Task.FromResult<ValidationResult?>(ValidationResult.Success);
+        }
+    }
+
+    private sealed class MockFirstSuccessAsyncValidationAttribute : AsyncValidationAttribute
+    {
+        public static int ValidateCount { get; private set; }
+
+        public static void Reset() => ValidateCount = 0;
+
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+            => throw new InvalidOperationException("The synchronous validation path should not be used.");
+
+        protected override Task<ValidationResult?> IsValidAsync(
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken)
+        {
+            ValidateCount++;
+            return Task.FromResult<ValidationResult?>(ValidationResult.Success);
+        }
+    }
+
+    private sealed class MockSecondSuccessAsyncValidationAttribute : AsyncValidationAttribute
+    {
+        public static int ValidateCount { get; private set; }
+
+        public static void Reset() => ValidateCount = 0;
+
+        protected override ValidationResult? IsValid(object? value, ValidationContext validationContext)
+            => throw new InvalidOperationException("The synchronous validation path should not be used.");
+
+        protected override Task<ValidationResult?> IsValidAsync(
+            object? value,
+            ValidationContext validationContext,
+            CancellationToken cancellationToken)
+        {
+            ValidateCount++;
+            return Task.FromResult<ValidationResult?>(ValidationResult.Success);
         }
     }
 

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -116,7 +116,7 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         var field = typeof(BootstrapBlazorDataAnnotationsValidator).GetField(
             "_fieldValidationOperations",
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
-        var operations = Assert.IsAssignableFrom<System.Collections.IDictionary>(field?.GetValue(validator));
+        var operations = Assert.IsType<System.Collections.IDictionary>(field?.GetValue(validator), false);
         cut.WaitForAssertion(() => Assert.Empty(operations));
     }
 


### PR DESCRIPTION
## Link issues
fixes #8422

## Summary By Copilot

- Update the ValidateForm async validation sample layout and related code comments.
- Add ValidateForm unit coverage for `AsyncValidationAttribute` execution outside the .NET 11-only path.
- Cover `ValidateDataAnnotationsAsync` cancellation checks and multiple async validation attributes passing through the full foreach path.

## Regression?
- [ ] Yes
- [x] No

The changes are limited to samples, comments, and unit test coverage around existing async validation behavior.

## Risk
- [ ] High
- [ ] Medium
- [x] Low

No public API or package configuration changes are included.

## Verification
- [ ] Manual (required)
- [ ] Automated

Not run per request.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

No package metadata or target framework files changed.

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Improve cross-target asynchronous validation coverage and expose the corresponding sample consistently.

Enhancements:
- Make the asynchronous validation sample available across supported target frameworks and clarify its validation flow.
- Add coverage for cancellation before asynchronous validation and successful execution of multiple asynchronous validation attributes.

Tests:
- Expand ValidateForm tests for asynchronous model errors, cancellation handling, and multiple passing asynchronous validation attributes.