### PR TITLE
feat(Virtualize): add InitialItemIndex/AnchorMode parameter support net11

### DIFF
--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor
@@ -34,12 +34,11 @@
             <div class="dropdown-menu-body dropdown-virtual">
                 @if (OnQueryAsync == null)
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@Rows" ChildContent="RenderRow">
-                    </Virtualize>
+                    @RenderVirtualizeByItems()
                 }
                 else
                 {
-                    @RenderVirtualize()
+                    @RenderVirtualizeByProvider()
                 }
             </div>
         }

--- a/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
+++ b/src/BootstrapBlazor/Components/AutoFill/AutoFill.razor.cs
@@ -144,6 +144,20 @@ public partial class AutoFill<TValue>
     [Parameter]
     [NotNull]
     public IEqualityComparer<TValue>? ItemComparer { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置首次交互式渲染时滚动到的虚拟项索引，默认为 0</para>
+    /// <para lang="en">Gets or sets the virtual item index to scroll to on first interactive render. Default is 0.</para>
+    /// </summary>
+    [Parameter]
+    public int InitialItemIndex { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置虚拟滚动锚定模式，默认为 <see cref="VirtualizeAnchorMode.Start"/></para>
+    /// <para lang="en">Gets or sets the virtual scrolling anchor mode. Default is <see cref="VirtualizeAnchorMode.Start"/>.</para>
+    /// </summary>
+    [Parameter]
+    public VirtualizeAnchorMode AnchorMode { get; set; } = VirtualizeAnchorMode.Start;
 #endif
 
     /// <summary>
@@ -317,7 +331,10 @@ public partial class AutoFill<TValue>
         if (OnQueryAsync != null)
         {
             _searchText = val;
-            await _virtualizeElement.RefreshDataAsync();
+            if (_virtualizeElement != null)
+            {
+                await _virtualizeElement.RefreshDataAsync();
+            }
             _dropdown.Render();
             return;
         }
@@ -359,9 +376,32 @@ public partial class AutoFill<TValue>
         }
     }
 
-    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceholderRow, RowHeight, OverscanCount,
+    private RenderFragment RenderVirtualizeByProvider() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceholderRow, RowHeight, OverscanCount,
 #if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
         ItemComparer,
 #endif
         element => _virtualizeElement = element);
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(Rows, RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
+#endif
+        element => _virtualizeElement = element);
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">滚动到指定索引的虚拟项</para>
+    /// <para lang="en">Scrolls to the virtual item at the specified index.</para>
+    /// </summary>
+    /// <param name="itemIndex"><para lang="zh">从零开始的虚拟项索引</para><para lang="en">The zero-based virtual item index.</para></param>
+    /// <param name="cancellationToken"><para lang="zh">取消令牌</para><para lang="en">The cancellation token.</para></param>
+    public async Task ScrollToIndexAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (_virtualizeElement != null)
+        {
+            await _virtualizeElement.ScrollToItemAsync(itemIndex, cancellationToken);
+        }
+    }
+#endif
 }

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor
@@ -79,12 +79,11 @@
             <div class="dropdown-menu-body dropdown-virtual">
                 @if (OnQueryAsync == null)
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@GetVirtualItems()" ChildContent="RenderRow">
-                    </Virtualize>
+                    @RenderVirtualizeByItems()
                 }
                 else
                 {
-                    @RenderVirtualize()
+                    @RenderVirtualizeByProvider()
                 }
             </div>
         }

--- a/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/MultiSelect.razor.cs
@@ -293,9 +293,16 @@ public partial class MultiSelect<TValue>
         return _result;
     }
 
-    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+    private RenderFragment RenderVirtualizeByProvider() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
 #if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
         VirtualizeItemComparer,
+#endif
+        element => _virtualizeElement = element);
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(GetVirtualItems(), RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
 #endif
         element => _virtualizeElement = element);
 

