### PR TITLE
feat(Virtualize): add ItemComparer parameter support NET11

### DIFF
--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TValue
 @inherits PopoverCompleteBase<TValue>
@@ -39,9 +39,7 @@
                 }
                 else
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" ItemsProvider="LoadItems"
-                                Placeholder="RenderPlaceholderRow" ItemContent="RenderRow" @ref="_virtualizeElement">
-                    </Virtualize>
+                    @RenderVirtualize()
                 }
             </div>
         }

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -135,6 +135,17 @@ public partial class AutoFill<TValue>
     [NotNull]
     public Func<VirtualizeQueryOption, Task<QueryData<TValue>>>? OnQueryAsync { get; set; }
 
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">获得/设置虚拟滚动项目比较器。远程数据源返回新实例时，应按唯一标识进行比较</para>
+    /// <para lang="en">Gets or sets the virtualized item comparer. It should compare unique identifiers when the remote data source returns new instances.</para>
+    /// <para>v<version>11.0.0</version></para>
+    /// </summary>
+    [Parameter]
+    [NotNull]
+    public IEqualityComparer<TValue>? ItemComparer { get; set; } = EqualityComparer<TValue>.Default;
+#endif
+
     /// <summary>
     /// <para lang="zh">获得/设置 点击清除按钮回调方法 默认为 null</para>
     /// <para lang="en">Gets or sets the callback method when the clear button is clicked. Default is null</para>
@@ -343,4 +354,10 @@ public partial class AutoFill<TValue>
             await InvokeVoidAsync("setValue", Id, "");
         }
     }
+
+    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceholderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        ItemComparer,
+#endif
+        element => _virtualizeElement = element);
 }

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -143,7 +143,7 @@ public partial class AutoFill<TValue>
     /// </summary>
     [Parameter]
     [NotNull]
-    public IEqualityComparer<TValue>? ItemComparer { get; set; } = EqualityComparer<TValue>.Default;
+    public IEqualityComparer<TValue>? ItemComparer { get; set; }
 #endif
 
     /// <summary>
@@ -209,6 +209,10 @@ public partial class AutoFill<TValue>
         _displayText = GetDisplayText(Value);
         _clientValue = _displayText;
         Items ??= [];
+
+#if NET11_0_OR_GREATER
+        ItemComparer ??= EqualityComparer<TValue>.Default;
+#endif
     }
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -84,9 +84,7 @@
                 }
                 else
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" ItemsProvider="LoadItems"
-                                Placeholder="RenderPlaceHolderRow" ItemContent="RenderRow" @ref="_virtualizeElement">
-                    </Virtualize>
+                    @RenderVirtualize()
                 }
             </div>
         }

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -293,6 +293,12 @@ public partial class MultiSelect<TValue>
         return _result;
     }
 
+    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        VirtualizeItemComparer,
+#endif
+        element => _virtualizeElement = element);
+
     /// <summary>
     /// <inheritdoc/>
     /// </summary>

--- a/src/BootstrapBlazor/Components/Select/Select.razor
+++ b/src/BootstrapBlazor/Components/Select/Select.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TValue
 @inherits SimpleSelectBase<TValue>
@@ -49,9 +49,7 @@
                     }
                     else
                     {
-                        <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" ItemsProvider="LoadItems"
-                                    Placeholder="RenderPlaceHolderRow" ItemContent="RenderRow" @ref="_virtualizeElement">
-                        </Virtualize>
+                        @RenderVirtualize()
                     }
                 </div>
             }

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -270,6 +270,12 @@ public partial class Select<TValue> : ISelect, ILookup
         return _result;
     }
 
+    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        VirtualizeItemComparer,
+#endif
+        element => _virtualizeElement = element);
+
     /// <summary>
     /// <inheritdoc/>
     /// </summary>

