### PR TITLE
feat(ValidateForm): add IAsyncValidatableObject support

### DIFF
--- a/src/BootstrapBlazor/Attributes/IAsyncValidatableObject.cs
+++ b/src/BootstrapBlazor/Attributes/IAsyncValidatableObject.cs
@@ -1,0 +1,23 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+#if !NET11_0_OR_GREATER
+namespace System.ComponentModel.DataAnnotations;
+
+/// <summary>
+/// <para lang="zh">异步验证对象接口</para>
+/// <para lang="en">Interface for asynchronously validating an object</para>
+/// </summary>
+public interface IAsyncValidatableObject : IValidatableObject
+{
+    /// <summary>
+    /// <para lang="zh">异步验证当前对象</para>
+    /// <para lang="en">Asynchronously validates the current object</para>
+    /// </summary>
+    /// <param name="validationContext"></param>
+    /// <param name="cancellationToken"></param>
+    IAsyncEnumerable<ValidationResult> ValidateAsync(ValidationContext validationContext, CancellationToken cancellationToken = default);
+}
+#endif

--- a/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
+++ b/src/BootstrapBlazor/Components/ValidateForm/ValidateForm.razor.cs
@@ -355,11 +355,9 @@ public partial class ValidateForm
                 results.AddRange(messages);
             }
 
-            // 验证 IValidatableObject
             if (results.Count == 0)
             {
                 var messages = new List<ValidationResult>();
-#if NET11_0_OR_GREATER
                 IAsyncValidatableObject? asyncValidate;
                 if (context.ObjectInstance is IAsyncValidatableObject asyncValidatableObject)
                 {
@@ -372,13 +370,13 @@ public partial class ValidateForm
 
                 if (asyncValidate != null)
                 {
+                    // 验证 IAsyncValidatableObject
                     await foreach (var message in asyncValidate.ValidateAsync(context, cancellationToken).WithCancellation(cancellationToken))
                     {
                         messages.Add(message);
                     }
                 }
                 else
-#endif
                 {
                     IValidatableObject? validate;
                     if (context.ObjectInstance is IValidatableObject v)
@@ -391,6 +389,7 @@ public partial class ValidateForm
                     }
                     if (validate != null)
                     {
+                        // 验证 IValidatableObject
                         messages.AddRange(validate.Validate(context));
                     }
                 }

--- a/src/BootstrapBlazor/Extensions/ValidateContextExtensions.cs
+++ b/src/BootstrapBlazor/Extensions/ValidateContextExtensions.cs
@@ -10,17 +10,17 @@ namespace BootstrapBlazor.Components;
 
 /// <summary>
 /// <para lang="zh">ValidationContext 扩展方法</para>
-/// <para lang="en">ValidationContext 扩展方法</para>
+/// <para lang="en">ValidationContext extension methods</para>
 /// </summary>
 public static class ValidationContextExtensions
 {
     /// <summary>
     /// <para lang="zh">从 <see cref="MetadataTypeAttribute"/> 中获取指定类型实例</para>
-    /// <para lang="en">从 <see cref="MetadataTypeAttribute"/> 中获取指定typeinstance</para>
+    /// <para lang="en">Gets an instance of the specified type from <see cref="MetadataTypeAttribute"/></para>
     /// </summary>
-    /// <typeparam name="T"><para lang="zh">验证接口类型</para><para lang="en">验证接口type</para></typeparam>
-    /// <param name="context"></param>
-    /// <returns><para lang="zh">没有实现 <typeparamref name="T"/> 接口，则返回 <see langword="null"/></para><para lang="en">没有实现 <typeparamref name="T"/> 接口，则返回 <see langword="null"/></para></returns>
+    /// <typeparam name="T"><para lang="zh">验证接口类型</para><para lang="en">Validation interface type</para></typeparam>
+    /// <param name="context"><para lang="zh">验证上下文</para><para lang="en">Validation context</para></param>
+    /// <returns><para lang="zh">未配置 <see cref="MetadataTypeAttribute"/> 或元数据类型未实现 <typeparamref name="T"/> 接口时返回 <see langword="null"/></para><para lang="en">Returns <see langword="null"/> when <see cref="MetadataTypeAttribute"/> is not configured or the metadata type does not implement <typeparamref name="T"/></para></returns>
     public static T? GetInstanceFromMetadataType<T>(this ValidationContext context) where T : class
     {
         T? ret = default;
@@ -37,8 +37,9 @@ public static class ValidationContextExtensions
     /// <para lang="zh">获得 <see cref="ValidationResult"/> 实例</para>
     /// <para lang="en">Gets <see cref="ValidationResult"/> instance</para>
     /// </summary>
-    /// <param name="context"></param>
-    /// <param name="errorMessage"></param>
+    /// <param name="context"><para lang="zh">验证上下文</para><para lang="en">Validation context</para></param>
+    /// <param name="errorMessage"><para lang="zh">错误信息</para><para lang="en">Error message</para></param>
+    /// <returns><para lang="zh">验证结果实例</para><para lang="en">Validation result instance</para></returns>
     public static ValidationResult GetValidationResult(this ValidationContext context, string? errorMessage)
     {
         var memberNames = string.IsNullOrEmpty(context.MemberName) ? null : new string[] { context.MemberName };

--- a/test/UnitTest/Components/ValidateFormTest.cs
+++ b/test/UnitTest/Components/ValidateFormTest.cs
@@ -8,9 +8,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using System.Collections.Concurrent;
 using System.ComponentModel.DataAnnotations;
-#if NET11_0_OR_GREATER
 using System.Runtime.CompilerServices;
-#endif
 
 namespace UnitTest.Components;
 
@@ -20,9 +18,7 @@ public class ValidateFormTest : BootstrapBlazorTestBase
     {
         services.AddBootstrapBlazor();
         services.ConfigureJsonLocalizationOptions(op => op.AdditionalJsonAssemblies = new[] { GetType().Assembly });
-#if !NET11_0_OR_GREATER
         services.AddSingleton<ILogger<BootstrapBlazorDataAnnotationsValidator>, ValidateFormTestLogger>();
-#endif
     }
 
     [Fact]
@@ -51,7 +47,7 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         var editContext = Assert.IsType<EditContext>(property?.GetValue(validator));
 
 #if NET11_0_OR_GREATER
-        var valid = await cut.InvokeAsync(() => editContext.ValidateAsync(Xunit.TestContext.Current.CancellationToken));
+        var valid = await cut.InvokeAsync(() => editContext.ValidateAsync(CancellationToken.None));
         Assert.False(valid);
 #else
         await cut.InvokeAsync(() => editContext.Validate());
@@ -60,7 +56,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         cut.WaitForAssertion(() => Assert.NotEmpty(editContext.GetValidationMessages()));
     }
 
-#if !NET11_0_OR_GREATER
     [Fact]
     public async Task OnValidationRequested_Exception()
     {
@@ -83,7 +78,11 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
         var editContext = Assert.IsType<EditContext>(property?.GetValue(validator));
 
+#if NET11_0_OR_GREATER
+        await cut.InvokeAsync(() => editContext.ValidateAsync(CancellationToken.None));
+#else
         await cut.InvokeAsync(() => editContext.Validate());
+#endif
 
         cut.WaitForAssertion(() => Assert.IsType<InvalidOperationException>(logger.Exception));
     }
@@ -156,7 +155,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             await validation;
         });
     }