--- a/src/BootstrapBlazor/Components/Select/Select.razor
+++ b/src/BootstrapBlazor/Components/Select/Select.razor
@@ -44,12 +44,11 @@
                 <div class="dropdown-menu-body dropdown-virtual">
                     @if (OnQueryAsync == null)
                     {
-                        <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@GetVirtualItems()" ChildContent="RenderRow">
-                        </Virtualize>
+                        @RenderVirtualizeByItems()
                     }
                     else
                     {
-                        @RenderVirtualize()
+                        @RenderVirtualizeByProvider()
                     }
                 </div>
             }

--- a/src/BootstrapBlazor/Components/Select/Select.razor.cs
+++ b/src/BootstrapBlazor/Components/Select/Select.razor.cs
@@ -270,9 +270,16 @@ public partial class Select<TValue> : ISelect, ILookup
         return _result;
     }
 
-    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+    private RenderFragment RenderVirtualizeByProvider() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
 #if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
         VirtualizeItemComparer,
+#endif
+        element => _virtualizeElement = element);
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(GetVirtualItems(), RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
 #endif
         element => _virtualizeElement = element);
 

--- a/src/BootstrapBlazor/Components/Select/SelectBase.cs
+++ b/src/BootstrapBlazor/Components/Select/SelectBase.cs
@@ -3,6 +3,10 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+#if NET11_0_OR_GREATER
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+#endif
+
 namespace BootstrapBlazor.Components;
 
 /// <summary>
@@ -127,6 +131,22 @@ public abstract class SelectBase<TValue> : PopoverSelectBase<TValue>
     /// <remarks>Effective when <see cref="IsVirtualize"/> is set to true.</remarks>
     [Parameter]
     public int OverscanCount { get; set; } = 4;
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">获得/设置首次交互式渲染时滚动到的虚拟项索引，默认为 0</para>
+    /// <para lang="en">Gets or sets the virtual item index to scroll to on first interactive render. Default is 0.</para>
+    /// </summary>
+    [Parameter]
+    public int InitialItemIndex { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置虚拟滚动锚定模式，默认为 <see cref="VirtualizeAnchorMode.Start"/></para>
+    /// <para lang="en">Gets or sets the virtual scrolling anchor mode. Default is <see cref="VirtualizeAnchorMode.Start"/>.</para>
+    /// </summary>
+    [Parameter]
+    public VirtualizeAnchorMode AnchorMode { get; set; } = VirtualizeAnchorMode.Start;
+#endif
 
     /// <summary>
     /// <para lang="zh">获得/设置 当清除按钮被点击时的回调方法，默认值为 null</para>

--- a/src/BootstrapBlazor/Components/Select/SimpleSelectBase.cs
+++ b/src/BootstrapBlazor/Components/Select/SimpleSelectBase.cs
@@ -27,6 +27,20 @@ public abstract class SimpleSelectBase<TValue> : SelectBase<TValue>
     /// <para lang="en">Gets the virtualized item comparer</para>
     /// </summary>
     protected static IEqualityComparer<SelectedItem> VirtualizeItemComparer { get; } = new SelectedItemComparer();
+
+    /// <summary>
+    /// <para lang="zh">滚动到指定索引的虚拟项</para>
+    /// <para lang="en">Scrolls to the virtual item at the specified index.</para>
+    /// </summary>
+    /// <param name="itemIndex"><para lang="zh">从零开始的虚拟项索引</para><para lang="en">The zero-based virtual item index.</para></param>
+    /// <param name="cancellationToken"><para lang="zh">取消令牌</para><para lang="en">The cancellation token.</para></param>
+    public async Task ScrollToIndexAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (_virtualizeElement != null)
+        {
+            await _virtualizeElement.ScrollToItemAsync(itemIndex, cancellationToken);
+        }
+    }
 #endif
 
     /// <summary>