--- a/src/BootstrapBlazor/Components/Select/SimpleSelectBase.cs
+++ b/src/BootstrapBlazor/Components/Select/SimpleSelectBase.cs
@@ -21,6 +21,14 @@ public abstract class SimpleSelectBase<TValue> : SelectBase<TValue>
     [NotNull]
     protected Virtualize<SelectedItem>? _virtualizeElement = default;
 
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">获得虚拟滚动项目比较器</para>
+    /// <para lang="en">Gets the virtualized item comparer</para>
+    /// </summary>
+    protected static IEqualityComparer<SelectedItem> VirtualizeItemComparer { get; } = new SelectedItemComparer();
+#endif
+
     /// <summary>
     /// <para lang="zh">获得/设置 最后选中的值字符串</para>
     /// <para lang="en">Gets or sets the last selected value string</para>

--- a/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor
+++ b/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TValue
 @inherits SelectBase<List<TValue>>
@@ -77,9 +77,7 @@
                 }
                 else
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" ItemsProvider="LoadItems"
-                                Placeholder="RenderPlaceHolderRow" ItemContent="RenderRow" @ref="_virtualizeElement">
-                    </Virtualize>
+                    @RenderVirtualize()
                 }
             </div>
         }

--- a/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor.cs
@@ -245,6 +245,12 @@ public partial class MultiSelectGeneric<TValue> : IModelEqualityComparer<TValue>
     [NotNull]
     private Virtualize<SelectedItem<TValue>>? _virtualizeElement = default;
 
+#if NET11_0_OR_GREATER
+    private IEqualityComparer<SelectedItem<TValue>> VirtualizeItemComparer => _virtualizeItemComparer ??= new SelectedItemComparer<TValue>(this);
+
+    private IEqualityComparer<SelectedItem<TValue>>? _virtualizeItemComparer;
+#endif
+
     /// <summary>
     /// <inheritdoc/>
     /// </summary>
@@ -356,6 +362,12 @@ public partial class MultiSelectGeneric<TValue> : IModelEqualityComparer<TValue>
 
         int GetCountByTotal() => _totalCount == 0 ? request.Count : Math.Min(request.Count, _totalCount - request.StartIndex);
     }
+
+    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        VirtualizeItemComparer,
+#endif
+        element => _virtualizeElement = element);
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor
@@ -1,4 +1,4 @@
-﻿@namespace BootstrapBlazor.Components
+@namespace BootstrapBlazor.Components
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @typeparam TValue
 @inherits SelectBase<TValue>
@@ -48,7 +48,7 @@
                     }
                     else
                     {
-                        <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" ItemsProvider="LoadItems" Placeholder="RenderPlaceHolderRow" ItemContent="RenderRow" @ref="VirtualizeElement" />
+                        @RenderVirtualize()
                     }
                 </div>
             }

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
@@ -114,6 +114,12 @@ public partial class SelectGeneric<TValue> : ISelectGeneric<TValue>, IModelEqual
     [NotNull]
     private Virtualize<SelectedItem<TValue>>? VirtualizeElement { get; set; }
 
+#if NET11_0_OR_GREATER
+    private IEqualityComparer<SelectedItem<TValue>> VirtualizeItemComparer => _virtualizeItemComparer ??= new SelectedItemComparer<TValue>(this);
+
+    private IEqualityComparer<SelectedItem<TValue>>? _virtualizeItemComparer;
+#endif
+
     /// <summary>
     /// <para lang="zh">获得/设置 绑定数据集</para>
     /// <para lang="en">Gets or sets Bound Dataset</para>
@@ -325,6 +331,12 @@ public partial class SelectGeneric<TValue> : ISelectGeneric<TValue>, IModelEqual
 
         int GetCountByTotal() => TotalCount == 0 ? request.Count : Math.Min(request.Count, TotalCount - request.StartIndex);
     }
