### PR TITLE
feat(Card): remove --bs-card-body-color variable

### DIFF
--- a/src/BootstrapBlazor.Server/Components/Samples/Cards.razor
+++ b/src/BootstrapBlazor.Server/Components/Samples/Cards.razor
@@ -10,6 +10,7 @@
 
         .custom-body {
             --bs-card-body-bg: #f7eed0;
+            --bs-card-color: #000;
         }
 
         .custom-footer {
@@ -216,7 +217,8 @@
 }
 
 .custom-body {
-    background-color: #f7eed0;
+    --bs-card-body-bg: #f7eed0;
+    --bs-card-color: #000;
 }
 
 .custom-footer {

--- a/src/BootstrapBlazor/Components/Card/Card.razor.scss
+++ b/src/BootstrapBlazor/Components/Card/Card.razor.scss
@@ -5,8 +5,8 @@
     --bb-card-hover-shadow: #{$bb-card-hover-shadow};
     --bb-card-title-margin-left: #{$bb-card-title-margin-left};
     --bb-card-header-tag-height: #{$bb-card-header-tag-height};
+    --bs-card-body-bg: var(--bs-body-bg);
     --bs-card-title-spacer-y: #{$bb-card-title-spacer-y};
-    overflow: hidden;
 }
 
 .card-header {

--- a/src/BootstrapBlazor/Components/Card/Card.razor.scss
+++ b/src/BootstrapBlazor/Components/Card/Card.razor.scss
@@ -6,6 +6,7 @@
     --bb-card-title-margin-left: #{$bb-card-title-margin-left};
     --bb-card-header-tag-height: #{$bb-card-header-tag-height};
     --bs-card-title-spacer-y: #{$bb-card-title-spacer-y};
+    overflow: hidden;
 }
 
 .card-header {

--- a/src/BootstrapBlazor/Components/Card/Card.razor.scss
+++ b/src/BootstrapBlazor/Components/Card/Card.razor.scss
@@ -43,7 +43,6 @@
 
 .card-body {
     background-color: var(--bs-card-body-bg);
-    color: var(--bs-card-body-color);
 }
 
 .card-footer {

--- a/src/BootstrapBlazor/Components/Card/Card.razor.scss
+++ b/src/BootstrapBlazor/Components/Card/Card.razor.scss
@@ -7,6 +7,16 @@
     --bb-card-header-tag-height: #{$bb-card-header-tag-height};
     --bs-card-body-bg: var(--bs-body-bg);
     --bs-card-title-spacer-y: #{$bb-card-title-spacer-y};
+
+    > .card-body:first-child {
+        border-start-start-radius: var(--bs-card-inner-border-radius);
+        border-start-end-radius: var(--bs-card-inner-border-radius);
+    }
+
+    > .card-body:last-child {
+        border-end-start-radius: var(--bs-card-inner-border-radius);
+        border-end-end-radius: var(--bs-card-inner-border-radius);
+    }
 }
 
 .card-header {

--- a/src/BootstrapBlazor/Components/Console/Console.razor.scss
+++ b/src/BootstrapBlazor/Components/Console/Console.razor.scss
@@ -1,8 +1,8 @@
 @use "../../wwwroot/scss/variables" as *;
 
 .console {
-    --bs-card-body-color: #{$bb-console-body-color};
-    --bb-console-body-bg: #{$bb-console-body-bg};
+    --bs-card-color: #{$bb-console-body-color};
+    --bs-card-body-bg: #{$bb-console-body-bg};
     --bb-console-clear-button-margin-left: #{$bb-console-clear-button-margin-left};
     width: 100%;
 
@@ -17,7 +17,6 @@
     }
 
     .card-body {
-        background-color: var(--bb-console-body-bg);
         overflow: auto;
     }
 


### PR DESCRIPTION
## Link issues
fixes #8454 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Replace the card body color variable with Bootstrap’s standard card styling variables and improve card body appearance consistency.

Bug Fixes:
- Remove the deprecated card body color variable and align card text styling with Bootstrap’s standard card color variable.

Enhancements:
- Set the default card body background and preserve rounded corners when card bodies are the first or last card content.
- Update console styling to use the standard card color and body background variables.