--- a/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor
+++ b/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor
@@ -72,12 +72,11 @@
             <div class="dropdown-menu-body dropdown-virtual">
                 @if (OnQueryAsync == null)
                 {
-                    <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@GetVirtualItems()" ChildContent="RenderRow">
-                    </Virtualize>
+                    @RenderVirtualizeByItems()
                 }
                 else
                 {
-                    @RenderVirtualize()
+                    @RenderVirtualizeByProvider()
                 }
             </div>
         }

--- a/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/MultiSelectGeneric.razor.cs
@@ -363,11 +363,34 @@ public partial class MultiSelectGeneric<TValue> : IModelEqualityComparer<TValue>
         int GetCountByTotal() => _totalCount == 0 ? request.Count : Math.Min(request.Count, _totalCount - request.StartIndex);
     }
 
-    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+    private RenderFragment RenderVirtualizeByProvider() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
 #if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
         VirtualizeItemComparer,
 #endif
         element => _virtualizeElement = element);
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(GetVirtualItems(), RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
+#endif
+        element => _virtualizeElement = element);
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">滚动到指定索引的虚拟项</para>
+    /// <para lang="en">Scrolls to the virtual item at the specified index.</para>
+    /// </summary>
+    /// <param name="itemIndex"><para lang="zh">从零开始的虚拟项索引</para><para lang="en">The zero-based virtual item index.</para></param>
+    /// <param name="cancellationToken"><para lang="zh">取消令牌</para><para lang="en">The cancellation token.</para></param>
+    public async Task ScrollToIndexAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (_virtualizeElement != null)
+        {
+            await _virtualizeElement.ScrollToItemAsync(itemIndex, cancellationToken);
+        }
+    }
+#endif
 
     /// <summary>
     /// <inheritdoc/>

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor
@@ -44,11 +44,11 @@
                 <div class="dropdown-menu-body dropdown-virtual">
                     @if (OnQueryAsync == null)
                     {
-                        <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@GetVirtualItems()" ChildContent="RenderRow" />
+                        @RenderVirtualizeByItems()
                     }
                     else
                     {
-                        @RenderVirtualize()
+                        @RenderVirtualizeByProvider()
                     }
                 </div>
             }

--- a/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
+++ b/src/BootstrapBlazor/Components/SelectGeneric/SelectGeneric.razor.cs
@@ -332,11 +332,34 @@ public partial class SelectGeneric<TValue> : ISelectGeneric<TValue>, IModelEqual
         int GetCountByTotal() => TotalCount == 0 ? request.Count : Math.Min(request.Count, TotalCount - request.StartIndex);
     }
 