+
+    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        VirtualizeItemComparer,
+#endif
+        element => VirtualizeElement = element);
 
     private async Task RefreshVirtualizeElement()
     {

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -111,10 +111,7 @@
                 {
                     @if (OnQueryAsync != null)
                     {
-                        <Virtualize @ref="_virtualizeElement"
-                                    ItemSize="RowHeight" OverscanCount="@OverscanCount" ItemsProvider="LoadItems"
-                                    ItemContent="RenderRow" Placeholder="RenderPlaceholderRow">
-                        </Virtualize>
+                        @RenderVirtualize()
                     }
                     else
                     {

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -68,6 +68,12 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     [NotNull]
     private Virtualize<TItem>? _virtualizeElement = null;
 
+#if NET11_0_OR_GREATER
+    private IEqualityComparer<TItem> VirtualizeItemComparer => _virtualizeItemComparer ??= new ModelHashSetComparer<TItem>(this);
+
+    private IEqualityComparer<TItem>? _virtualizeItemComparer;
+#endif
+
     /// <summary>
     /// <para lang="zh">获得 Table 组件样式表</para>
     /// <para lang="en">Get Table Component CSS Class</para>
@@ -1845,6 +1851,12 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
 
         return new ItemsProviderResult<TItem>(QueryItems, TotalCount);
     }
+
+    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceholderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        VirtualizeItemComparer,
+#endif
+        element => _virtualizeElement = element);
 
     private Func<Task> TriggerDoubleClickCell(ITableColumn col, TItem item) => async () =>
     {

--- a/src/BootstrapBlazor/Components/Virtualization/VirtualizeHelper.cs
+++ b/src/BootstrapBlazor/Components/Virtualization/VirtualizeHelper.cs
@@ -1,0 +1,35 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+
+namespace BootstrapBlazor.Components;
+
+internal static class VirtualizeHelper
+{
+    public static RenderFragment Render<TItem>(
+        ItemsProviderDelegate<TItem> itemsProvider,
+        RenderFragment<TItem> itemContent,
+        RenderFragment<PlaceholderContext> placeholder,
+        float itemSize,
+        int overscanCount,
+#if NET11_0_OR_GREATER
+        IEqualityComparer<TItem> itemComparer,
+#endif
+        Action<Virtualize<TItem>> componentRef) => builder =>
+    {
+        builder.OpenComponent<Virtualize<TItem>>(0);
+        builder.AddAttribute(1, nameof(Virtualize<TItem>.ItemsProvider), itemsProvider);
+        builder.AddAttribute(2, nameof(Virtualize<TItem>.ItemContent), itemContent);
+        builder.AddAttribute(3, nameof(Virtualize<TItem>.Placeholder), placeholder);
+        builder.AddAttribute(4, nameof(Virtualize<TItem>.ItemSize), itemSize);
+        builder.AddAttribute(5, nameof(Virtualize<TItem>.OverscanCount), overscanCount);
+#if NET11_0_OR_GREATER
+        builder.AddAttribute(6, nameof(Virtualize<TItem>.ItemComparer), itemComparer);
+#endif
+        builder.AddComponentReferenceCapture(7, component => componentRef((Virtualize<TItem>)component));
+        builder.CloseComponent();
+    };
+}

--- a/src/BootstrapBlazor/Misc/SelectedItemComparer.cs
+++ b/src/BootstrapBlazor/Misc/SelectedItemComparer.cs
@@ -1,0 +1,24 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+namespace BootstrapBlazor.Components;
+
+#if NET11_0_OR_GREATER
+internal sealed class SelectedItemComparer : IEqualityComparer<SelectedItem>
+{
+    public bool Equals(SelectedItem? x, SelectedItem? y) => ReferenceEquals(x, y) || (x is not null && y is not null && x.Value == y.Value);
+
+    public int GetHashCode(SelectedItem obj) => obj.Value.GetHashCode();
+}
+
+internal sealed class SelectedItemComparer<TValue>(IModelEqualityComparer<TValue> comparer) : IEqualityComparer<SelectedItem<TValue>>
+{
+    private readonly ModelHashSetComparer<TValue> _comparer = new(comparer);
+
+    public bool Equals(SelectedItem<TValue>? x, SelectedItem<TValue>? y) => ReferenceEquals(x, y) || (x is not null && y is not null && _comparer.Equals(x.Value, y.Value));
+
+    public int GetHashCode(SelectedItem<TValue> obj) => obj.Value is null ? 0 : _comparer.GetHashCode(obj.Value);
+}
+#endif

--- a/test/UnitTest/Misc/SelectedItemComparerTest.cs
+++ b/test/UnitTest/Misc/SelectedItemComparerTest.cs
@@ -1,0 +1,84 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+using System.ComponentModel.DataAnnotations;
+using System.Reflection;
+
+namespace UnitTest.Misc;
+
+#if NET11_0_OR_GREATER
+public class SelectedItemComparerTest : BootstrapBlazorTestBase
+{
+    [Fact]
+    public void SelectedItem_Equals_Ok()
+    {
+        var comparer = CreateComparer<SelectedItem>("BootstrapBlazor.Components.SelectedItemComparer");
+        var item = new SelectedItem("1", "Test 1");
+
+        Assert.True(comparer.Equals(null, null));
+        Assert.True(comparer.Equals(item, item));
+        Assert.False(comparer.Equals(null, item));
+        Assert.False(comparer.Equals(item, null));
+        Assert.True(comparer.Equals(item, new SelectedItem("1", "Test 2")));
+        Assert.False(comparer.Equals(item, new SelectedItem("2", "Test 1")));
+        Assert.Equal(item.Value.GetHashCode(), comparer.GetHashCode(item));
+    }
+
+    [Fact]
+    public void SelectedItemGeneric_Equals_Ok()
+    {
+        var modelComparer = new MockModelEqualityComparer<Model>()
+        {
+            ModelEqualityComparer = (x, y) => x.Id == y.Id
+        };
+        var comparer = CreateComparer<SelectedItem<Model>>(
+            "BootstrapBlazor.Components.SelectedItemComparer`1",
+            [typeof(Model)],
+            modelComparer);
+        var item = new SelectedItem<Model>(new() { Id = 1 }, "Test 1");
+
+        Assert.True(comparer.Equals(null, null));
+        Assert.True(comparer.Equals(item, item));
+        Assert.False(comparer.Equals(null, item));
+        Assert.False(comparer.Equals(item, null));
+        Assert.True(comparer.Equals(item, new SelectedItem<Model>(new() { Id = 1 }, "Test 2")));
+        Assert.False(comparer.Equals(item, new SelectedItem<Model>(new() { Id = 2 }, "Test 1")));
+        Assert.Equal(1, comparer.GetHashCode(item));
+        Assert.Equal(0, comparer.GetHashCode(new SelectedItem<Model>(null!, "Null")));
+    }
+
+    private static IEqualityComparer<TItem> CreateComparer<TItem>(string typeName, Type[]? genericArguments = null, params object[] arguments)
+    {
+        var type = typeof(SelectedItem).Assembly.GetType(typeName, throwOnError: true)!;
+        if (genericArguments is not null)
+        {
+            type = type.MakeGenericType(genericArguments);
+        }
+
+        return (IEqualityComparer<TItem>)Activator.CreateInstance(
+            type,
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args: arguments,
+            culture: null)!;
+    }
+
+    private sealed class Model
+    {
+        public int Id { get; set; }
+
+        public override int GetHashCode() => Id;
+    }
+
+    private sealed class MockModelEqualityComparer<TModel> : IModelEqualityComparer<TModel>
+    {
+        public Func<TModel, TModel, bool>? ModelEqualityComparer { get; set; }
+
+        public Type CustomKeyAttribute { get; set; } = typeof(KeyAttribute);
+
+        public bool Equals(TModel? x, TModel? y) => this.Equals<TModel>(x, y);
+    }
+}
+#endif


### PR DESCRIPTION
## Link issues
fixes #8458 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Support stable item comparison in NET11 virtualized controls across selection and tabular components.

New Features:
- Add NET11 virtualized item comparer support to AutoFill, Select, MultiSelect, generic select, and Table components to preserve item identity when refreshed data contains new instances.

Bug Fixes:
- Ensure virtualized controls correctly recognize equivalent items from remote data sources based on their identifiers or model equality.

Enhancements:
- Centralize Virtualize component rendering and reference handling across supported components.
- Add equality comparers for standard and generic selected items. 

Tests:
- Add NET11 tests covering equality and hash-code behavior for standard and generic selected-item comparers.