### PR TITLE
feat(Dom2Image): bump version 10.0.5

### DIFF
--- a/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
+++ b/src/BootstrapBlazor.Server/BootstrapBlazor.Server.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="BootstrapBlazor.CodeEditor" Version="10.0.1" />
     <PackageReference Include="BootstrapBlazor.Dock" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.DockView" Version="10.0.24" />
-    <PackageReference Include="BootstrapBlazor.Dom2Image" Version="10.0.4" />
+    <PackageReference Include="BootstrapBlazor.Dom2Image" Version="10.0.5" />
     <PackageReference Include="BootstrapBlazor.DriverJs" Version="10.0.3" />
     <PackageReference Include="BootstrapBlazor.ElementIcon" Version="10.0.0" />
     <PackageReference Include="BootstrapBlazor.EmbedPDF" Version="10.0.8" />


### PR DESCRIPTION
## Link issues
fixes #8456 

Dom2Image bump version 10.0.5
Snapdom bump version 2.24.18

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Enhancements:
- Update the BootstrapBlazor.Server project dependency version to incorporate the Dom2Image 10.0.5 and Snapdom 2.24.18 upgrades.