-    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
+    private RenderFragment RenderVirtualizeByProvider() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceHolderRow, RowHeight, OverscanCount,
 #if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
         VirtualizeItemComparer,
 #endif
         element => VirtualizeElement = element);
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(GetVirtualItems(), RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
+#endif
+        element => VirtualizeElement = element);
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">滚动到指定索引的虚拟项</para>
+    /// <para lang="en">Scrolls to the virtual item at the specified index.</para>
+    /// </summary>
+    /// <param name="itemIndex"><para lang="zh">从零开始的虚拟项索引</para><para lang="en">The zero-based virtual item index.</para></param>
+    /// <param name="cancellationToken"><para lang="zh">取消令牌</para><para lang="en">The cancellation token.</para></param>
+    public async Task ScrollToIndexAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (VirtualizeElement != null)
+        {
+            await VirtualizeElement.ScrollToItemAsync(itemIndex, cancellationToken);
+        }
+    }
+#endif
 
     private async Task RefreshVirtualizeElement()
     {

--- a/src/BootstrapBlazor/Components/Table/Table.razor
+++ b/src/BootstrapBlazor/Components/Table/Table.razor
@@ -111,13 +111,11 @@
                 {
                     @if (OnQueryAsync != null)
                     {
-                        @RenderVirtualize()
+                        @RenderVirtualizeByProvider()
                     }
                     else
                     {
-                        <Virtualize ItemSize="RowHeight" OverscanCount="@OverscanCount" Items="@Rows"
-                                    ChildContent="RenderRow">
-                        </Virtualize>
+                        @RenderVirtualizeByItems()
                     }
                 }
                 else

--- a/src/BootstrapBlazor/Components/Table/Table.razor.cs
+++ b/src/BootstrapBlazor/Components/Table/Table.razor.cs
@@ -516,6 +516,22 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
     [Parameter]
     public int OverscanCount { get; set; } = 10;
 
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">获得/设置首次交互式渲染时滚动到的虚拟项索引，默认为 0</para>
+    /// <para lang="en">Gets or sets the virtual item index to scroll to on first interactive render. Default is 0.</para>
+    /// </summary>
+    [Parameter]
+    public int InitialItemIndex { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置虚拟滚动锚定模式，默认为 <see cref="VirtualizeAnchorMode.Start"/></para>
+    /// <para lang="en">Gets or sets the virtual scrolling anchor mode. Default is <see cref="VirtualizeAnchorMode.Start"/>.</para>
+    /// </summary>
+    [Parameter]
+    public VirtualizeAnchorMode AnchorMode { get; set; } = VirtualizeAnchorMode.Start;
+#endif
+
     [Inject]
     [NotNull]
     private IOptionsMonitor<BootstrapBlazorOptions>? Options { get; set; }
@@ -1852,11 +1868,34 @@ public partial class Table<TItem> : ITable, IModelEqualityComparer<TItem> where 
         return new ItemsProviderResult<TItem>(QueryItems, TotalCount);
     }
 
-    private RenderFragment RenderVirtualize() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceholderRow, RowHeight, OverscanCount,
+    private RenderFragment RenderVirtualizeByProvider() => VirtualizeHelper.Render(LoadItems, RenderRow, RenderPlaceholderRow, RowHeight, OverscanCount,
 #if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
         VirtualizeItemComparer,
 #endif
         element => _virtualizeElement = element);
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(Rows, RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
+#endif
+        element => _virtualizeElement = element);
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">滚动到指定索引的虚拟项</para>
+    /// <para lang="en">Scrolls to the virtual item at the specified index.</para>
+    /// </summary>
+    /// <param name="itemIndex"><para lang="zh">从零开始的虚拟项索引</para><para lang="en">The zero-based virtual item index.</para></param>
+    /// <param name="cancellationToken"><para lang="zh">取消令牌</para><para lang="en">The cancellation token.</para></param>
+    public async Task ScrollToIndexAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (_virtualizeElement != null)
+        {
+            await _virtualizeElement.ScrollToItemAsync(itemIndex, cancellationToken);
+        }
+    }
+#endif
 
     private Func<Task> TriggerDoubleClickCell(ITableColumn col, TItem item) => async () =>
     {

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor
@@ -47,9 +47,7 @@ else
         @if (IsVirtualize)
         {
             <div class="tree-root scroll is-virtual" tabindex="0">
-                <Virtualize ItemSize="RowHeight" OverscanCount="OverscanCount" Items="@Rows">
-                    @RenderRow(context)
-                </Virtualize>
+                @RenderVirtualizeByItems()
             </div>
         }
         else

--- a/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
+++ b/src/BootstrapBlazor/Components/TreeView/TreeView.razor.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 // Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
 
+using Microsoft.AspNetCore.Components.Web.Virtualization;
 using Microsoft.Extensions.Localization;
 
 namespace BootstrapBlazor.Components;
@@ -23,6 +24,9 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
         .Build();
 
     private TreeViewItem<TItem>? _activeItem;
+
+    [NotNull]
+    private Virtualize<TreeViewItem<TItem>>? _virtualizeElement = default;
 
     /// <summary>
     /// <para lang="zh">获得/设置 是否显示加载动画，默认为 false</para>
@@ -281,6 +285,22 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     /// <remarks>Effective when <see cref="IsVirtualize"/> is set to true.</remarks>
     [Parameter]
     public int OverscanCount { get; set; } = 10;
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">获得/设置首次交互式渲染时滚动到的虚拟项索引，默认为 0</para>
+    /// <para lang="en">Gets or sets the virtual item index to scroll to on first interactive render. Default is 0.</para>
+    /// </summary>
+    [Parameter]
+    public int InitialItemIndex { get; set; }
+
+    /// <summary>
+    /// <para lang="zh">获得/设置虚拟滚动锚定模式，默认为 <see cref="VirtualizeAnchorMode.Start"/></para>
+    /// <para lang="en">Gets or sets the virtual scrolling anchor mode. Default is <see cref="VirtualizeAnchorMode.Start"/>.</para>
+    /// </summary>
+    [Parameter]
+    public VirtualizeAnchorMode AnchorMode { get; set; } = VirtualizeAnchorMode.Start;
+#endif
 
     /// <summary>
     /// <para lang="zh">获得/设置 工具栏内容模板，默认为 null</para>
@@ -987,6 +1007,28 @@ public partial class TreeView<TItem> : IModelEqualityComparer<TItem>
     }
 
     private List<TreeViewItem<TItem>> GetTreeItems() => _searchItems ?? Items;