-#endif
 
     [Fact]
     public async Task Validate_Ok()
@@ -839,7 +837,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         Assert.Equal(["Model validation failed"], messages);
     }
 
-#if NET11_0_OR_GREATER
     [Fact]
     public async Task IAsyncValidatableObject_Ok()
     {
@@ -861,7 +858,7 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         Assert.False(model.SyncValidated);
         Assert.Equal("Async validation failed", cut.FindComponent<MockInput<string>>().Instance.GetErrorMessage());
     }
-    
+
     [Fact]
     public async Task IAsyncValidatableObject_ModelError()
     {
@@ -877,10 +874,8 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         });
 
         var valid = await cut.InvokeAsync(() => cut.Instance.ValidateAsync(CancellationToken.None));
-
         Assert.False(valid);
     }
-#endif
 
     [Fact]
     public async Task AsyncValidationAttribute_Ok()
@@ -1213,7 +1208,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
         }
     }
 
-#if !NET11_0_OR_GREATER
     private sealed class ThrowingValidator : ValidatorAsyncBase
     {
         public override Task ValidateAsync(
@@ -1276,9 +1270,7 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             Exception = exception;
         }
     }
-#endif
 
-#if NET11_0_OR_GREATER
     private sealed class MockAsyncValidatableModel : IAsyncValidatableObject
     {
         public string? Name { get; set; }
@@ -1319,7 +1311,6 @@ public class ValidateFormTest : BootstrapBlazorTestBase
             yield return new ValidationResult("Model validation failed");
         }
     }
-#endif
 
     private sealed class MockAsyncValidationAttributeModel
     {


### PR DESCRIPTION
## Link issues
fixes #8424

## Summary By Copilot

- Add a non-.NET 11 compatible `System.ComponentModel.DataAnnotations.IAsyncValidatableObject` interface.
- Integrate async model validation into `ValidateForm` across supported target frameworks.
- Update ValidateForm tests and validation context comments for the cross-target async validation path.

## Regression?
- [ ] Yes
- [x] No

Existing synchronous `IValidatableObject` validation remains the fallback when async model validation is not implemented.

## Risk
- [ ] High
- [x] Medium
- [ ] Low

This adds a compatibility API in the `System.ComponentModel.DataAnnotations` namespace for non-.NET 11 targets and changes model validation dispatch to prefer async validation when available.

## Verification
- [ ] Manual (required)
- [ ] Automated

Not run per request.

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [x] N/A

No package metadata or target framework files changed.

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [x] Doc is updated/provided or not needed
- [x] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Support asynchronous model validation in ValidateForm across all supported target frameworks.

New Features:
- Add cross-target asynchronous model validation support through IAsyncValidatableObject.
- Prefer asynchronous model validation while retaining synchronous IValidatableObject as a fallback.

Enhancements:
- Improve ValidationContext extension method documentation and comments.

Tests:
- Extend ValidateForm coverage for asynchronous validation across supported target frameworks.