### PR TITLE
feat(TreeView): add IsIncludeIndeterminateWhenGetCheckedItems parameter

### DIFF
--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -325,6 +325,13 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     public bool AutoCheckParent { get; set; }
 
     /// <summary>
+    /// <para lang="zh">获得/设置 <see cref="GetCheckedItems()"/> 方法返回的集合是否包含半选节点，默认为 false</para>
+    /// <para lang="en">Gets or sets whether the collection returned by <see cref="GetCheckedItems()"/> includes indeterminate nodes. Default is false</para>
+    /// </summary>
+    [Parameter]
+    public bool IsIncludeIndeterminateWhenGetCheckedItems { get; set; }
+
+    /// <summary>
     /// <para lang="zh">获得/设置 是否允许拖放操作，默认为 false</para>
     /// <para lang="en">Gets or sets a value indicating whether drag-and-drop operations are allowed. Default is false</para>
     /// </summary>
@@ -955,7 +962,10 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
         t.Add(item);
         t.AddRange(item.GetAllSubItems().OfType<TreeViewItem<TItem>>());
         return t;
-    }).Where(i => i.CheckedState == CheckboxState.Checked);
+    }).Where(GetCheckedItems);
+
+
+    private bool GetCheckedItems(TreeViewItem<TItem> item) => IsIncludeIndeterminateWhenGetCheckedItems ? item.CheckedState != CheckboxState.UnChecked : item.CheckedState == CheckboxState.Checked;
 
     /// <summary>
     /// <para lang="zh">检查数据是否相同</para>

--- a/test/UnitTest/Components/TreeViewTest.cs
+++ b/test/UnitTest/Components/TreeViewTest.cs
@@ -334,6 +334,35 @@ public class TreeViewTest : BootstrapBlazorTestBase
     }
 
     [Fact]
+    public void GetCheckedItems_IncludeIndeterminate_Ok()
+    {
+        var items = new List<TreeFoo>
+        {
+            new() { Text = "Node1", Id = "1010" },
+            new() { Text = "Node11", Id = "1011", ParentId = "1010" },
+            new() { Text = "Node12", Id = "1012", ParentId = "1010" }
+        };
+
+        var nodes = TreeFoo.CascadingTree(items);
+        nodes[0].Items[0].CheckedState = CheckboxState.Checked;
+
+        var cut = Context.Render<TreeView<TreeFoo>>(pb =>
+        {
+            pb.Add(a => a.AutoCheckParent, true);
+            pb.Add(a => a.Items, nodes);
+            pb.Add(a => a.ShowCheckbox, true);
+        });
+
+        Assert.Equal(CheckboxState.Indeterminate, nodes[0].CheckedState);
+        Assert.False(cut.Instance.IsIncludeIndeterminateWhenGetCheckedItems);
+        Assert.Equal([nodes[0].Items[0]], cut.Instance.GetCheckedItems());
+
+        cut.Render(pb => pb.Add(a => a.IsIncludeIndeterminateWhenGetCheckedItems, true));
+
+        Assert.Equal([nodes[0], nodes[0].Items[0]], cut.Instance.GetCheckedItems());
+    }
+
+    [Fact]
     public async Task AutoCheckParent_ToggleNode_Ok()
     {
         // 仅设置 AutoCheckParent 时 展开/折叠已加载子节点的节点不重算勾选状态


### PR DESCRIPTION
## Link issues
fixes #8450 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Allow TreeView consumers to control whether indeterminate nodes are returned as checked items.

New Features:
- Add a TreeView parameter that optionally includes indeterminate nodes in the collection returned by GetCheckedItems().

Tests:
- Add coverage verifying GetCheckedItems() behavior with and without indeterminate nodes.