+
+    private RenderFragment RenderVirtualizeByItems() => VirtualizeHelper.Render(Rows, RenderRow, RowHeight, OverscanCount,
+#if NET11_0_OR_GREATER
+        InitialItemIndex, AnchorMode,
+#endif
+        element => _virtualizeElement = element);
+
+#if NET11_0_OR_GREATER
+    /// <summary>
+    /// <para lang="zh">滚动到指定索引的虚拟项</para>
+    /// <para lang="en">Scrolls to the virtual item at the specified index.</para>
+    /// </summary>
+    /// <param name="itemIndex"><para lang="zh">从零开始的虚拟项索引</para><para lang="en">The zero-based virtual item index.</para></param>
+    /// <param name="cancellationToken"><para lang="zh">取消令牌</para><para lang="en">The cancellation token.</para></param>
+    public async Task ScrollToIndexAsync(int itemIndex, CancellationToken cancellationToken = default)
+    {
+        if (_virtualizeElement != null)
+        {
+            await _virtualizeElement.ScrollToItemAsync(itemIndex, cancellationToken);
+        }
+    }
+#endif
 
     private bool GetActive(TreeViewItem<TItem> item) => _activeItem == null ? false : this.Equals<TItem>(_activeItem.Value, item.Value);
 

--- a/src/BootstrapBlazor/Components/Virtualization/VirtualizeHelper.cs
+++ b/src/BootstrapBlazor/Components/Virtualization/VirtualizeHelper.cs
@@ -16,6 +16,8 @@ internal static class VirtualizeHelper
         float itemSize,
         int overscanCount,
 #if NET11_0_OR_GREATER
+        int initialItemIndex,
+        VirtualizeAnchorMode anchorMode,
         IEqualityComparer<TItem> itemComparer,
 #endif
         Action<Virtualize<TItem>> componentRef) => builder =>
@@ -27,7 +29,33 @@ internal static class VirtualizeHelper
         builder.AddAttribute(4, nameof(Virtualize<TItem>.ItemSize), itemSize);
         builder.AddAttribute(5, nameof(Virtualize<TItem>.OverscanCount), overscanCount);
 #if NET11_0_OR_GREATER
-        builder.AddAttribute(6, nameof(Virtualize<TItem>.ItemComparer), itemComparer);
+        builder.AddAttribute(6, nameof(Virtualize<TItem>.InitialItemIndex), initialItemIndex);
+        builder.AddAttribute(7, nameof(Virtualize<TItem>.AnchorMode), anchorMode);
+        builder.AddAttribute(8, nameof(Virtualize<TItem>.ItemComparer), itemComparer);
+#endif
+        builder.AddComponentReferenceCapture(9, component => componentRef((Virtualize<TItem>)component));
+        builder.CloseComponent();
+    };
+
+    public static RenderFragment Render<TItem>(
+        ICollection<TItem> items,
+        RenderFragment<TItem> itemContent,
+        float itemSize,
+        int overscanCount,
+#if NET11_0_OR_GREATER
+        int initialItemIndex,
+        VirtualizeAnchorMode anchorMode,
+#endif
+        Action<Virtualize<TItem>> componentRef) => builder =>
+    {
+        builder.OpenComponent<Virtualize<TItem>>(0);
+        builder.AddAttribute(1, nameof(Virtualize<TItem>.Items), items);
+        builder.AddAttribute(2, nameof(Virtualize<TItem>.ItemContent), itemContent);
+        builder.AddAttribute(3, nameof(Virtualize<TItem>.ItemSize), itemSize);
+        builder.AddAttribute(4, nameof(Virtualize<TItem>.OverscanCount), overscanCount);
+#if NET11_0_OR_GREATER
+        builder.AddAttribute(5, nameof(Virtualize<TItem>.InitialItemIndex), initialItemIndex);
+        builder.AddAttribute(6, nameof(Virtualize<TItem>.AnchorMode), anchorMode);
 #endif
         builder.AddComponentReferenceCapture(7, component => componentRef((Virtualize<TItem>)component));
         builder.CloseComponent();

--- a/test/UnitTest/Components/VirtualizeNet11Test.cs
+++ b/test/UnitTest/Components/VirtualizeNet11Test.cs
@@ -1,0 +1,177 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License
+// See the LICENSE file in the project root for more information.
+// Maintainer: Argo Zhang(argo@live.ca) Website: https://www.blazor.zone
+
+#if NET11_0_OR_GREATER
+using Microsoft.AspNetCore.Components.Web.Virtualization;
+
+namespace UnitTest.Components;
+
+public class VirtualizeNet11Test : BootstrapBlazorTestBase
+{
+    [Fact]
+    public void Items_Parameters_Ok()
+    {
+        var cut = Context.Render<AutoFill<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items, ["Item 1", "Item 2"]);
+            pb.Add(a => a.InitialItemIndex, 1);
+            pb.Add(a => a.AnchorMode, VirtualizeAnchorMode.End);
+        });
+
+        var virtualize = cut.FindComponent<Virtualize<string>>().Instance;
+        Assert.Equal(1, virtualize.InitialItemIndex);
+        Assert.Equal(VirtualizeAnchorMode.End, virtualize.AnchorMode);
+    }
+
+    [Fact]
+    public void ItemsProvider_Parameters_Ok()
+    {
+        var cut = Context.Render<AutoFill<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.InitialItemIndex, 2);
+            pb.Add(a => a.AnchorMode, VirtualizeAnchorMode.None);
+            pb.Add(a => a.OnQueryAsync, option => Task.FromResult(new QueryData<string>
+            {
+                Items = ["Item 1", "Item 2", "Item 3"],
+                TotalCount = 3
+            }));
+        });
+
+        var virtualize = cut.FindComponent<Virtualize<string>>().Instance;
+        Assert.Equal(2, virtualize.InitialItemIndex);
+        Assert.Equal(VirtualizeAnchorMode.None, virtualize.AnchorMode);
+    }
+
+    [Fact]
+    public void ComponentApi_Ok()
+    {
+        Type[] types =
+        [
+            typeof(AutoFill<string>),
+            typeof(Select<string>),
+            typeof(MultiSelect<string>),
+            typeof(SelectGeneric<string>),
+            typeof(MultiSelectGeneric<string>),
+            typeof(Table<Foo>),
+            typeof(TreeView<Foo>)
+        ];
+
+        Assert.All(types, type =>
+        {
+            Assert.NotNull(type.GetProperty(nameof(AutoFill<string>.InitialItemIndex)));
+            Assert.NotNull(type.GetProperty(nameof(AutoFill<string>.AnchorMode)));
+            Assert.NotNull(type.GetMethod(
+                nameof(AutoFill<string>.ScrollToIndexAsync),
+                [typeof(int), typeof(CancellationToken)]));
+        });
+    }
+
+    [Fact]
+    public async Task AutoFill_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<AutoFill<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items, ["Item 1", "Item 2"]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+
+    [Fact]
+    public async Task Select_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<Select<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items,
+            [
+                new SelectedItem("1", "Item 1"),
+                new SelectedItem("2", "Item 2")
+            ]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+
+    [Fact]
+    public async Task MultiSelect_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<MultiSelect<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items,
+            [
+                new SelectedItem("1", "Item 1"),
+                new SelectedItem("2", "Item 2")
+            ]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+
+    [Fact]
+    public async Task SelectGeneric_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<SelectGeneric<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items,
+            [
+                new SelectedItem<string>("1", "Item 1"),
+                new SelectedItem<string>("2", "Item 2")
+            ]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+
+    [Fact]
+    public async Task MultiSelectGeneric_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<MultiSelectGeneric<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items,
+            [
+                new SelectedItem<string>("1", "Item 1"),
+                new SelectedItem<string>("2", "Item 2")
+            ]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+
+    [Fact]
+    public async Task Table_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<Table<Foo>>(pb =>
+        {
+            pb.Add(a => a.ScrollMode, ScrollMode.Virtual);
+            pb.Add(a => a.Items, [new Foo(), new Foo()]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+
+    [Fact]
+    public async Task TreeView_ScrollToIndexAsync_Ok()
+    {
+        var cut = Context.Render<TreeView<string>>(pb =>
+        {
+            pb.Add(a => a.IsVirtualize, true);
+            pb.Add(a => a.Items,
+            [
+                new TreeViewItem<string>("1") { Text = "Item 1" },
+                new TreeViewItem<string>("2") { Text = "Item 2" }
+            ]);
+        });
+
+        await cut.InvokeAsync(() => cut.Instance.ScrollToIndexAsync(1));
+    }
+}
+#endif


### PR DESCRIPTION
## Link issues
fixes #8462 

<!--[Please fill in the relevant Issue number after the # above, such as #42]-->
<!--[请在上方 # 后面填写相关 Issue 编号，如 #42]-->

## Summary By Copilot


## Regression?
- [ ] Yes
- [ ] No

<!--[If yes, specify the version the behavior has regressed from]-->
<!--[是否影响老版本]-->

## Risk
- [ ] High
- [ ] Medium
- [ ] Low

<!--[Justify the selection above]-->

## Verification
- [ ] Manual (required)
- [ ] Automated

## Packaging changes reviewed?
- [ ] Yes
- [ ] No
- [ ] N/A

## ☑️ Self Check before Merge
⚠️ Please check all items below before review. ⚠️
- [ ] Doc is updated/provided or not needed
- [ ] Demo is updated/provided or not needed
- [ ] Merge the latest code from the main branch

## Summary by Sourcery

Support initial positioning, anchoring, and programmatic scrolling for virtualized components on .NET 11.

New Features:
- Add configurable initial virtual item index and anchor mode to virtualized AutoFill, selection, table, and tree components on .NET 11.
- Expose APIs for scrolling virtualized components to a specified item index.

Bug Fixes:
- Avoid attempting to refresh an unavailable virtualization element during asynchronous filtering.

Enhancements:
- Unify collection-backed and provider-backed virtualization rendering across supported components.

Tests:
- Add .NET 11 coverage for virtualization parameters, component APIs, and index-scrolling behavior.